### PR TITLE
Fix missing prompt on Shift+Enter (#8)

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -11,3 +11,4 @@ code contributions under these terms.
 The VGC Developers:
 -------------------
 Copyright (C) 2017-2018 Boris Dalstein <dalboris@gmail.com>
+Copyright (C) 2018 Min Yin <minyin142p@gmail.com>

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -413,6 +413,20 @@ void Console::keyPressEvent(QKeyEvent* e)
             codeBlocks_.push_back(currentLineNumber_());
         }
 
+        // On 'Shift + Enter', remove the Shift modifier to prevent inserting a line-break `\r`
+        // with no corresponding line-feed `\n`, messing up the console line numbering.
+        else if ((e->text() == "\r") &&
+                 (e->modifiers() & Qt::SHIFT))
+        {
+            // Using bit flag manipulation to remove shift modifier
+            // QFlags::setFlag does not exists in all Qt versions
+            Qt::KeyboardModifiers m = e->modifiers();
+            m &= ~Qt::ShiftModifier;
+            e->setModifiers(m);
+
+            Console::keyPressEvent(e);
+        }
+
         // Normal insertion/deletion of character, including newlines
         else {
             QPlainTextEdit::keyPressEvent(e);


### PR DESCRIPTION
I just created a new QKeyEvent with the Shift Modifier removed. I have not found a way to directly remove it from the event.