### PR TITLE
Prevent edit in already interpreted code (#5)

### DIFF
--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -466,31 +466,6 @@ void Console::mouseDoubleClickEvent(QMouseEvent* e)
     QPlainTextEdit::mouseDoubleClickEvent(e);
 }
 
-void Console::handleMousePresses_(QMouseEvent* e)
-{
-    // On mouse event, we have to check where the cursor would be
-    QTextCursor cursor = cursorForPosition(e->pos());
-
-    // If there is a selection, we should always use the real cursor
-    // Except on middle mouse click to allow copy on Linux
-    QTextCursor realCursor = textCursor();
-
-    if ((realCursor.hasSelection()) &&
-        (e->button() != Qt::MiddleButton))
-    {
-        cursor = realCursor;
-    }
-
-    protectPreviousCodeBlocks_(cursor);
-
-    // Right Mouse Click does not move cursor
-    // We have to move it ourselves to prevent pasting inside previous code blocks 
-    // And when there is no selection so we can still copy selections
-    if (e->button() == Qt::RightButton && !realCursor.hasSelection()) {
-        setTextCursor(cursor);
-    }
-}
-
 // Removes readonly after mouse release
 // otherwise middle mouse button paste will not be filtered
 void Console::mouseReleaseEvent(QMouseEvent* e)
@@ -523,19 +498,6 @@ void Console::contextMenuEvent(QContextMenuEvent* e)
     setReadOnly(false);
 }
 
-// Prevents write on already interpreted python code
-// by checking the position of the cursor / selection start
-void Console::protectPreviousCodeBlocks_(QTextCursor cursor)
-{
-    // Use selection start line number instead of currentLineNumber
-    // to prevent case where selection ends inside last code block
-    cursor.setPosition(cursor.selectionStart());
-
-    // Set readonly instead of just accepting or ignoring event
-    // because context menu paste cannot be detected
-    setReadOnly(lineNumber_(cursor) < codeBlocks_.back());
-}
-
 void Console::dropEvent(QDropEvent* e)
 {
     QTextCursor cursor = cursorForPosition(e->pos());
@@ -548,6 +510,44 @@ void Console::dropEvent(QDropEvent* e)
     // drop position after the event
     setTextCursor(cursor);
     setReadOnly(false);
+}
+
+void Console::handleMousePresses_(QMouseEvent* e)
+{
+    // On mouse event, we have to check where the cursor would be
+    QTextCursor cursor = cursorForPosition(e->pos());
+
+    // If there is a selection, we should always use the real cursor
+    // Except on middle mouse click to allow copy on Linux
+    QTextCursor realCursor = textCursor();
+
+    if ((realCursor.hasSelection()) &&
+        (e->button() != Qt::MiddleButton))
+    {
+        cursor = realCursor;
+    }
+
+    protectPreviousCodeBlocks_(cursor);
+
+    // Right Mouse Click does not move cursor
+    // We have to move it ourselves to prevent pasting inside previous code blocks 
+    // And when there is no selection so we can still copy selections
+    if (e->button() == Qt::RightButton && !realCursor.hasSelection()) {
+        setTextCursor(cursor);
+    }
+}
+
+// Prevents write on already interpreted python code
+// by checking the position of the cursor / selection start
+void Console::protectPreviousCodeBlocks_(QTextCursor cursor)
+{
+    // Use selection start line number instead of currentLineNumber
+    // to prevent case where selection ends inside last code block
+    cursor.setPosition(cursor.selectionStart());
+
+    // Set readonly instead of just accepting or ignoring event
+    // because context menu paste cannot be detected
+    setReadOnly(lineNumber_(cursor) < codeBlocks_.back());
 }
 
 int Console::currentLineNumber_() const

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -460,7 +460,10 @@ void Console::mousePressEvent(QMouseEvent* e)
 {
     // On mouse event, we have to move the cursor to the correct position first
     // But without executing any pasting events
-    setTextCursor(cursorForPosition(e->pos()));
+    // Exclude selection to allow copy with right-click menu
+    if(!textCursor().hasSelection()){
+        setTextCursor(cursorForPosition(e->pos()));
+    }
     protectPreviousCodeBlocks_();
 
     QPlainTextEdit::mousePressEvent(e);

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -464,17 +464,34 @@ void Console::mousePressEvent(QMouseEvent* e)
     // On mouse event, we have to move the cursor to the correct position first
     // But without executing any pasting events
     // Exclude selection to allow copy with right-click menu
-    if(!textCursor().hasSelection()){
-        setTextCursor(cursorForPosition(e->pos()));
-    }
+    moveCursorOnMouseEvent_(e);
     protectPreviousCodeBlocks_();
 
     QPlainTextEdit::mousePressEvent(e);
+}
 
-    // Readonly cannot be removed for context menu here
-    // otherwise paste option will be available
-    if(e->button() != Qt::RightButton){
-        setReadOnly(false);
+void Console::mouseDoubleClickEvent(QMouseEvent* e)
+{
+    // Same as mouse press event, just for double click
+    moveCursorOnMouseEvent_(e);
+    protectPreviousCodeBlocks_();
+
+    QPlainTextEdit::mouseDoubleClickEvent(e);
+}
+
+// Removes readonly after mouse release
+// otherwise middle mouse button paste will not be filtered
+void Console::mouseReleaseEvent(QMouseEvent* e)
+{
+    QPlainTextEdit::mouseReleaseEvent(e);
+    setReadOnly(false);
+}
+
+// Moves cursor to mouse position if is not a selection
+void Console::moveCursorOnMouseEvent_(QMouseEvent* e)
+{
+    if (!textCursor().hasSelection()) {
+        setTextCursor(cursorForPosition(e->pos()));
     }
 }
 

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -358,13 +358,13 @@ void Console::keyPressEvent(QKeyEvent* e)
     if (isTextInsertionOrDeletion_(e)) {
         // Prevent inserting or deleting text before last code block
         // because here are no navigation, we can call it before everything
-        protectPreviousCodeBlock(e);
+        protectPreviousCodeBlocks_();
 
         QTextCursor cursor = textCursor();
 
         // Process last code block on Ctrl + Enter
         if ((e->text() == "\r") &&
-                 (e->modifiers() & Qt::CTRL))
+            (e->modifiers() & Qt::CTRL))
         {
             // Move cursor's anchor+position to beginning of code block
             cursor.movePosition(QTextCursor::StartOfLine);
@@ -452,7 +452,7 @@ void Console::keyPressEvent(QKeyEvent* e)
         QPlainTextEdit::keyPressEvent(e);
 
         // This has to be called after any navigation of the cursor
-        protectPreviousCodeBlock(e);
+        protectPreviousCodeBlocks_();
     }
 }
 
@@ -461,22 +461,22 @@ void Console::mousePressEvent(QMouseEvent* e)
     // On mouse event, we have to move the cursor to the correct position first
     // But without executing any pasting events
     setTextCursor(cursorForPosition(e->pos()));
-    protectPreviousCodeBlock(e);
+    protectPreviousCodeBlocks_();
 
     QPlainTextEdit::mousePressEvent(e);
 }
 
-// Preventing write on already interpreted python code
+// Prevents write on already interpreted python code
 // by checking the position of the cursor / selection start
 // thus cursor movement has to be executed before calling this function
-void Console::protectPreviousCodeBlock(QEvent* e)
+void Console::protectPreviousCodeBlocks_()
 {
-    // Using selection start line number instead of currentLineNumber
+    // Use selection start line number instead of currentLineNumber
     // to prevent case where selection ends inside last code block
     QTextCursor cursor = textCursor();
     cursor.setPosition(cursor.selectionStart());
 
-    // Setting readonly instead of just accepting or ignoring event
+    // Set readonly instead of just accepting or ignoring event
     // because context menu paste cannot be detected
     setReadOnly(lineNumber_(cursor) < codeBlocks_.back());
 }

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -463,7 +463,6 @@ void Console::mousePressEvent(QMouseEvent* e)
 {
     // On mouse event, we have to move the cursor to the correct position first
     // But without executing any pasting events
-    // Exclude selection to allow copy with right-click menu
     moveCursorOnMouseEvent_(e);
     protectPreviousCodeBlocks_();
 
@@ -487,10 +486,10 @@ void Console::mouseReleaseEvent(QMouseEvent* e)
     setReadOnly(false);
 }
 
-// Moves cursor to mouse position if is not a selection
+// Moves cursor to mouse position if is not right mouse click
 void Console::moveCursorOnMouseEvent_(QMouseEvent* e)
 {
-    if (!textCursor().hasSelection()) {
+    if (e->button() != Qt::RightButton) {
         setTextCursor(cursorForPosition(e->pos()));
     }
 }

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -442,6 +442,8 @@ void Console::keyPressEvent(QKeyEvent* e)
         else {
             QPlainTextEdit::keyPressEvent(e);
         }
+
+        endProtectPreviousBlocks_();
     }
     else {
         // Anything which is not an insertion or deletion, such as:
@@ -450,8 +452,6 @@ void Console::keyPressEvent(QKeyEvent* e)
         // - Complex input methods (dead key, Chinese character composition, etc.)
         QPlainTextEdit::keyPressEvent(e);
     }
-
-    endProtectPreviousBlocks_();
 }
 
 void Console::mousePressEvent(QMouseEvent* e)

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -472,35 +472,13 @@ void Console::handleMousePresses_(QMouseEvent* e)
     QTextCursor cursor = cursorForPosition(e->pos());
 
     // If there is a selection, we should always use the real cursor
+    // Except on middle mouse click to allow copy on Linux
     QTextCursor realCursor = textCursor();
 
-    if (realCursor.hasSelection()) {
-
-        // Except for middle mouse button
-        // Here we have to distinguish between:
-        //  - completely inside previous / current block ( for copy in Linux )
-        //  - partially inside both
-        if (e->button() == Qt::MiddleButton) {
-
-            QTextCursor tempCursor = realCursor;
-
-            // We have to use real cursor selection position because the temp cursor
-            // will be moved with setPosition() and remove the selection
-            tempCursor.setPosition(realCursor.selectionStart());
-            int selectionStart = lineNumber_(tempCursor);
-
-            tempCursor.setPosition(realCursor.selectionEnd());
-            int selectionEnd = lineNumber_(tempCursor);
-
-            // Check if selection is partially inside both blocks
-            if (selectionStart < codeBlocks_.back() != selectionEnd < codeBlocks_.back()) {
-                cursor = realCursor;
-            }
-        }
-
-        else {
-            cursor = realCursor;
-        }
+    if ((realCursor.hasSelection()) &&
+        (e->button() != Qt::MiddleButton))
+    {
+        cursor = realCursor;
     }
 
     protectPreviousCodeBlocks_(cursor);

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -536,6 +536,20 @@ void Console::protectPreviousCodeBlocks_(QTextCursor cursor)
     setReadOnly(lineNumber_(cursor) < codeBlocks_.back());
 }
 
+void Console::dropEvent(QDropEvent* e)
+{
+    QTextCursor cursor = cursorForPosition(e->pos());
+    protectPreviousCodeBlocks_(cursor);
+
+    QPlainTextEdit::dropEvent(e);
+
+    // We have to move cursor to drop position
+    // because of a graphical glitch that still shows
+    // drop position after the event
+    setTextCursor(cursor);
+    setReadOnly(false);
+}
+
 int Console::currentLineNumber_() const
 {
     return lineNumber_(textCursor());

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -436,8 +436,6 @@ void Console::keyPressEvent(QKeyEvent* e)
         else {
             QPlainTextEdit::keyPressEvent(e);
         }
-
-        endProtectPreviousBlocks_();
     }
     else {
         // Anything which is not an insertion or deletion, such as:
@@ -446,6 +444,12 @@ void Console::keyPressEvent(QKeyEvent* e)
         // - Complex input methods (dead key, Chinese character composition, etc.)
         QPlainTextEdit::keyPressEvent(e);
     }
+}
+
+void Console::keyReleaseEvent(QKeyEvent* e)
+{
+    QPlainTextEdit::keyReleaseEvent(e);
+    endProtectPreviousBlocks_();
 }
 
 void Console::mousePressEvent(QMouseEvent* e)

--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -443,6 +443,8 @@ void Console::keyPressEvent(QKeyEvent* e)
         else {
             QPlainTextEdit::keyPressEvent(e);
         }
+
+        setReadOnly(false);
     }
     else {
         // Anything which is not an insertion or deletion, such as:
@@ -453,6 +455,7 @@ void Console::keyPressEvent(QKeyEvent* e)
 
         // This has to be called after any navigation of the cursor
         protectPreviousCodeBlocks_();
+        setReadOnly(false);
     }
 }
 
@@ -467,6 +470,19 @@ void Console::mousePressEvent(QMouseEvent* e)
     protectPreviousCodeBlocks_();
 
     QPlainTextEdit::mousePressEvent(e);
+
+    // Readonly cannot be removed for context menu here
+    // otherwise paste option will be available
+    if(e->button() != Qt::RightButton){
+        setReadOnly(false);
+    }
+}
+
+// Removes readonly after opening context menu
+void Console::contextMenuEvent(QContextMenuEvent* e)
+{
+    QPlainTextEdit::contextMenuEvent(e);
+    setReadOnly(false);
 }
 
 // Prevents write on already interpreted python code

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -87,6 +87,7 @@ private:
     void inputMethodEvent(QInputMethodEvent*);
     QVariant inputMethodQuery(Qt::InputMethodQuery) const;
     void keyPressEvent(QKeyEvent* e) override;
+    void keyReleaseEvent(QKeyEvent* e) override;
     void mousePressEvent(QMouseEvent* e) override;
     void mouseDoubleClickEvent(QMouseEvent* e) override;
     void mouseReleaseEvent(QMouseEvent* e) override;

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -89,7 +89,7 @@ private:
     void keyPressEvent(QKeyEvent* e) override;
     void mousePressEvent(QMouseEvent* e) override;
 
-    void protectPreviousCodeBlock(QEvent* e);
+    void protectPreviousCodeBlocks_();
     int currentLineNumber_() const;
 
     // Code blocks. This is a sorted list of 0-indexed

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -91,6 +91,7 @@ private:
     void mouseReleaseEvent(QMouseEvent* e) override;
     void mouseDoubleClickEvent(QMouseEvent* e) override;
     void contextMenuEvent(QContextMenuEvent* e) override;
+    void dropEvent(QDropEvent* e) override;
 
     void handleMousePresses_(QMouseEvent* e);
     void protectPreviousCodeBlocks_(QTextCursor);

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -93,8 +93,9 @@ private:
     void contextMenuEvent(QContextMenuEvent* e) override;
     void dropEvent(QDropEvent* e) override;
 
-    void handleMousePresses_(QMouseEvent* e);
-    void protectPreviousCodeBlocks_(QTextCursor);
+    void beginProtectPreviousBlocks_(QMouseEvent* e);
+    void beginProtectPreviousBlocks_(const QTextCursor&);
+    void endProtectPreviousBlocks_();
     int currentLineNumber_() const;
 
     // Code blocks. This is a sorted list of 0-indexed

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -94,8 +94,8 @@ private:
     void contextMenuEvent(QContextMenuEvent* e) override;
     void dropEvent(QDropEvent* e) override;
 
-    void beginProtectPreviousBlocks_(QMouseEvent* e);
-    void beginProtectPreviousBlocks_(const QTextCursor&);
+    void beginReadOnlyProtection_(QMouseEvent* e);
+    void beginReadOnlyProtection_(const QTextCursor&);
     void endProtectPreviousBlocks_();
     int currentLineNumber_() const;
 

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -88,8 +88,11 @@ private:
     QVariant inputMethodQuery(Qt::InputMethodQuery) const;
     void keyPressEvent(QKeyEvent* e) override;
     void mousePressEvent(QMouseEvent* e) override;
+    void mouseReleaseEvent(QMouseEvent* e) override;
+    void mouseDoubleClickEvent(QMouseEvent* e) override;
     void contextMenuEvent(QContextMenuEvent* e) override;
 
+    void moveCursorOnMouseEvent_(QMouseEvent* e);
     void protectPreviousCodeBlocks_();
     int currentLineNumber_() const;
 

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -87,7 +87,9 @@ private:
     void inputMethodEvent(QInputMethodEvent*);
     QVariant inputMethodQuery(Qt::InputMethodQuery) const;
     void keyPressEvent(QKeyEvent* e) override;
+    void mousePressEvent(QMouseEvent* e) override;
 
+    void protectPreviousCodeBlock(QEvent* e);
     int currentLineNumber_() const;
 
     // Code blocks. This is a sorted list of 0-indexed

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -88,6 +88,7 @@ private:
     QVariant inputMethodQuery(Qt::InputMethodQuery) const;
     void keyPressEvent(QKeyEvent* e) override;
     void mousePressEvent(QMouseEvent* e) override;
+    void contextMenuEvent(QContextMenuEvent* e) override;
 
     void protectPreviousCodeBlocks_();
     int currentLineNumber_() const;

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -92,8 +92,8 @@ private:
     void mouseDoubleClickEvent(QMouseEvent* e) override;
     void contextMenuEvent(QContextMenuEvent* e) override;
 
-    void moveCursorOnMouseEvent_(QMouseEvent* e);
-    void protectPreviousCodeBlocks_();
+    void handleMousePresses_(QMouseEvent* e);
+    void protectPreviousCodeBlocks_(QTextCursor);
     int currentLineNumber_() const;
 
     // Code blocks. This is a sorted list of 0-indexed

--- a/libs/vgc/widgets/console.h
+++ b/libs/vgc/widgets/console.h
@@ -88,8 +88,8 @@ private:
     QVariant inputMethodQuery(Qt::InputMethodQuery) const;
     void keyPressEvent(QKeyEvent* e) override;
     void mousePressEvent(QMouseEvent* e) override;
-    void mouseReleaseEvent(QMouseEvent* e) override;
     void mouseDoubleClickEvent(QMouseEvent* e) override;
+    void mouseReleaseEvent(QMouseEvent* e) override;
     void contextMenuEvent(QContextMenuEvent* e) override;
     void dropEvent(QDropEvent* e) override;
 


### PR DESCRIPTION
Do not know if it is the best way, but have not found something better.

I now completely disable all writes inside already interpreted code by setting read-only. Because pastes called inside the context menu cannot be detected easily, I think. So I just blocked all edits.