### PR TITLE
Fix undo deleting last line (#47)

### DIFF
--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -412,6 +412,9 @@ void Console::keyPressEvent(QKeyEvent* e)
 
             // Update code blocks
             codeBlocks_.push_back(currentLineNumber_());
+
+            // Clear Undo/Redo Stack to prevent going back to previous block
+            document()->clearUndoRedoStacks();
         }
 
         // On 'Shift + Enter', remove the Shift modifier to prevent inserting a line-break `\r`


### PR DESCRIPTION
Should be the best way to deal with undoing the last line. It just removes the undo stack after ctrl+enter.