### PR TITLE
Remove unnecessary call to base method QWidget::paintEvent() (#151)

### DIFF
--- a/libs/vgc/widgets/centralwidget.cpp
+++ b/libs/vgc/widgets/centralwidget.cpp
@@ -70,7 +70,7 @@ QSize CentralWidget::sizeHint() const
 
 void CentralWidget::paintEvent(QPaintEvent* e)
 {
-    QWidget::paintEvent(e);
+
 }
 
 void CentralWidget::resizeEvent(QResizeEvent *event)


### PR DESCRIPTION
#151 