### PR TITLE
Fix macOS compile error: missing include <string> (#180)

### DIFF
--- a/libs/vgc/core/charutil.h
+++ b/libs/vgc/core/charutil.h
@@ -17,6 +17,8 @@
 #ifndef VGC_CORE_CHARUTIL_H
 #define VGC_CORE_CHARUTIL_H
 
+#include <string>
+
 #include <vgc/core/api.h>
 #include <vgc/core/exceptions.h>
 

--- a/libs/vgc/core/exceptions.h
+++ b/libs/vgc/core/exceptions.h
@@ -18,6 +18,8 @@
 #define VGC_CORE_EXCEPTIONS_H
 
 #include <stdexcept>
+#include <string>
+
 #include <vgc/core/api.h>
 
 namespace vgc {


### PR DESCRIPTION
#180 