### PR TITLE
Fix python console multiline code blocks on Windows (#109)

### DIFF
--- a/libs/vgc/widgets/console.cpp
+++ b/libs/vgc/widgets/console.cpp
@@ -409,7 +409,7 @@ void Console::keyPressEvent(QKeyEvent* e)
             // QString::replace() to replace these characters with newlines."
             //
             QString codeBlock = cursor.selectedText();
-            codeBlock.replace("\u2029", "\n");
+            codeBlock.replace(QChar(QChar::ParagraphSeparator), QChar(QChar::LineFeed));
 
             // Deselect
             cursor.movePosition(QTextCursor::NoMove, QTextCursor::MoveAnchor);


### PR DESCRIPTION
#109 

The `replace()` function wasn't actually doing anything. Explicitly passing the correct QChar to the `replace()` function (instead of passing a `char*`) fixed the problem.