### PR TITLE
Disable non-dll interface warnings from {fmt} (#84)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,12 @@ if(EXISTS ${FMT_DIR})
         endif()
     endif()
     add_subdirectory(${FMT_DIR})
+    if(MSVC)
+        # disable warning C4275: non dll-interface class
+        # 'std::runtime_error' used as base for dll-interface class
+        # 'fmt::v6::format_error' / 'fmt::v6::system_error'
+        target_compile_options(fmt PRIVATE /wd4275)
+    endif()
     if(VGC_FMT_LIB_TYPE STREQUAL "static")
         set_target_properties(fmt PROPERTIES POSITION_INDEPENDENT_CODE ON)
     elseif(VGC_FMT_LIB_TYPE STREQUAL "shared")

--- a/libs/vgc/core/format.h
+++ b/libs/vgc/core/format.h
@@ -42,7 +42,14 @@
 #include <type_traits>
 #include <vector>
 
+#if defined(VGC_CORE_COMPILER_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable: 4275) // warning C4275: non dll-interface class 'std::runtime_error' used as base for dll-interface class 'fmt::v6::format_error'/'fmt::v6::system_error'
+#endif
 #include <fmt/format.h>
+#if defined(VGC_CORE_COMPILER_MSVC)
+#  pragma warning(pop)
+#endif
 
 #include <vgc/core/api.h>
 


### PR DESCRIPTION
#84 