### PR TITLE
Only sign with a SHA-256 timestamp instead of a dual-signed SHA-1/SHA-256 (#397)

### DIFF
--- a/tools/windows/wix.py
+++ b/tools/windows/wix.py
@@ -451,7 +451,7 @@ class CodeSignerResource:
             #
             def sign(self, file):
                 if (self.certificate):
-                    if not dualSign or file.suffix == ".msi":
+                    if not self.dualSign or file.suffix == ".msi":
                         self.sign_(file, fd="sha256", dualSign=False)
                     else:
                         self.sign_(file, fd="sha1", dualSign=False)


### PR DESCRIPTION
#397 