### PR TITLE
Fix slow builds on Travis macOS (#424)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,10 @@ matrix:
     - name: "macOS 10.14.4"
       os: osx
       osx_image: xcode10.3
-      addons:
-        homebrew:
-          packages:
-            - qt
-            - freetype
-            - harfbuzz
+      install:
+        - brew install qt
+        - brew install freetype
+        - brew install harfbuzz
       before_script:
         - export CXX=clang++ CC=clang
         - CMAKE_EXTRA_ARGS+=" -DQt=/usr/local/opt/qt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ matrix:
       os: osx
       osx_image: xcode10.3
       install:
-        - brew install qt
-        - brew install freetype
-        - brew install harfbuzz
+        - brew list qt &>/dev/null || brew install qt
+        - brew list freetype &>/dev/null || brew install freetype
+        - brew list harfbuzz &>/dev/null || brew install harfbuzz
       before_script:
         - export CXX=clang++ CC=clang
         - CMAKE_EXTRA_ARGS+=" -DQt=/usr/local/opt/qt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,15 @@ matrix:
         - CMAKE_EXTRA_ARGS+=" -DPYTHON_LIBRARY=$PYTHON_PREFIX/lib/lib${PYTHON_XY}m.so"
         - CMAKE_EXTRA_ARGS+=" -DPYTHON_INCLUDE_DIR=$PYTHON_PREFIX/include/${PYTHON_XY}m"
         - CMAKE_EXTRA_ARGS+=" -DQt=/opt/qt/$QT_VERSION/gcc_64"
-    - name: "macOS 10.14.4"
+    - name: "macOS 10.15.4"
       os: osx
-      osx_image: xcode10.3
-      install:
-        - brew list qt &>/dev/null || brew install qt
-        - brew list freetype &>/dev/null || brew install freetype
-        - brew list harfbuzz &>/dev/null || brew install harfbuzz
+      osx_image: xcode11.6
+      addons:
+        homebrew:
+          packages:
+            - qt
+            - freetype
+            - harfbuzz
       before_script:
         - export CXX=clang++ CC=clang
         - CMAKE_EXTRA_ARGS+=" -DQt=/usr/local/opt/qt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
             - qt
             - freetype
             - harfbuzz
-          update: true
       before_script:
         - export CXX=clang++ CC=clang
         - CMAKE_EXTRA_ARGS+=" -DQt=/usr/local/opt/qt"


### PR DESCRIPTION
#424 

For now, we just remove `homebrew: update: true` and see if it still fails. Else, we can try with a newer macOS configuration, or by manually calling `brew install ...` commands (possibly manually caching the compiled binaries).
 