### PR TITLE
Ensure and document that glyphs returned by shape() are never null (#369)

### DIFF
--- a/libs/vgc/graphics/font.cpp
+++ b/libs/vgc/graphics/font.cpp
@@ -332,7 +332,9 @@ public:
             FontGlyph* glyph = facePtr->getGlyphFromIndex(info.codepoint);
             core::Vec2d offset = toVec2d(pos.x_offset, pos.y_offset);
             core::Vec2d advance = toVec2d(pos.x_advance, pos.y_advance);
-            items.append(FontItem(glyph, totalAdvance + offset));
+            if (glyph) {
+                items.append(FontItem(glyph, totalAdvance + offset));
+            }
             totalAdvance += advance;
         }
     }

--- a/libs/vgc/graphics/font.h
+++ b/libs/vgc/graphics/font.h
@@ -121,6 +121,19 @@ public:
 
     /// Returns the glyph.
     ///
+    /// Note that the shape() methods of FontShaper and FontFace never return
+    /// NULL glyphs:
+    ///
+    /// - In case of a missing glyph in the face, the ".notdef" glyph [1] is
+    ///   returned. It is typically represented as a rectangle (sometimes with
+    ///   an "X" or "?" inside). More info:
+    ///
+    ///   https://docs.microsoft.com/en-us/typography/opentype/spec/recom#glyph-0-the-notdef-glyph
+    ///
+    /// - In case of other shaping problems (such as invalid unicode input),
+    ///   the `U+FFFD � REPLACEMENT CHARACTER` might be used, or the codepoints
+    ///   causing problems are simply skipped.
+    ///
     FontGlyph* glyph() const {
         return glyph_;
     }

--- a/libs/vgc/ui/label.cpp
+++ b/libs/vgc/ui/label.cpp
@@ -82,17 +82,15 @@ void Label::onPaintDraw(graphics::Engine* engine)
             graphics::FontFace* fontFace = fontLibrary->addFace(facePath); // XXX can this be nullptr?
             core::DoubleArray b;
             for (const graphics::FontItem& shape : fontFace->shape(text_)) {
-                if (shape.glyph()) { // XXX can this be nullptr?
-                    float xoffset = shape.offset()[0];
-                    float yoffset = shape.offset()[1];
-                    b.clear();
-                    shape.glyph()->outline().stroke(b, 3);
-                    for (Int i = 0; 2*i+1 < b.length(); ++i) {
-                        a.insert(a.end(), {
-                            xoffset + static_cast<float>(b[2*i]),
-                            yoffset + static_cast<float>(b[2*i+1]),
-                            1, 0, 0});
-                    }
+                float xoffset = shape.offset()[0];
+                float yoffset = shape.offset()[1];
+                b.clear();
+                shape.glyph()->outline().stroke(b, 3);
+                for (Int i = 0; 2*i+1 < b.length(); ++i) {
+                    a.insert(a.end(), {
+                        xoffset + static_cast<float>(b[2*i]),
+                        yoffset + static_cast<float>(b[2*i+1]),
+                        1, 0, 0});
                 }
             }
         }


### PR DESCRIPTION
#369 