### PR TITLE
fix error C2398 Element '3': conversion from 'double' to 'float' requires a narrowing conversion

### DIFF
--- a/libs/vgc/ui/label.cpp
+++ b/libs/vgc/ui/label.cpp
@@ -120,7 +120,7 @@ void Label::onPaintDraw(graphics::Engine* engine)
                     a.insert(a.end(), {
                         xoffset + static_cast<float>(b[2*i]),
                         baseline - (yoffset + static_cast<float>(b[2*i+1])),
-                        0.9, 0.9, 0.9});
+                        0.9f, 0.9f, 0.9f});
                 }
             }
         }


### PR DESCRIPTION
to fix the following errors on build.
```
C:\vgc\libs\vgc\ui\label.cpp(123): error C2398: Element '3': conversion from 'double' to 'float' requires a narrowing conversion [C:\vgc\build\libs\vgc\ui\vgc_lib_ui.vcxproj]
C:\vgc\libs\vgc\ui\label.cpp(123): error C2398: Element '4': conversion from 'double' to 'float' requires a narrowing conversion [C:\vgc\build\libs\vgc\ui\vgc_lib_ui.vcxproj]
C:\vgc\libs\vgc\ui\label.cpp(123): error C2398: Element '5': conversion from 'double' to 'float' requires a narrowing conversion [C:\vgc\build\libs\vgc\ui\vgc_lib_ui.vcxproj]
```
```