### PR TITLE
Fix typos in core::Vec2x (#349)

### DIFF
--- a/libs/vgc/core/tools/vec2.h
+++ b/libs/vgc/core/tools/vec2.h
@@ -39,7 +39,7 @@ namespace core {
 /// (= unit vector). Unlike other libraries, we do not use separate types for
 /// all these use cases.
 ///
-/// The memory size a Vec2x is exactly 2 * sizeof(float). This will never
+/// The memory size of a Vec2x is exactly 2 * sizeof(float). This will never
 /// change in any future version, as this allows to conveniently use this class
 /// for data transfer to the GPU (via OpenGL, Metal, etc.).
 ///

--- a/libs/vgc/core/tools/vec2.py
+++ b/libs/vgc/core/tools/vec2.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script generates all Vec2x.h/.cpp files. Usage:
+# This script generates all vec2x.h/.cpp files. Usage:
 #
 # ./vec2.py
 #

--- a/libs/vgc/core/vec2d.h
+++ b/libs/vgc/core/vec2d.h
@@ -39,7 +39,7 @@ namespace core {
 /// (= unit vector). Unlike other libraries, we do not use separate types for
 /// all these use cases.
 ///
-/// The memory size a Vec2d is exactly 2 * sizeof(double). This will never
+/// The memory size of a Vec2d is exactly 2 * sizeof(double). This will never
 /// change in any future version, as this allows to conveniently use this class
 /// for data transfer to the GPU (via OpenGL, Metal, etc.).
 ///

--- a/libs/vgc/core/vec2f.h
+++ b/libs/vgc/core/vec2f.h
@@ -39,7 +39,7 @@ namespace core {
 /// (= unit vector). Unlike other libraries, we do not use separate types for
 /// all these use cases.
 ///
-/// The memory size a Vec2f is exactly 2 * sizeof(float). This will never
+/// The memory size of a Vec2f is exactly 2 * sizeof(float). This will never
 /// change in any future version, as this allows to conveniently use this class
 /// for data transfer to the GPU (via OpenGL, Metal, etc.).
 ///


### PR DESCRIPTION
#349 