### PR TITLE
Fix onMouseLeave() not propagated to child widgets (#252)

### DIFF
--- a/libs/vgc/ui/widget.cpp
+++ b/libs/vgc/ui/widget.cpp
@@ -279,7 +279,11 @@ bool Widget::onMouseEnter()
 
 bool Widget::onMouseLeave()
 {
-    return false;
+    if (mouseEnteredChild_) {
+        mouseEnteredChild_->onMouseLeave();
+        mouseEnteredChild_ = nullptr;
+    }
+    return true;
 }
 
 } // namespace ui


### PR DESCRIPTION
#252 