### PR TITLE
Fix onPaintDestroy() called without prior call of onPaintCreate() (#252)

### DIFF
--- a/libs/vgc/widgets/uiwidget.h
+++ b/libs/vgc/widgets/uiwidget.h
@@ -89,6 +89,10 @@ private:
     int colLoc_;
     int projLoc_;
     int viewLoc_;
+
+    // Ensure that we don't call onPaintDestroy() if onPaintCreate()
+    // has not been called
+    bool isInitialized_;
 };
 
 /// \class vgc::widget::UiWidgetEngine


### PR DESCRIPTION
This caused a crash on program exit (IndexError exception with trianglesId == -1), and happened due to a widget being created but never shown because it didn't fit in the toolbar.

#252 