### PR TITLE
Have vgc::ui depends on QtGui (#200)

### DIFF
--- a/libs/vgc/ui/CMakeLists.txt
+++ b/libs/vgc/ui/CMakeLists.txt
@@ -1,4 +1,7 @@
 vgc_add_library(ui
+    THIRD_DEPENDENCIES
+        Qt5::Gui
+
     VGC_DEPENDENCIES
         core
         geometry


### PR DESCRIPTION
#200 

Note that this is a dependency to QtGui, not QtWidgets. We don't want vgc::ui to depend on QtWidgets. Also, we want to keep the dependency to QtGui minimal, but for now, reimplementing some of the functionality in QtGui would take too much time.