### PR TITLE
Override all shortcuts in UiWidget (#540)

### DIFF
--- a/libs/vgc/widgets/uiwidget.cpp
+++ b/libs/vgc/widgets/uiwidget.cpp
@@ -202,6 +202,14 @@ void UiWidget::inputMethodEvent(QInputMethodEvent* event)
     }
 }
 
+bool UiWidget::event(QEvent* e)
+{
+    if (e->type() == QEvent::ShortcutOverride) {
+        e->accept();
+    }
+    return QWidget::event(e);
+}
+
 void UiWidget::initializeGL()
 {
     // Initialize shader program

--- a/libs/vgc/widgets/uiwidget.h
+++ b/libs/vgc/widgets/uiwidget.h
@@ -72,9 +72,10 @@ protected:
     void leaveEvent(QEvent* event) override;
     void focusInEvent(QFocusEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
-    void keyPressEvent(QKeyEvent *event) override;
-    void keyReleaseEvent(QKeyEvent *event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
     void inputMethodEvent(QInputMethodEvent* event) override;
+    bool event(QEvent* e) override;
 
 private:
     OpenGLFunctions* openGLFunctions() const;


### PR DESCRIPTION
#540 

After this change, the LineEdit correctly receives the "c" key when it has focus, despite "c" being a global shortcut.