### PR TITLE
Compile Linux builds with GCC 7 so that AppImages work on Ubuntu 18.04 (#572)

### DIFF
--- a/.github/workflows/linuxbuild.yml
+++ b/.github/workflows/linuxbuild.yml
@@ -5,8 +5,8 @@ on: [push, pull_request]
 env:
   BUILD_TYPE: Release
   QT_VERSION: 5.12.5
-  CC: gcc-9
-  CXX: g++-9
+  CC: gcc-7
+  CXX: g++-7
 
 defaults:
   run:


### PR DESCRIPTION
#572 