### PR TITLE
Fix warning C4099: hash<StringId> first seen using struct now seen using class (#577)

### DIFF
--- a/libs/vgc/core/stringid.h
+++ b/libs/vgc/core/stringid.h
@@ -152,7 +152,7 @@ public:
     }
 
 private:
-    friend class std::hash<StringId>;
+    friend struct std::hash<StringId>;
     const std::string* stringPtr_;
 };
 


### PR DESCRIPTION
#577 