### PR TITLE
Add max param to libtess2's cmake_minimum_required to remove deprecation warning (#613)

### DIFF
--- a/third/libtess2/CMakeLists.txt
+++ b/third/libtess2/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 # Used features:
 # - target_include_directories (2.8.11+)
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.11...3.23)
 
 project(libtess2)
 


### PR DESCRIPTION
#613