### PR TITLE
Add skipExpectedString(..) in core/parse.h (#635)

### DIFF
--- a/libs/vgc/core/parse.h
+++ b/libs/vgc/core/parse.h
@@ -34,6 +34,7 @@
 /// \endcode
 ///
 
+#include <cstring> // std::strlen
 #include <limits>
 #include <string>
 #include <type_traits>
@@ -159,6 +160,61 @@ void skipExpectedCharacter(IStream& in, char c)
         throw ParseError(
             std::string("Unexpected '") + d + "'. Expected '" + c + "'.");
     }
+}
+
+/// Attempts to read the string [begin, end) from the input stream.
+/// Raises ParseError if the input stream does not start with [begin, end).
+///
+template<typename IStream, typename CharIterator>
+void skipExpectedString(IStream& in, CharIterator begin, CharIterator end)
+{
+    CharIterator it = begin;
+    char c = -1;
+    for (CharIterator it = begin; it < end; ++it) {
+        if (!in.get(c)) {
+            std::string message;
+            if (it == begin) {
+                message += "Unexpected end of stream.";
+            }
+            else {
+                message += "Unexpected end of stream after '";
+                message.append(begin, it);
+                message += "'.";
+            }
+            message += " Expected '";
+            message.append(begin, end);
+            message += "'.";
+            throw ParseError(message);
+        }
+        if (c != *it)  {
+            std::string message;
+            message += "Unexpected '";
+            message.append(begin, end);
+            message += *it;
+            message += "'. Expected '";
+            message.append(begin, end);
+            message += "'.";
+            throw ParseError(message);
+        }
+    }
+}
+
+/// Attempts to read the string s from the input stream.
+/// Raises ParseError if the input stream does not start with s.
+///
+template<typename IStream>
+void skipExpectedString(IStream& in, const std::string& s)
+{
+    skipExpectedString(in, s.begin(), s.end());
+}
+
+/// Attempts to read the string literal s from the input stream.
+/// Raises ParseError if the input stream does not start with s.
+///
+template<typename IStream>
+void skipExpectedString(IStream& in, const char* s)
+{
+    skipExpectedString(in, s, s + std::strlen(s));
 }
 
 /// Extracts the next character from the input stream, excepting that there is

--- a/libs/vgc/core/tests/test_parse.cpp
+++ b/libs/vgc/core/tests/test_parse.cpp
@@ -21,12 +21,75 @@
 
 // TODO: write more tests
 
+
+template<typename IStream>
+void skipExpectedString(IStream& in, const std::string& s)
+{
+
+
+}
+
 TEST(TestParse, ReadChar)
 {
     std::string s = "hello";
     vgc::core::StringReader in(s);
     char c = vgc::core::readCharacter(in);
     EXPECT_EQ(c, 'h');
+}
+
+TEST(TestParse, SkipExpectedString)
+{
+    {
+        std::string s = "";
+        vgc::core::StringReader in(s);
+        vgc::core::skipExpectedString(in, "");
+        EXPECT_NO_THROW(vgc::core::skipExpectedEof(in));
+    }
+    {
+        std::string s = "hello";
+        vgc::core::StringReader in(s);
+        vgc::core::skipExpectedString(in, "");
+        EXPECT_EQ(vgc::core::readCharacter(in), 'h');
+    }
+    {
+        std::string s = "hello";
+        vgc::core::StringReader in(s);
+        vgc::core::skipExpectedString(in, "hell");
+        EXPECT_EQ(vgc::core::readCharacter(in), 'o');
+    }
+    {
+        std::string s = "hello";
+        std::string s2 = "hell";
+        vgc::core::StringReader in(s);
+        vgc::core::skipExpectedString(in, s2);
+        EXPECT_EQ(vgc::core::readCharacter(in), 'o');
+    }
+    {
+        std::string s = "hello";
+        vgc::core::StringReader in(s);
+        vgc::core::skipExpectedString(in, "hello");
+        EXPECT_NO_THROW(vgc::core::skipExpectedEof(in));
+    }
+    {
+        std::string s = "hell";
+        vgc::core::StringReader in(s);
+        EXPECT_THROW(vgc::core::skipExpectedString(in, "hello"), vgc::core::ParseError);
+    }
+    {
+        std::string s = "help";
+        vgc::core::StringReader in(s);
+        EXPECT_THROW(vgc::core::skipExpectedString(in, "hello"), vgc::core::ParseError);
+    }
+    {
+        std::string s = "hello";
+        vgc::core::StringReader in(s);
+        EXPECT_THROW(vgc::core::skipExpectedString(in, "help"), vgc::core::ParseError);
+    }
+    {
+        std::string s = "";
+        vgc::core::StringReader in(s);
+        EXPECT_THROW(vgc::core::skipExpectedString(in, "help"), vgc::core::ParseError);
+    }
 }
 
 // We need this to ensure that std::stod uses the C locale


### PR DESCRIPTION
#635

Helper function to make it easy to implement proper parsing of "None" and "Invalid" dom::Value.