### PR TITLE
Fix various dependency issues between CMake targets (#90)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,39 +144,18 @@ message(STATUS "Python Library Dirs:  ${Python_LIBRARY_DIRS}")
 message(STATUS "Python Include Dirs:  ${Python_INCLUDE_DIRS}")
 message(STATUS "") # newline
 
-# Generate the vgc.conf file, telling VGC executables about the location
-# of various runtime resources.
-#
-add_custom_target(conf ALL
-    VERBATIM
-    COMMAND ${Python_EXECUTABLE}
-        "${CMAKE_CURRENT_SOURCE_DIR}/tools/conf.py"
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${CMAKE_CURRENT_BINARY_DIR}"
-        "$<CONFIG>"
-        "${VGC_PYTHON_HOME}"
-)
-set_target_properties(conf PROPERTIES FOLDER misc)
-
 # Always generate unit tests
 enable_testing()
 
-# Define `make tests` to build the C++ tests. Indeed, we do not build tests by
-# default when running `make`. However, note that the "tests" target is a
-# dependency of the "check" target, so there is no need to call `make tests`
-# explicitly before running `make check`.
-#
-add_custom_target(tests)
-set_target_properties(tests PROPERTIES FOLDER misc)
+# Define a vgc_tests target that builds all tests (in particular, C++ tests)
+add_custom_target(vgc_tests)
+set_target_properties(vgc_tests PROPERTIES FOLDER misc)
 
-# Define `make check` to run the unit tests in --output-on-failure mode. This
-# is more useful than the built-in `make test` which would run without printing
-# what went wrong when a test fails. We also use the --force-new-ctest-process
-# option as this is what `make test` uses too. Note that while you can run
-# `make test` in any subfolder, you can only run `make check` at the root of
-# the build folder.
-#
-# Implementation inspired from: https://stackoverflow.com/q/16158091
+# Define a `check` target that builds and run all tests.
+# Unlike `make test`, running `make check` builds the tests and all its
+# dependencies so you don't need to run `make` beforehand. Also, unlike
+# `make test`, which doesn't print what went wrong after a test fails, we
+# use --output-on-failure for `make check` which is much more useful.
 #
 if (CMAKE_CONFIGURATION_TYPES)
     add_custom_target(check
@@ -190,7 +169,7 @@ else()
             --force-new-ctest-process --output-on-failure
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
-add_dependencies(check tests)
+add_dependencies(check vgc_tests)
 set_target_properties(check PROPERTIES FOLDER misc)
 
 # Set "third" as default FOLDER target property
@@ -492,18 +471,10 @@ message(STATUS "") # newline
 # Restore default value of FOLDER target property
 set(CMAKE_FOLDER ${VGC_CMAKE_FOLDER_OLD})
 
-# Add internal libs and apps
-# TODO: avoid global `include_directories`
-message(STATUS "[VGC]")
-include_directories(${CMAKE_CURRENT_LIST_DIR}/libs)
-add_subdirectory(libs)
-add_subdirectory(apps)
-message(STATUS "") # newline
-
 # Generate the file resources/core/version.txt with versioning info.
 # See vgc/tools/version.py for details.
 #
-add_custom_target(version ALL
+add_custom_target(vgc_version
     VERBATIM
     COMMAND ${Python_EXECUTABLE}
         "${CMAKE_CURRENT_SOURCE_DIR}/tools/version.py"
@@ -522,7 +493,64 @@ add_custom_target(version ALL
         "${VGC_ARCHITECTURE}"
         "$<CONFIG>"
 )
-set_target_properties(version PROPERTIES FOLDER misc)
+set_target_properties(vgc_version PROPERTIES FOLDER misc)
+
+# Generate the vgc.conf file, telling VGC executables about the location
+# of various runtime resources.
+#
+add_custom_target(vgc_conf
+    VERBATIM
+    COMMAND ${Python_EXECUTABLE}
+        "${CMAKE_CURRENT_SOURCE_DIR}/tools/conf.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+        "${CMAKE_CURRENT_BINARY_DIR}"
+        "$<CONFIG>"
+        "${VGC_PYTHON_HOME}"
+)
+set_target_properties(vgc_conf PROPERTIES FOLDER misc)
+
+# Copy Python dependencies
+#
+# On Windows we cannot easily use the system Python to import our Python wrappers
+# (including for running our Python unit tests), because the system Python wouldn't
+# find our DLLs even if we add them to the PATH.
+#
+# For example, for our python tests, if we used:
+#   add_test(... COMMAND ${Python_EXECUTABLE} ...)
+#   set_tests_properties(... ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}/$<CONFIG>/bin;PYTHONPATH=${CMAKE_BINARY_DIR}/$<CONFIG>/python") 
+#
+# Then ${Python_EXECUTABLE} would correctly find <build>/<config>/python/vgc/core.*.pyd
+# thanks to the provided PYTHONPATH, but would still fail with:
+#
+#   ImportError: DLL load failed while importing core: The specified module could not be found.
+#
+# The reason is that python/vgc/core.*.pyd cannot find bin/vgccore.dll, even if the
+# bin folder is in the PATH. Indeed, since Python 3.8, Python completely ignores
+# the PATH variable for DLL resolution. Instead, it is required to use
+# os.add_dll_directory('path/to/dll'), see:
+#
+#   - https://docs.python.org/3/library/os.html#os.add_dll_directory
+#   - https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
+#
+# Therefore, for now, our solution is to copy the whole Python distribution to our build 
+# folder and use this copy of Python instead of the system Python whenever we need to
+# import our Python modules (for example, in our Python tests, or in the embedded interpreter
+# of our apps).
+#
+# A more long-term solution might be to rename our pyd module `core_`, and have a
+# pure-Python module called `core` that calls os.add_dll_directory() before 
+# importing core_ and transferring all symbols from core_ to core.
+#
+if(WIN32)
+    add_custom_target(vgc_copy_python
+        VERBATIM
+        COMMAND ${Python_EXECUTABLE}
+            "${CMAKE_CURRENT_SOURCE_DIR}/tools/windows/copy_python.py"
+            "${CMAKE_CURRENT_BINARY_DIR}"
+            "$<CONFIG>"
+    )
+    set_target_properties(vgc_copy_python PROPERTIES FOLDER misc)
+endif()
 
 # On Windows, create a convenient batch script called 'make.bat' in the build
 # folder, which allows you to run the following command in cmd.exe:
@@ -555,19 +583,6 @@ if(WIN32)
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/tools/windows/test.in.bat
         ${CMAKE_BINARY_DIR}/test.bat)
-endif()
-
-# Copy Python dependencies
-#
-if(WIN32)
-    add_custom_target(copy_python ALL
-        VERBATIM
-        COMMAND ${Python_EXECUTABLE}
-            "${CMAKE_CURRENT_SOURCE_DIR}/tools/windows/copy_python.py"
-            "${CMAKE_CURRENT_BINARY_DIR}"
-            "$<CONFIG>"
-    )
-    set_target_properties(copy_python PROPERTIES FOLDER misc)
 endif()
 
 # Add deploy target.
@@ -618,3 +633,11 @@ else()
     )
 endif()
 set_target_properties(deploy PROPERTIES FOLDER misc)
+
+# Add internal libs and apps
+# TODO: avoid global `include_directories`
+message(STATUS "[VGC]")
+include_directories(${CMAKE_CURRENT_LIST_DIR}/libs)
+add_subdirectory(libs)
+add_subdirectory(apps)
+message(STATUS "") # newline

--- a/libs/vgc/core/CMakeLists.txt
+++ b/libs/vgc/core/CMakeLists.txt
@@ -70,5 +70,7 @@ vgc_add_library(core
 vgc_optional_compile_definition(core PUBLIC VGC_CORE_USE_32BIT_INT "Define vgc::Int/UInt as 32-bit integers (default is 64-bit)")
 vgc_optional_compile_definition(core PRIVATE VGC_CORE_OBJECT_DEBUG "Enable debug mode for vgc::core::Object")
 
+add_dependencies(vgc_core_lib vgc_version)
+
 add_subdirectory(wraps)
 add_subdirectory(tests)

--- a/tools/VgcTools.cmake
+++ b/tools/VgcTools.cmake
@@ -296,7 +296,7 @@ function(vgc_test_library LIB_NAME)
     # Create target vgc_<libname>_tests
     add_custom_target(${TESTS_TARGET} SOURCES ${ARG_CPP_TESTS} ${ARG_PYTHON_TESTS})
     set_target_properties(${TESTS_TARGET} PROPERTIES FOLDER libs/${LIB_NAME}/tests)
-    add_dependencies(tests ${TESTS_TARGET})
+    add_dependencies(vgc_tests ${TESTS_TARGET})
 
     # C++ tests
     if(ARG_CPP_TESTS) # If there is at least one C++ test
@@ -363,6 +363,9 @@ function(vgc_test_library LIB_NAME)
         set_target_properties(${PYTHON_TESTS_TARGET} PROPERTIES FOLDER libs/${LIB_NAME}/tests)
         add_dependencies(${TESTS_TARGET} ${PYTHON_TESTS_TARGET})
         add_dependencies(${PYTHON_TESTS_TARGET} ${BASE_TARGET})
+        if(WIN32)
+            add_dependencies(${PYTHON_TESTS_TARGET} vgc_copy_python)
+        endif()
     endif()
     foreach(FILENAME ${ARG_PYTHON_TESTS})
         set(TEST_TARGET vgc_${LIB_NAME}_${FILENAME})
@@ -371,9 +374,6 @@ function(vgc_test_library LIB_NAME)
                 NAME ${TEST_TARGET}
                 COMMAND ${CMAKE_BINARY_DIR}/$<CONFIG>/bin/python.exe ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME} -v
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            set_tests_properties(${TEST_TARGET} PROPERTIES
-                ENVIRONMENT "PATH=%PATH%\;${CMAKE_BINARY_DIR}/$<CONFIG>/bin"
             )
         else()
             add_test(
@@ -494,6 +494,12 @@ function(vgc_add_app APP_NAME)
         )
         add_dependencies(${APP_TARGET} ${RESOURCES_TARGET})
     endif()    
+    
+    # Ensures the vgc.conf file is generated next to the app
+    add_dependencies(${APP_TARGET} vgc_conf)
+    
+    # Add the app to the deploy target
+    add_dependencies(deploy ${APP_TARGET})
 
     if(WIN32)
         # Run windeployqt to copy all required Qt dependencies in the bin
@@ -533,10 +539,10 @@ function(vgc_add_app APP_NAME)
             VERBATIM
         )
 
-        # Add dependency to copy_python so that pythonXY.dll is copied to the 
+        # Add dependency to vgc_copy_python so that pythonXY.dll is copied to the 
         # build folder when building the app.
         #
-        add_dependencies(${APP_TARGET} copy_python)
+        add_dependencies(${APP_TARGET} vgc_copy_python)
     endif()
 
 endfunction()

--- a/tools/VgcTools.cmake
+++ b/tools/VgcTools.cmake
@@ -375,6 +375,9 @@ function(vgc_test_library LIB_NAME)
                 COMMAND ${CMAKE_BINARY_DIR}/$<CONFIG>/bin/python.exe ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME} -v
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             )
+            set_tests_properties(${TEST_TARGET} PROPERTIES
+                ENVIRONMENT "PATH=%PATH%\;${CMAKE_BINARY_DIR}/$<CONFIG>/bin"
+            )
         else()
             add_test(
                 NAME ${TEST_TARGET}


### PR DESCRIPTION
#90

We now have python tests depend on vgc_copy_python, vgc_core_lib depend
on vgc_version, vgc_illustration_app depend on vgc_conf, and deploy depend
on vgc_illustration.