### PR TITLE
Improve text rendering performance: minimize allocations, copies, arithmetic operations, and prefer single-precision floats (#742)

### DIFF
--- a/libs/vgc/geometry/curves2d.h
+++ b/libs/vgc/geometry/curves2d.h
@@ -156,21 +156,6 @@ private:
 /// - http://ericniebler.com/2015/01/28/to-be-or-not-to-be-an-iterator/
 /// - https://en.cppreference.com/w/cpp/container/vector_bool
 ///
-/// The reason we use a proxy iterator is the same as why std::vector<bool>
-///
-///
-///  that the reason we call this a "proxy" iterator is that there is no
-/// actual "Command" objects stored in a Curves2d. Instead, command data is
-/// split into an internal array storing command metadata (command type and
-/// number of arguments), and a a DoubleArray storing the geometric data (see
-/// Curves2d::data()). The class Curves2dCommandRef allows you to conveniently
-/// access the commands like if there was some Command object, but in fact
-/// there isn't. If you are curious about proxy iterators, you can read the
-/// following interesting article by Eric Niebler, lead designer of the C++20
-/// ranges concept:
-///
-///
-///
 class VGC_GEOMETRY_API Curves2dCommandIterator {
 public:
     using difference_type = ptrdiff_t;

--- a/libs/vgc/graphics/font.cpp
+++ b/libs/vgc/graphics/font.cpp
@@ -602,20 +602,65 @@ void FontGlyph::fill(core::FloatArray& data,
     // if the FontGlyph has a small ppem then the cached tesselation may have a
     // small number of triangles not suitable to draw at larger sizes.
 
-    const core::FloatArray& triangles = impl_->triangles;
-    Int numVertices = triangles.length() / 2;
+    Int numVertices = impl_->triangles.length() / 2;
+    Int oldLength = data.length();
 
-    Int offset = data.length();
-    data.resizeNoInit(offset + 2 * numVertices);
+    data.resizeNoInit(oldLength + 2 * numVertices);
 
-    auto itIn = triangles.begin();
-    auto itOut = data.begin() + offset;
-    while (itOut != data.end()) {
-        float x = *itIn++;
-        float y = *itIn++;
-        geometry::Vec2f v2 = transform * geometry::Vec2f(x, y);
-        *itOut++ = v2[0];
-        *itOut++ = v2[1];
+    const float* in = impl_->triangles.begin();
+    float* out = data.begin() + oldLength;
+    float* end = data.end();
+
+    while (out != end) {
+        float x = *in++;
+        float y = *in++;
+        geometry::Vec2f v = transform * geometry::Vec2f(x, y);
+        *out++ = v[0];
+        *out++ = v[1];
+    }
+}
+
+void FontGlyph::fill(core::FloatArray& data,
+                     const geometry::Vec2f& translation) const
+{
+    Int numVertices = impl_->triangles.length() / 2;
+    Int oldLength = data.length();
+
+    data.resizeNoInit(oldLength + 2 * numVertices);
+
+    const float* in = impl_->triangles.begin();
+    float* out = data.begin() + oldLength;
+    float* end = data.end();
+    float x0 = translation[0];
+    float y0 = translation[1];
+
+    while (out != end) {
+        float x = *in++;
+        float y = *in++;
+        *out++ = x0 + x;
+        *out++ = y0 + y;
+    }
+}
+
+void FontGlyph::fillYMirrored(core::FloatArray& data,
+                              const geometry::Vec2f& translation) const
+{
+    Int numVertices = impl_->triangles.length() / 2;
+    Int oldLength = data.length();
+
+    data.resizeNoInit(oldLength + 2 * numVertices);
+
+    const float* in = impl_->triangles.begin();
+    float* out = data.begin() + oldLength;
+    float* end = data.end();
+    float x0 = translation[0];
+    float y0 = translation[1];
+
+    while (out != end) {
+        float x = *in++;
+        float y = *in++;
+        *out++ = x0 + x;
+        *out++ = y0 - y;
     }
 }
 

--- a/libs/vgc/graphics/font.h
+++ b/libs/vgc/graphics/font.h
@@ -95,6 +95,12 @@ geometry::Vec2d f266ToVec2d(T x, T y)
     return geometry::Vec2d(x / 64.0, y / 64.0);
 }
 
+template<class T>
+geometry::Vec2f f266ToVec2f(T x, T y)
+{
+    return geometry::Vec2f(x / 64.0f, y / 64.0f);
+}
+
 } // namespace internal
 
 /// \class vgc::graphics::FontLibrary
@@ -326,6 +332,29 @@ public:
     ///
     void fill(core::FloatArray& data,
               const geometry::Mat3f& transform) const;
+
+    /// Same as fill(data, transform) but with only a translation part. This is
+    /// equivalent (but faster) to:
+    ///
+    /// ```cpp
+    /// geometry::Mat3f transform = geometry::Mat3f::identity;
+    /// transform.translate(translation);
+    /// ```
+    ///
+    void fill(core::FloatArray& data,
+              const geometry::Vec2f& translation) const;
+
+    /// Same as fill(data, transform) but with only a translation part as well as flipping the Y-coordinate. This is
+    /// equivalent (but faster) to:
+    ///
+    /// ```cpp
+    /// geometry::Mat3f transform = geometry::Mat3f::identity;
+    /// transform.translate(translation);
+    /// transform.scale(1, -1);
+    /// ```
+    ///
+    void fillYMirrored(core::FloatArray& data,
+                       const geometry::Vec2f& translation) const;
 
 protected:
     /// \reimp

--- a/libs/vgc/graphics/text.h
+++ b/libs/vgc/graphics/text.h
@@ -136,9 +136,9 @@ public:
     /// Creates a ShapedGlyph.
     ///
     ShapedGlyph(FontGlyph* fontGlyph,
-                const geometry::Vec2d& offset,
-                const geometry::Vec2d& advance,
-                const geometry::Vec2d& position,
+                const geometry::Vec2f& offset,
+                const geometry::Vec2f& advance,
+                const geometry::Vec2f& position,
                 Int bytePosition) :
         fontGlyph_(fontGlyph),
         offset_(offset),
@@ -177,7 +177,7 @@ public:
     /// should not affect how much the line advances. This is expressed in
     /// ShapedText coordinates, that is, with the Y-axis pointing down.
     ///
-    const geometry::Vec2d& offset() const {
+    const geometry::Vec2f& offset() const {
         return offset_;
     }
 
@@ -187,7 +187,7 @@ public:
     /// text in vertical direction. This is expressed in ShapedText
     /// coordinates, that is, with the Y-axis pointing down.
     ///
-    const geometry::Vec2d& advance() const {
+    const geometry::Vec2f& advance() const {
         return advance_;
     }
 
@@ -200,7 +200,7 @@ public:
     /// This is expressed in ShapedText coordinates, that is, with the Y-axis
     /// pointing down.
     ///
-    const geometry::Vec2d& position() const {
+    const geometry::Vec2f& position() const {
         return position_;
     }
 
@@ -258,7 +258,7 @@ public:
     /// position.
     ///
     void fill(core::FloatArray& data,
-              const geometry::Vec2d& origin,
+              const geometry::Vec2f& origin,
               float r, float g, float b) const;
 
     /// Overload of fill that doesn't output color information, that is, the
@@ -277,13 +277,13 @@ public:
     ///  ...]
     ///
     void fill(core::FloatArray& data,
-              const geometry::Vec2d& origin) const;
+              const geometry::Vec2f& origin) const;
 
 private:
     FontGlyph* fontGlyph_;
-    geometry::Vec2d offset_;
-    geometry::Vec2d advance_;
-    geometry::Vec2d position_;
+    geometry::Vec2f offset_;
+    geometry::Vec2f advance_;
+    geometry::Vec2f position_;
     Int bytePosition_;
     geometry::Rect2f boundingBox_;
 };
@@ -324,8 +324,8 @@ public:
     /// Creates a ShapedGrapheme.
     ///
     ShapedGrapheme(Int glyphIndex,
-                   const geometry::Vec2d& advance,
-                   const geometry::Vec2d& position,
+                   const geometry::Vec2f& advance,
+                   const geometry::Vec2f& position,
                    Int bytePosition) :
         glyphIndex_(glyphIndex),
         advance_(advance),
@@ -355,7 +355,7 @@ public:
     /// returns the glyph advance divided by the number of graphemes which are
     /// part of the glyph.
     ///
-    geometry::Vec2d advance() const {
+    geometry::Vec2f advance() const {
         return advance_;
     }
 
@@ -365,7 +365,7 @@ public:
     /// This is equal to the sum of the advances of all the previous graphemes
     /// of the ShapedText.
     ///
-    geometry::Vec2d position() const {
+    geometry::Vec2f position() const {
         return position_;
     }
 
@@ -383,8 +383,8 @@ public:
 private:
     friend class internal::ShapedTextImpl;
     Int glyphIndex_;
-    geometry::Vec2d advance_;
-    geometry::Vec2d position_;
+    geometry::Vec2f advance_;
+    geometry::Vec2f position_;
     Int bytePosition_;
 };
 
@@ -406,6 +406,12 @@ using ShapedGraphemeArray = core::Array<ShapedGrapheme>;
 ///     ...
 /// }
 /// ```
+///
+/// Note that the fill functions of this class are not thread-safe. In
+/// particular, two threads cannot concurrently call fill functions on the same
+/// ShapedText instance. The reason is that ShapedText uses internal buffers
+/// for intermediate computations, which are stored as data members to avoid
+/// dynamic allocations.
 ///
 class VGC_GRAPHICS_API ShapedText {
 public:
@@ -468,14 +474,14 @@ public:
     // This is equal to the sum of `glyph->advance()` for all the ShapedGlyph
     // elements in glyphs().
     //
-    geometry::Vec2d advance() const;
+    geometry::Vec2f advance() const;
 
     // Returns how much the line advances after drawing all the graphemes until
     // the given bytePosition.
     //
     // \sa bytePosition()
     //
-    geometry::Vec2d advance(Int bytePosition) const;
+    geometry::Vec2f advance(Int bytePosition) const;
 
     /// Fills this ShapedText at the given origin:
     ///
@@ -509,7 +515,7 @@ public:
     /// then all the Y-coordinates of the triangle vertices will be negative.
     ///
     void fill(core::FloatArray& data,
-              const geometry::Vec2d& origin,
+              const geometry::Vec2f& origin,
               float r, float g, float b) const;
 
     /// Fills this ShapedText from glyph index `start` (included) to glyph
@@ -519,7 +525,7 @@ public:
     /// arguments.
     ///
     void fill(core::FloatArray& data,
-              const geometry::Vec2d& origin,
+              const geometry::Vec2f& origin,
               float r, float g, float b,
               Int start, Int end) const;
 
@@ -530,7 +536,7 @@ public:
     /// arguments.
     ///
     void fill(core::FloatArray& data,
-              const geometry::Vec2d& origin,
+              const geometry::Vec2f& origin,
               float r, float g, float b,
               float clipLeft, float clipRight,
               float clipTop, float clipBottom) const;
@@ -538,7 +544,7 @@ public:
     /// Returns the byte position in the original text corresponding to the
     /// grapheme boundary closest to the given mouse position.
     ///
-    Int bytePosition(const geometry::Vec2d& mousePosition);
+    Int bytePosition(const geometry::Vec2f& mousePosition);
 
 private:
     internal::ShapedTextImpl* impl_;

--- a/libs/vgc/ui/internal/paintutil.cpp
+++ b/libs/vgc/ui/internal/paintutil.cpp
@@ -193,7 +193,7 @@ void insertText(
         // we may want to clip up to the border of the given text box instead.
         //
         constexpr bool clipAtPadding = true;
-        geometry::Vec2d origin(static_cast<double>(textLeft), static_cast<double>(baseline));
+        geometry::Vec2f origin(textLeft, baseline);
         float clipLeft   = x1 + (clipAtPadding ? paddingLeft   : 0);
         float clipRight  = x2 - (clipAtPadding ? paddingRight  : 0);
         float clipTop    = y1 + (clipAtPadding ? paddingTop    : 0);
@@ -209,7 +209,7 @@ void insertText(
                 if (grapheme.bytePosition() >= cursorBytePosition) {
                     break;
                 }
-                cursorAdvance += static_cast<float>(grapheme.advance()[0]);
+                cursorAdvance += grapheme.advance()[0];
             }
             float cursorX = x1 + paddingLeft + cursorAdvance;
             float cursorW = 1.0f;

--- a/libs/vgc/ui/lineedit.cpp
+++ b/libs/vgc/ui/lineedit.cpp
@@ -293,10 +293,9 @@ void LineEdit::updateBytePosition_(const geometry::Vec2f& mousePosition)
 Int LineEdit::bytePosition_(const geometry::Vec2f& mousePosition)
 {
     float paddingLeft = internal::getLength(this, strings::padding_left);
-    float x = mousePosition[0] - paddingLeft;
+    float x = mousePosition[0] - paddingLeft + scrollLeft_;
     float y = mousePosition[1];
-    return shapedText_.bytePosition(
-                geometry::Vec2d(static_cast<double>(x + scrollLeft_), static_cast<double>(y)));
+    return shapedText_.bytePosition(geometry::Vec2f(x, y));
 }
 
 void LineEdit::updateScroll_(float textWidth)


### PR DESCRIPTION
#742