### PR TITLE
Clear LineEdit focus when clicking on empty space in toolbar (#539)

### DIFF
--- a/libs/vgc/widgets/toolbar.cpp
+++ b/libs/vgc/widgets/toolbar.cpp
@@ -43,6 +43,7 @@ Toolbar::Toolbar(QWidget* parent)
     setOrientation(Qt::Vertical);
     setMovable(false);
     setIconSize(iconSize);
+    setFocusPolicy(Qt::ClickFocus);
 
     QWidget* topMargin = new QWidget();
     topMargin->setMinimumSize(0, margin);


### PR DESCRIPTION
#539