### PR TITLE
Reorder call to preMouseMove() after the hover-chain child update (#252)

### DIFF
--- a/libs/vgc/ui/widget.cpp
+++ b/libs/vgc/ui/widget.cpp
@@ -524,21 +524,10 @@ void Widget::mouseMove_(MouseEvent* event) {
         return;
     }
 
-    // User-defined capture phase handler.
+    // Prepare against death of `this`
     WidgetPtr thisPtr = this;
-    preMouseMove(event);
-    if (!thisPtr.isAlive()) {
-        // Widget got killed. Event can be considered handled.
-        event->handled_ = true;
-        return;
-    }
 
-    // Handle stop propagation.
-    if (event->isStopPropagationRequested()) {
-        return;
-    }
-
-    // Get hover-chain child.
+    // Get or update hover-chain child.
     Widget* hcChild = hoverChainChild();
     const bool hasNoHoverLockedChild = !hcChild || !hcChild->isHoverLocked();
     if (isChildHoverEnabled_ && hasNoHoverLockedChild) {
@@ -555,6 +544,22 @@ void Widget::mouseMove_(MouseEvent* event) {
             return;
         }
     }
+
+    // User-defined capture phase handler.
+    preMouseMove(event);
+    if (!thisPtr.isAlive()) {
+        // Widget got killed. Event can be considered handled.
+        event->handled_ = true;
+        return;
+    }
+
+    // Handle stop propagation.
+    if (event->isStopPropagationRequested()) {
+        return;
+    }
+
+    // Get final hover-chain child (possibly changed in preMouseMove).
+    hcChild = hoverChainChild();
 
     // Call hover-chain child's handler.
     if (hcChild) {

--- a/libs/vgc/ui/widget.h
+++ b/libs/vgc/ui/widget.h
@@ -741,6 +741,11 @@ public:
     /// Override this function if you wish to handle MouseMove events during the
     /// capture phase (from root to leaf).
     ///
+    /// The hover-chain child is automatically updated (if it is not hover-locked)
+    /// prior to calling this function using `computeHoverChainChild()`.
+    /// However you can change it again in this function using `setHoverChainChild()`.
+    /// This let's you override a hover-locked hover-chain child.
+    ///
     virtual void preMouseMove(MouseEvent* event);
 
     /// Override this function if you wish to handle MousePress events during the


### PR DESCRIPTION
#252