### PR TITLE
Fix out-of-bounds access in fullEnumClassName() (#517)

### DIFF
--- a/libs/vgc/core/enum.h
+++ b/libs/vgc/core/enum.h
@@ -36,6 +36,10 @@ inline std::string_view fullEnumClassName(std::string_view enumDataPrettyFunctio
 
     // Find closing parenthesis
     size_t j = s.size();
+    if (j == 0) {
+        return "";
+    }
+    --j;
     while (j > 0 && s[j] != ')') {
         --j;
     }


### PR DESCRIPTION
#517