### PR TITLE
Fix Object incorrectly destructed when removed from parent (#709)

### DIFF
--- a/libs/vgc/core/object.cpp
+++ b/libs/vgc/core/object.cpp
@@ -341,6 +341,7 @@ void Object::insertObjectToParent_(Object* parent, Object* nextSibling) {
 
 ObjectPtr Object::removeObjectFromParent_() {
     Object* parent = parentObject_;
+    ObjectPtr res(this);
     if (parent) {
         if (previousSiblingObject_) {
             previousSiblingObject_->nextSiblingObject_ = nextSiblingObject_;
@@ -359,7 +360,7 @@ ObjectPtr Object::removeObjectFromParent_() {
         parentObject_ = nullptr;
         parent->onChildRemoved_(this);
     }
-    return ObjectPtr(this);
+    return res;
 }
 
 Int Object::branchSize() const {


### PR DESCRIPTION
#709

I had a crash where the issue was that `Object::removeObjectFromParent_()` calls `parent->onChildRemoved_(this)`, which can indirectly create a temporary `ObjPtr` doing an `incref` followed by a `decref`, destructing the object.
