### PR TITLE
Redesign how style property specifications are defined (#481)

### DIFF
--- a/apps/uitest/main.cpp
+++ b/apps/uitest/main.cpp
@@ -346,14 +346,14 @@ int main(int argc, char* argv[]) {
     mainLayout->addStyleClass(core::StringId("main-layout"));
 
     std::string path = core::resourcePath("ui/stylesheets/default.vgcss");
-    std::string stylesheet = core::readFile(path);
-    stylesheet += ".main-layout { "
+    std::string styleSheet = core::readFile(path);
+    styleSheet += ".main-layout { "
                   "    row-gap: 0dp; "
                   "    padding-top: 0dp; "
                   "    padding-right: 0dp; "
                   "    padding-bottom: 0dp; "
                   "    padding-left: 0dp; }";
-    mainLayout->setStyleSheet(stylesheet);
+    mainLayout->setStyleSheet(styleSheet);
 
     // Create menubar
     createMenu(mainLayout);

--- a/apps/uitest/main.cpp
+++ b/apps/uitest/main.cpp
@@ -22,6 +22,7 @@
 #include <QSettings>
 #include <QTimer>
 
+#include <vgc/core/io.h>
 #include <vgc/core/paths.h>
 #include <vgc/core/python.h>
 #include <vgc/core/random.h>
@@ -343,12 +344,16 @@ int main(int argc, char* argv[]) {
     ui::Column* mainLayout = overlay->createChild<ui::Column>();
     overlay->setAreaWidget(mainLayout);
     mainLayout->addStyleClass(core::StringId("main-layout"));
-    mainLayout->setStyleSheet(".main-layout { "
-                              "    row-gap: 0dp; "
-                              "    padding-top: 0dp; "
-                              "    padding-right: 0dp; "
-                              "    padding-bottom: 0dp; "
-                              "    padding-left: 0dp; }");
+
+    std::string path = core::resourcePath("ui/stylesheets/default.vgcss");
+    std::string stylesheet = core::readFile(path);
+    stylesheet += ".main-layout { "
+                  "    row-gap: 0dp; "
+                  "    padding-top: 0dp; "
+                  "    padding-right: 0dp; "
+                  "    padding-bottom: 0dp; "
+                  "    padding-left: 0dp; }";
+    mainLayout->setStyleSheet(stylesheet);
 
     // Create menubar
     createMenu(mainLayout);

--- a/libs/vgc/graphics/richtext.cpp
+++ b/libs/vgc/graphics/richtext.cpp
@@ -63,80 +63,69 @@ StyleValue parseTextVerticalAlign(StyleTokenIterator begin, StyleTokenIterator e
     return parseIdentifierAmong(begin, end, {top, middle, bottom});
 }
 
-// clang-format off
+} // namespace
 
-style::StylePropertySpecTablePtr createGlobalStylePropertySpecTable_() {
+void RichTextSpan::doPopulateStyleSpecTable(style::SpecTable* table) {
+
+    if (!table->setRegistered(RichTextSpan::staticClassName())) {
+        return;
+    }
 
     using namespace strings;
     using namespace style::strings;
     using namespace style::literals;
+    using style::BorderRadius;
+    using style::Length;
+    using style::LengthOrAuto;
+    using style::LengthOrPercentage;
+    using style::LengthOrPercentageOrAuto;
 
+    // clang-format off
     // Reference: https://www.w3.org/TR/CSS21/propidx.html
-    auto black_         = StyleValue::custom(core::colors::black);
-    auto white_         = StyleValue::custom(core::colors::white);
-    auto blueish_       = StyleValue::custom(core::Color(0.20f, 0.56f, 1.0f));
-    auto transparent_   = StyleValue::custom(core::colors::transparent);
-    auto zerol_         = StyleValue::custom(style::Length());
-    auto zerolp_        = StyleValue::custom(style::LengthOrPercentage());
-    auto zerobr_        = StyleValue::custom(style::BorderRadius());
-    auto twelve_        = StyleValue::custom(style::Length(12.0_dp));
-    auto autol_         = StyleValue::custom(style::LengthOrAuto());
-    auto normal_        = StyleValue::identifier(strings::normal);
-    auto left_          = StyleValue::identifier(strings::left);
-    auto top_           = StyleValue::identifier(strings::top);
 
-    auto table = std::make_shared<style::StylePropertySpecTable>();
+    auto cBlack = StyleValue::custom(core::colors::black);
+    auto cWhite = StyleValue::custom(core::colors::white);
+    auto cBlue = StyleValue::custom(core::Color(0.20f, 0.56f, 1.0f));
+    auto cTransp = StyleValue::custom(core::colors::transparent);
+    auto lZero = StyleValue::custom(Length());
+    auto lpZero = StyleValue::custom(LengthOrPercentage());
+    auto brZero = StyleValue::custom(BorderRadius());
+    auto lTwelve = StyleValue::custom(Length(12.0_dp));
+    auto laAuto = StyleValue::custom(LengthOrAuto());
+    auto iNormal = StyleValue::identifier(strings::normal);
+    auto iLeft = StyleValue::identifier(strings::left);
+    auto iTop = StyleValue::identifier(strings::top);
 
-    table->insert(background_color,                 transparent_,   false, &style::parseColor);
-    table->insert(margin_top,                       zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(margin_right,                     zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(margin_bottom,                    zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(margin_left,                      zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(padding_top,                      zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(padding_right,                    zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(padding_bottom,                   zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(padding_left,                     zerolp_,        false, &style::LengthOrPercentage::parse);
-    table->insert(border_width,                     zerol_,         false, &style::Length::parse);
-    table->insert(border_color,                     black_,         false, &style::parseColor);
-    table->insert(border_top_left_radius,           zerobr_,        false, &style::BorderRadius::parse);
-    table->insert(border_top_right_radius,          zerobr_,        false, &style::BorderRadius::parse);
-    table->insert(border_bottom_right_radius,       zerobr_,        false, &style::BorderRadius::parse);
-    table->insert(border_bottom_left_radius,        zerobr_,        false, &style::BorderRadius::parse);
+    table->insert(background_color, cTransp, false, &style::parseColor);
+    table->insert(margin_top, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(margin_right, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(margin_bottom, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(margin_left, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(padding_top, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(padding_right, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(padding_bottom, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(padding_left, lpZero, false, &LengthOrPercentage::parse);
+    table->insert(border_width, lZero, false, &Length::parse);
+    table->insert(border_color, cBlack, false, &style::parseColor);
+    table->insert(border_top_left_radius, brZero, false, &BorderRadius::parse);
+    table->insert(border_top_right_radius, brZero, false, &BorderRadius::parse);
+    table->insert(border_bottom_right_radius, brZero, false, &BorderRadius::parse);
+    table->insert(border_bottom_left_radius, brZero, false, &BorderRadius::parse);
 
-    table->insert(pixel_hinting,                    normal_,        true,  &parsePixelHinting);
-    table->insert(font_size,                        twelve_,        true,  &style::Length::parse);
-    table->insert(font_ascent,                      autol_,         true,  &style::LengthOrAuto::parse);
-    table->insert(font_descent,                     autol_,         true,  &style::LengthOrAuto::parse);
-    table->insert(text_color,                       black_,         true,  &style::parseColor);
-    table->insert(text_selection_color,             white_,         true,  &style::parseColor);
-    table->insert(text_selection_background_color,  blueish_,       true,  &style::parseColor);
-    table->insert(text_horizontal_align,            left_,          true,  &parseTextHorizontalAlign);
-    table->insert(text_vertical_align,              top_,           true,  &parseTextVerticalAlign);
-    table->insert(caret_color,                      black_,         true,  &style::parseColor);
+    //table->insert(pixel_hinting, iNormal, true, &parsePixelHinting);
+    table->insert(font_size, lTwelve, true, &Length::parse);
+    table->insert(font_ascent, laAuto, true, &LengthOrAuto::parse);
+    table->insert(font_descent, laAuto, true, &LengthOrAuto::parse);
+    table->insert(text_color, cBlack, true, &style::parseColor);
+    table->insert(text_selection_color, cWhite, true, &style::parseColor);
+    table->insert(text_selection_background_color, cBlue, true, &style::parseColor);
+    //table->insert(text_horizontal_align, iLeft, true, &parseTextHorizontalAlign);
+    //table->insert(text_vertical_align, iTop, true, &parseTextVerticalAlign);
+    table->insert(caret_color, cBlack, true, &style::parseColor);
 
-    return table;
-}
+    // clang-format on
 
-// clang-format on
-
-const style::StylePropertySpecTablePtr& stylePropertySpecTable_() {
-    static style::StylePropertySpecTablePtr table = createGlobalStylePropertySpecTable_();
-    return table;
-}
-
-style::StyleSheetPtr createGlobalStyleSheet_() {
-    return style::StyleSheet::create(stylePropertySpecTable_(), "");
-}
-
-} // namespace
-
-const style::StyleSheet* RichTextSpan::defaultStyleSheet() const {
-    static style::StyleSheetPtr s = createGlobalStyleSheet_();
-    return s.get();
-}
-
-const style::StylePropertySpecTable* RichTextSpan::stylePropertySpecs() {
-    return stylePropertySpecTable_().get();
+    SuperClass::doPopulateStyleSpecTable(table);
 }
 
 namespace {
@@ -751,5 +740,7 @@ void RichText::insertText_(std::string_view textToInsert) {
     // Clear selection
     selectionStart_ = selectionEnd_;
 }
+
+namespace detail {} // namespace detail
 
 } // namespace vgc::graphics

--- a/libs/vgc/graphics/richtext.cpp
+++ b/libs/vgc/graphics/richtext.cpp
@@ -65,9 +65,11 @@ StyleValue parseTextVerticalAlign(StyleTokenIterator begin, StyleTokenIterator e
 
 } // namespace
 
-void RichTextSpan::doPopulateStyleSpecTable(style::SpecTable* table) {
+// clang-format off
 
-    if (!table->setRegistered(RichTextSpan::staticClassName())) {
+void RichTextSpan::populateStyleSpecTable(style::SpecTable* table) {
+
+    if (!table->setRegistered(staticClassName())) {
         return;
     }
 
@@ -80,53 +82,54 @@ void RichTextSpan::doPopulateStyleSpecTable(style::SpecTable* table) {
     using style::LengthOrPercentage;
     using style::LengthOrPercentageOrAuto;
 
-    // clang-format off
     // Reference: https://www.w3.org/TR/CSS21/propidx.html
 
-    auto cBlack = StyleValue::custom(core::colors::black);
-    auto cWhite = StyleValue::custom(core::colors::white);
-    auto cBlue = StyleValue::custom(core::Color(0.20f, 0.56f, 1.0f));
-    auto cTransp = StyleValue::custom(core::colors::transparent);
-    auto lZero = StyleValue::custom(Length());
-    auto lpZero = StyleValue::custom(LengthOrPercentage());
-    auto brZero = StyleValue::custom(BorderRadius());
-    auto lTwelve = StyleValue::custom(Length(12.0_dp));
-    auto laAuto = StyleValue::custom(LengthOrAuto());
-    auto iNormal = StyleValue::identifier(strings::normal);
-    auto iLeft = StyleValue::identifier(strings::left);
-    auto iTop = StyleValue::identifier(strings::top);
+    auto black    = StyleValue::custom(core::colors::black);
+    auto white    = StyleValue::custom(core::colors::white);
+    auto blue     = StyleValue::custom(core::Color(0.20f, 0.56f, 1.0f));
+    auto transp   = StyleValue::custom(core::colors::transparent);
 
-    table->insert(background_color, cTransp, false, &style::parseColor);
-    table->insert(margin_top, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(margin_right, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(margin_bottom, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(margin_left, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(padding_top, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(padding_right, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(padding_bottom, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(padding_left, lpZero, false, &LengthOrPercentage::parse);
-    table->insert(border_width, lZero, false, &Length::parse);
-    table->insert(border_color, cBlack, false, &style::parseColor);
-    table->insert(border_top_left_radius, brZero, false, &BorderRadius::parse);
-    table->insert(border_top_right_radius, brZero, false, &BorderRadius::parse);
-    table->insert(border_bottom_right_radius, brZero, false, &BorderRadius::parse);
-    table->insert(border_bottom_left_radius, brZero, false, &BorderRadius::parse);
+    auto zero_l   = StyleValue::custom(Length());
+    auto zero_lp  = StyleValue::custom(LengthOrPercentage());
+    auto zero_br  = StyleValue::custom(BorderRadius());
+    auto auto_la  = StyleValue::custom(LengthOrAuto());
+    auto twelve_l = StyleValue::custom(Length(12.0_dp));
 
-    //table->insert(pixel_hinting, iNormal, true, &parsePixelHinting);
-    table->insert(font_size, lTwelve, true, &Length::parse);
-    table->insert(font_ascent, laAuto, true, &LengthOrAuto::parse);
-    table->insert(font_descent, laAuto, true, &LengthOrAuto::parse);
-    table->insert(text_color, cBlack, true, &style::parseColor);
-    table->insert(text_selection_color, cWhite, true, &style::parseColor);
-    table->insert(text_selection_background_color, cBlue, true, &style::parseColor);
-    //table->insert(text_horizontal_align, iLeft, true, &parseTextHorizontalAlign);
-    //table->insert(text_vertical_align, iTop, true, &parseTextVerticalAlign);
-    table->insert(caret_color, cBlack, true, &style::parseColor);
+    auto normal_i = StyleValue::identifier(normal);
+    auto left_i   = StyleValue::identifier(left);
+    auto top_i    = StyleValue::identifier(top);
 
-    // clang-format on
+    table->insert(background_color,           transp,  false, &style::parseColor);
+    table->insert(margin_top,                 zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(margin_right,               zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(margin_bottom,              zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(margin_left,                zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(padding_top,                zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(padding_right,              zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(padding_bottom,             zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(padding_left,               zero_lp, false, &LengthOrPercentage::parse);
+    table->insert(border_width,               zero_l,  false, &Length::parse);
+    table->insert(border_color,               black,   false, &style::parseColor);
+    table->insert(border_top_left_radius,     zero_br, false, &BorderRadius::parse);
+    table->insert(border_top_right_radius,    zero_br, false, &BorderRadius::parse);
+    table->insert(border_bottom_right_radius, zero_br, false, &BorderRadius::parse);
+    table->insert(border_bottom_left_radius,  zero_br, false, &BorderRadius::parse);
 
-    SuperClass::doPopulateStyleSpecTable(table);
+    table->insert(pixel_hinting,                   normal_i, true, &parsePixelHinting);
+    table->insert(font_size,                       twelve_l, true, &Length::parse);
+    table->insert(font_ascent,                     auto_la,  true, &LengthOrAuto::parse);
+    table->insert(font_descent,                    auto_la,  true, &LengthOrAuto::parse);
+    table->insert(text_color,                      black,    true, &style::parseColor);
+    table->insert(text_selection_color,            white,    true, &style::parseColor);
+    table->insert(text_selection_background_color, blue,     true, &style::parseColor);
+    table->insert(text_horizontal_align,           left_i,   true, &parseTextHorizontalAlign);
+    table->insert(text_vertical_align,             top_i,    true, &parseTextVerticalAlign);
+    table->insert(caret_color,                     black,    true, &style::parseColor);
+
+    SuperClass::populateStyleSpecTable(table);
 }
+
+// clang-format on
 
 namespace {
 
@@ -740,7 +743,5 @@ void RichText::insertText_(std::string_view textToInsert) {
     // Clear selection
     selectionStart_ = selectionEnd_;
 }
-
-namespace detail {} // namespace detail
 
 } // namespace vgc::graphics

--- a/libs/vgc/graphics/richtext.h
+++ b/libs/vgc/graphics/richtext.h
@@ -159,9 +159,15 @@ public:
         return RichTextSpanListView(children_);
     }
 
-    const style::StyleSheet* defaultStyleSheet() const override;
+    // Implementation of StylableObject interface
+    static void doPopulateStyleSpecTable(style::SpecTable* table);
+    void populateStyleSpecTable(style::SpecTable* table) override {
+        doPopulateStyleSpecTable(table);
+    }
 
-    static const style::StylePropertySpecTable* stylePropertySpecs();
+    // deprecated
+    const style::StyleSheet* defaultStyleSheet() const override;
+    static const style::SpecTable* stylePropertySpecs();
 
 private:
     RichTextSpan* parent_;

--- a/libs/vgc/graphics/richtext.h
+++ b/libs/vgc/graphics/richtext.h
@@ -28,18 +28,6 @@
 
 namespace vgc::graphics {
 
-VGC_GRAPHICS_API
-style::StyleValue
-parsePixelHinting(style::StyleTokenIterator begin, style::StyleTokenIterator end);
-
-VGC_GRAPHICS_API
-style::StyleValue
-parseTextHorizontalAlign(style::StyleTokenIterator begin, style::StyleTokenIterator end);
-
-VGC_GRAPHICS_API
-style::StyleValue
-parseTextVerticalAlign(style::StyleTokenIterator begin, style::StyleTokenIterator end);
-
 VGC_DECLARE_OBJECT(RichText);
 VGC_DECLARE_OBJECT(RichTextSpan);
 
@@ -160,14 +148,10 @@ public:
     }
 
     // Implementation of StylableObject interface
-    static void doPopulateStyleSpecTable(style::SpecTable* table);
-    void populateStyleSpecTable(style::SpecTable* table) override {
-        doPopulateStyleSpecTable(table);
+    static void populateStyleSpecTable(style::SpecTable* table);
+    void populateStyleSpecTableVirtual(style::SpecTable* table) override {
+        populateStyleSpecTable(table);
     }
-
-    // deprecated
-    const style::StyleSheet* defaultStyleSheet() const override;
-    static const style::SpecTable* stylePropertySpecs();
 
 private:
     RichTextSpan* parent_;

--- a/libs/vgc/style/style.cpp
+++ b/libs/vgc/style/style.cpp
@@ -17,6 +17,7 @@
 #include <vgc/style/style.h>
 
 #include <vgc/core/colors.h>
+#include <vgc/style/logcategories.h>
 #include <vgc/style/strings.h>
 #include <vgc/style/stylableobject.h>
 
@@ -27,6 +28,106 @@ VGC_DEFINE_ENUM(
     (ClassSelector, "Class Selector"),
     (DescendantCombinator, "Descendant Combinator"),
     (ChildCombinator, "Child Combinator"))
+
+namespace {
+
+class UnparsedValue {
+public:
+    UnparsedValue(StyleTokenIterator begin, StyleTokenIterator end)
+        : rawString_(begin->begin, end->begin)
+        , tokens_(begin, end) {
+
+        remapPointers_();
+    }
+
+    UnparsedValue(const UnparsedValue& other)
+        : rawString_(other.rawString_)
+        , tokens_(other.tokens_) {
+
+        remapPointers_();
+    }
+
+    UnparsedValue(UnparsedValue&& other)
+        : rawString_(std::move(other.rawString_))
+        , tokens_(std::move(other.tokens_)) {
+
+        remapPointers_();
+    }
+
+    UnparsedValue& operator=(const UnparsedValue& other) {
+        if (this != &other) {
+            rawString_ = other.rawString_;
+            tokens_ = other.tokens_;
+            remapPointers_();
+        }
+        return *this;
+    }
+
+    UnparsedValue& operator=(UnparsedValue&& other) {
+        if (this != &other) {
+            rawString_ = std::move(other.rawString_);
+            tokens_ = std::move(other.tokens_);
+            remapPointers_();
+        }
+        return *this;
+    }
+
+    const std::string& rawString() const {
+        return rawString_;
+    }
+
+    const StyleTokenArray& tokens() const {
+        return tokens_;
+    }
+
+private:
+    std::string rawString_;
+    StyleTokenArray tokens_;
+
+    // Ensures that the `const char*` pointers in `tokens_` points to the
+    // copied data in `rawString_`.
+    //
+    // Note that remapping is still needed even for the move constructor and
+    // move assignment operator, due to small-string optimization: a moved
+    // string may still have its data at a new location.
+    //
+    void remapPointers_() {
+        if (!tokens_.isEmpty()) {
+            const char* oldBegin = tokens_.begin()->begin;
+            const char* newBegin = rawString_.data();
+            auto offset = std::distance(newBegin, oldBegin);
+            if (offset != 0) {
+                for (StyleToken& token : tokens_) {
+                    token.begin += offset;
+                    token.end += offset;
+                }
+            }
+        }
+    }
+};
+
+} // namespace
+
+StyleValue StyleValue::unparsed(StyleTokenIterator begin, StyleTokenIterator end) {
+    return StyleValue(StyleValueType::Unparsed, UnparsedValue(begin, end));
+}
+
+void StyleValue::parse_(const StylePropertySpec* spec) {
+    const UnparsedValue* v = std::any_cast<UnparsedValue>(&value_);
+    StylePropertyParser parser = spec ? spec->parser() : &parseStyleDefault;
+    StyleValue parsed = parser(v->tokens().begin(), v->tokens().end());
+    if (parsed.type() == StyleValueType::Invalid) {
+        VGC_WARNING(
+            LogVgcStyle,
+            "Failed to parse attribute '{}' defined as '{}'.",
+            spec->name(),
+            v->rawString());
+        *this = StyleValue::none();
+    }
+    else {
+        value_ = parsed;
+    }
+}
 
 StyleValue parseStyleDefault(StyleTokenIterator begin, StyleTokenIterator end) {
     if (end == begin + 1) {
@@ -47,18 +148,14 @@ namespace detail {
 // befriend this class, instead of befriending all the free functions.
 //
 class StyleParser {
-    StylePropertySpecTablePtr specs_;
     bool topLevel_;
-    StyleParser(const StylePropertySpecTablePtr& specs, bool topLevel)
-        : specs_(specs)
-        , topLevel_(topLevel) {
+    StyleParser(bool topLevel)
+        : topLevel_(topLevel) {
     }
 
 public:
     // https://www.w3.org/TR/css-syntax-3/#parse-stylesheet
-    static StyleSheetPtr parseStyleSheet(
-        const StylePropertySpecTablePtr& specs,
-        std::string_view styleString) {
+    static StyleSheetPtr parseStyleSheet(std::string_view styleString) {
 
         // Tokenize
         std::string decoded = decodeStyleString(styleString);
@@ -66,13 +163,12 @@ public:
 
         // Parse
         bool topLevel = true;
-        StyleParser parser(specs, topLevel);
+        StyleParser parser(topLevel);
         StyleTokenIterator it = tokens.begin();
         core::Array<StyleRuleSetPtr> rules = parser.consumeRuleList_(it, tokens.end());
 
         // Create StyleSheet
         StyleSheetPtr styleSheet = StyleSheet::create();
-        styleSheet->propertySpecs_ = specs;
         for (const StyleRuleSetPtr& rule : rules) {
             styleSheet->appendChildObject_(rule.get());
             styleSheet->ruleSets_.append(rule.get());
@@ -305,14 +401,17 @@ private:
     // May return a null pointer in case of parse errors.
     StyleDeclarationPtr
     consumeDeclaration_(StyleTokenIterator& it, StyleTokenIterator end) {
+
         StyleDeclarationPtr declaration = StyleDeclaration::create();
         declaration->property_ = core::StringId(it->codePointsValue);
         declaration->value_ = StyleValue::invalid();
         ++it;
+
         // Consume whitespaces
         while (it != end && it->type == StyleTokenType::Whitespace) {
             ++it;
         }
+
         // Ensure first non-whitespace token is a Colon
         if (it == end || it->type != StyleTokenType::Colon) {
             // Parse error: return nothing
@@ -321,16 +420,19 @@ private:
         else {
             ++it;
         }
+
         // Consume whitespaces
         while (it != end && it->type == StyleTokenType::Whitespace) {
             ++it;
         }
+
         // Consume value components
         StyleTokenIterator valueBegin = it;
         while (it != end) {
             consumeComponentValue_(it, end);
         }
         StyleTokenIterator valueEnd = it;
+
         // Remove trailing whitespaces from value
         // TODO: also remove "!important" from value and set it as flag, see (5) in:
         //       https://www.w3.org/TR/css-syntax-3/#consume-declaration
@@ -338,17 +440,14 @@ private:
                && (valueEnd - 1)->type == StyleTokenType::Whitespace) {
             --valueEnd;
         }
-        // Parse value
-        // XXX We should probably first check for global keywords like 'inherit' and
-        // only call the custom parser if it's not a global keyword.
-        const StylePropertySpec* spec =
-            specs_ ? specs_->get(declaration->property_) : nullptr;
-        StylePropertyParser parser = spec ? spec->parser() : &parseStyleDefault;
-        declaration->value_ = parser(valueBegin, valueEnd);
-        if (declaration->value_.type() == StyleValueType::Invalid) {
-            // Parse error: return nothing
-            return StyleDeclarationPtr();
-        }
+
+        // Store unparsed value. Parsing is defer until the attribute is
+        // actually queried, that is, until we have an appropriate SpecTable.
+        //
+        // XXX We might still want to check here for global keywords like 'inherit'/etc.
+        //
+        declaration->value_ = StyleValue::unparsed(valueBegin, valueEnd);
+
         return declaration;
     }
 
@@ -526,6 +625,29 @@ private:
 
 } // namespace detail
 
+void SpecTable::insert(
+    core::StringId attributeName,
+    const StyleValue& initialValue,
+    bool isInherited,
+    StylePropertyParser parser) {
+
+    if (get(attributeName)) {
+        VGC_WARNING(
+            LogVgcStyle,
+            "Attempting to insert a property spec for the attribute '{}', which is "
+            "already registered. Aborted.",
+            attributeName);
+        return;
+    }
+    StylePropertySpec spec(attributeName, initialValue, isInherited, parser);
+    map_.insert({attributeName, spec});
+}
+
+bool SpecTable::setRegistered(core::StringId className) {
+    auto res = registeredClassNames_.insert(className);
+    return res.second;
+}
+
 StyleSheet::StyleSheet()
     : Object() {
 }
@@ -534,9 +656,8 @@ StyleSheetPtr StyleSheet::create() {
     return StyleSheetPtr(new StyleSheet());
 }
 
-StyleSheetPtr
-StyleSheet::create(const StylePropertySpecTablePtr& specs, std::string_view s) {
-    return detail::StyleParser::parseStyleSheet(specs, s);
+StyleSheetPtr StyleSheet::create(std::string_view s) {
+    return detail::StyleParser::parseStyleSheet(s);
 }
 
 StyleRuleSet::StyleRuleSet()

--- a/libs/vgc/style/style.h
+++ b/libs/vgc/style/style.h
@@ -70,6 +70,9 @@ enum class StyleValueType : Int8 {
     Custom      ///< The value is a custom type
 };
 
+VGC_STYLE_API
+VGC_DECLARE_ENUM(StyleValueType)
+
 /// \enum vgc::style::StyleValue
 /// \brief Stores the value of a style attribute.
 ///
@@ -102,8 +105,8 @@ public:
         return StyleValue(StyleValueType::None);
     }
 
-    /// Creates a StyleValue of type Unparsed. This is a temporary value
-    /// while waiting for the parse(StylableObject*) for
+    /// Creates a StyleValue of type Unparsed. This allows to defer parsing the
+    /// value until the `SpecTable` of the tree is properly populated.
     ///
     static StyleValue unparsed(StyleTokenIterator begin, StyleTokenIterator end);
 

--- a/libs/vgc/style/token.h
+++ b/libs/vgc/style/token.h
@@ -264,7 +264,12 @@ using StyleTokenArray = core::Array<StyleToken>;
 ///
 /// \sa StyleTokenArray, StyleToken
 ///
-using StyleTokenIterator = core::Array<StyleToken>::iterator;
+using StyleTokenIterator = core::Array<StyleToken>::const_iterator;
+
+struct TokenizedFragment {
+    std::string string;
+    StyleTokenArray tokens;
+};
 
 // Decodes the input style string. This is a pre-processing step that must be
 // run before calling tokenizeStyleString(). It cleans up any invalid

--- a/libs/vgc/style/token.h
+++ b/libs/vgc/style/token.h
@@ -266,11 +266,6 @@ using StyleTokenArray = core::Array<StyleToken>;
 ///
 using StyleTokenIterator = core::Array<StyleToken>::const_iterator;
 
-struct TokenizedFragment {
-    std::string string;
-    StyleTokenArray tokens;
-};
-
 // Decodes the input style string. This is a pre-processing step that must be
 // run before calling tokenizeStyleString(). It cleans up any invalid
 // characters.

--- a/libs/vgc/ui/widget.cpp
+++ b/libs/vgc/ui/widget.cpp
@@ -1353,84 +1353,42 @@ StyleValue parseStyleNumber(StyleTokenIterator begin, StyleTokenIterator end) {
     }
 }
 
-// clang-format off
-
-style::SpecTablePtr createGlobalSpecTable_() {
-
-    using namespace strings;
-
-    auto autosize    = StyleValue::custom(style::LengthOrPercentageOrAuto());
-    auto zerolp      = StyleValue::custom(style::LengthOrPercentage());
-    auto one         = StyleValue::number(1.0f);
-
-    // Start with the same specs as RichTextSpan
-    auto table = std::make_shared<style::SpecTable>();
-    *table.get() = *graphics::RichTextSpan::stylePropertySpecs();
-
-    // Insert additional specs
-    // Reference: https://www.w3.org/TR/CSS21/propidx.html
-
-    table->insert(preferred_height,     autosize, false, &style::LengthOrPercentageOrAuto::parse);
-    table->insert(preferred_width,      autosize, false, &style::LengthOrPercentageOrAuto::parse);
-    table->insert(column_gap,           zerolp,   false, &style::LengthOrPercentage::parse);
-    table->insert(row_gap,              zerolp,   false, &style::LengthOrPercentage::parse);
-    table->insert(grid_auto_columns,    autosize, false, &style::LengthOrPercentageOrAuto::parse);
-    table->insert(grid_auto_rows,       autosize, false, &style::LengthOrPercentageOrAuto::parse);
-    table->insert(horizontal_stretch,   one,      false, &parseStyleNumber);
-    table->insert(horizontal_shrink,    one,      false, &parseStyleNumber);
-    table->insert(vertical_stretch,     one,      false, &parseStyleNumber);
-    table->insert(vertical_shrink,      one,      false, &parseStyleNumber);
-
-    return table;
-}
-
-// clang-format on
-
-const style::SpecTablePtr& stylePropertySpecTable_() {
-    static style::SpecTablePtr table = createGlobalSpecTable_();
-    return table;
-}
-
-style::StyleSheetPtr createGlobalStyleSheet_() {
-    std::string path = core::resourcePath("ui/stylesheets/default.vgcss");
-    std::string s = core::readFile(path);
-    return style::StyleSheet::create(s);
-}
-
 } // namespace
 
-void Widget::doPopulateStyleSpecTable(style::SpecTable* table) {
+// clang-format off
+
+void Widget::populateStyleSpecTable(style::SpecTable* table) {
 
     if (!table->setRegistered(staticClassName())) {
         return;
     }
 
-    // TODO: RichTextSpan::doPopulate...
+    graphics::RichTextSpan::populateStyleSpecTable(table);
 
     using namespace strings;
-    using LP = style::LengthOrPercentage;
-    using LPA = style::LengthOrPercentageOrAuto;
+    using style::LengthOrPercentage;
+    using style::LengthOrPercentageOrAuto;
 
-    auto auto_lpa = StyleValue::custom(LPA());
-    auto zero_lp = StyleValue::custom(LP());
-    auto one_n = StyleValue::number(1.0f);
+    auto auto_lpa = StyleValue::custom(LengthOrPercentageOrAuto());
+    auto zero_lp =  StyleValue::custom(LengthOrPercentage());
+    auto one_n =    StyleValue::number(1.0f);
 
     // Reference: https://www.w3.org/TR/CSS21/propidx.html
-    // clang-format off
-    table->insert(preferred_height,   auto_lpa, false, &LPA::parse);
-    table->insert(preferred_width,    auto_lpa, false, &LPA::parse);
-    table->insert(column_gap,         zero_lp,  false, &LP::parse);
-    table->insert(row_gap,            zero_lp,  false, &LP::parse);
-    table->insert(grid_auto_columns,  auto_lpa, false, &LPA::parse);
-    table->insert(grid_auto_rows,     auto_lpa, false, &LPA::parse);
+    table->insert(preferred_height,   auto_lpa, false, &LengthOrPercentageOrAuto::parse);
+    table->insert(preferred_width,    auto_lpa, false, &LengthOrPercentageOrAuto::parse);
+    table->insert(column_gap,         zero_lp,  false, &LengthOrPercentage::parse);
+    table->insert(row_gap,            zero_lp,  false, &LengthOrPercentage::parse);
+    table->insert(grid_auto_columns,  auto_lpa, false, &LengthOrPercentageOrAuto::parse);
+    table->insert(grid_auto_rows,     auto_lpa, false, &LengthOrPercentageOrAuto::parse);
     table->insert(horizontal_stretch, one_n,    false, &parseStyleNumber);
     table->insert(horizontal_shrink,  one_n,    false, &parseStyleNumber);
     table->insert(vertical_stretch,   one_n,    false, &parseStyleNumber);
     table->insert(vertical_shrink,    one_n,    false, &parseStyleNumber);
-    // clang-format on
 
-    SuperClass::doPopulateStyleSpecTable(table);
+    SuperClass::populateStyleSpecTable(table);
 }
+
+// clang-format on
 
 void Widget::onChildRemoved(Object* child) {
     if (child == children_) {

--- a/libs/vgc/ui/widget.h
+++ b/libs/vgc/ui/widget.h
@@ -1140,9 +1140,9 @@ public:
     }
 
     // Implementation of StylableObject interface
-    static void doPopulateStyleSpecTable(style::SpecTable* table);
-    void populateStyleSpecTable(style::SpecTable* table) override {
-        doPopulateStyleSpecTable(table);
+    static void populateStyleSpecTable(style::SpecTable* table);
+    void populateStyleSpecTableVirtual(style::SpecTable* table) override {
+        populateStyleSpecTable(table);
     }
 
 protected:

--- a/libs/vgc/ui/widget.h
+++ b/libs/vgc/ui/widget.h
@@ -1139,8 +1139,11 @@ public:
         return action.get();
     }
 
-    // Implements StylableObject interface
-    const style::StyleSheet* defaultStyleSheet() const override;
+    // Implementation of StylableObject interface
+    static void doPopulateStyleSpecTable(style::SpecTable* table);
+    void populateStyleSpecTable(style::SpecTable* table) override {
+        doPopulateStyleSpecTable(table);
+    }
 
 protected:
     // Reimplementation of Object virtual methods.

--- a/libs/vgc/widgets/toolbar.cpp
+++ b/libs/vgc/widgets/toolbar.cpp
@@ -26,6 +26,8 @@
 
 #include <vgc/widgets/toolbar.h>
 
+#include <vgc/core/io.h>
+
 namespace {
 
 int iconWidth = 64;
@@ -45,6 +47,10 @@ Toolbar::Toolbar(QWidget* parent)
     setFocusPolicy(Qt::ClickFocus);
 
     auto colorPalettePtr = ui::ColorPalette::create();
+    std::string path = core::resourcePath("ui/stylesheets/default.vgcss");
+    std::string styleSheet = core::readFile(path);
+    colorPalettePtr->setStyleSheet(styleSheet);
+
     colorPalette_ = colorPalettePtr.get();
     colorPaletteq_ = new UiWidget(colorPalettePtr, this);
     // Note: it would be nice to std::move() the shared ptr instead of the


### PR DESCRIPTION
#481 

Before this change, we were storing a `SpecTable` per `StyleSheet`: this made sense, because in order to parse the stylesheet, it is in theory required to know how to parse the property values.

Unfortunately, this made defining the specifications convoluted, because often, it is the widgets that would like to advertise property specifications, and widgets are typically added to the tree after stylesheets are created. Also, because different stylesheets may have different `SpecTable`, this meant that when querying a property value, we had to look for potentially several `SpecTable`s to find where the property is specified, so that we know if the property is inherited or not.

In this PR, we change the design so that now, we store one `SpecTable` per widget tree, instead of one `SpecTable` per style sheet. During initial parsing of the stylesheet, the property values are kept as "unparsed". Parsing is deferred until a widget style is actually updated. Each widget can populate the per-tree table with custom properties, which is done automatically by calling a function `populateStyleSpecTable()` that can be re-implemented in Widget subclasses.
