### PR TITLE
Properly support High-DPI scaling on Windows, macOS, and Linux (#953)

### DIFF
--- a/apps/uitest/main.cpp
+++ b/apps/uitest/main.cpp
@@ -323,6 +323,11 @@ void createLineEdits(ui::Widget* parent) {
 
 int main(int argc, char* argv[]) {
 
+    qDebug() << QGuiApplication::testAttribute(Qt::AA_EnableHighDpiScaling);
+    qDebug() << QGuiApplication::testAttribute(Qt::AA_DisableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+    QGuiApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
+
     using vgc::Int;
     using vgc::UInt32;
 

--- a/apps/uitest/main.cpp
+++ b/apps/uitest/main.cpp
@@ -323,11 +323,6 @@ void createLineEdits(ui::Widget* parent) {
 
 int main(int argc, char* argv[]) {
 
-    qDebug() << QGuiApplication::testAttribute(Qt::AA_EnableHighDpiScaling);
-    qDebug() << QGuiApplication::testAttribute(Qt::AA_DisableHighDpiScaling);
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
-    QGuiApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
-
     using vgc::Int;
     using vgc::UInt32;
 
@@ -337,6 +332,7 @@ int main(int argc, char* argv[]) {
     QGuiApplication::setAttribute(Qt::AA_SynthesizeMouseForUnhandledTabletEvents, false);
 
     // Various initializations
+    QGuiApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
     QGuiApplication application(argc, argv);
     setBasePath();
 

--- a/libs/vgc/style/stylableobject.cpp
+++ b/libs/vgc/style/stylableobject.cpp
@@ -127,6 +127,11 @@ void StylableObject::populateStyleSpecTable(SpecTable*) {
     // nothing
 }
 
+void StylableObject::setStyleMetrics(const Metrics& metrics) {
+    styleMetrics_ = metrics;
+    updateStyle_();
+};
+
 void StylableObject::updateStyle_() {
     // In this function, we precompute which rule sets match this node and
     // precompute all "cascaded values". Note that "computed values" are
@@ -141,6 +146,8 @@ void StylableObject::updateStyle_() {
     // Clear previous data
     styleCachedData_.clear();
 
+    StylableObject* parent = parentStylableObject();
+
     // Ensure that we use the same spec table as our parent,
     // and that the object is properly registered in the spec table.
     //
@@ -149,12 +156,16 @@ void StylableObject::updateStyle_() {
     // object is fully constructed, and therefore the virtuall call to
     // populateStyleSpecTable() is properly dispatched to the subclass.
     //
-    if (parentStylableObject()
-        && parentStylableObject()->styleSpecTable() != styleSpecTable()) {
-
+    if (parent && parent->styleSpecTable() != styleSpecTable()) {
         styleSpecTable_ = parentStylableObject()->styleSpecTable_;
     }
     populateStyleSpecTableVirtual(styleSpecTable_.get());
+
+    // Update style metrics
+    if (parent) {
+        styleMetrics_ = parent->styleMetrics();
+        // Note: don't call setStyleMetrics() to avoid recursion
+    }
 
     // Get all non-null stylesheets from this node to the root nodes
     for (StylableObject* node = this; //

--- a/libs/vgc/style/stylableobject.h
+++ b/libs/vgc/style/stylableobject.h
@@ -252,9 +252,7 @@ public:
 
     /// Sets the style metrics of this stylable object.
     ///
-    void setStyleMetrics(const Metrics& metrics) {
-        styleMetrics_ = metrics;
-    };
+    void setStyleMetrics(const Metrics& metrics);
 
     /// Returns the `SpecTable` of this stylable object.
     ///

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -388,8 +388,8 @@ void Window::focusOutEvent(QFocusEvent* event) {
 void Window::resizeEvent(QResizeEvent* event) {
 
     // Remember old size
-    int oldWidth = width_;
-    int oldHeight = height_;
+    [[maybe_unused]] int oldWidth = width_;
+    [[maybe_unused]] int oldHeight = height_;
 
     // Get new unscaled size
     QSize size = event->size();

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -21,6 +21,8 @@
 #include <QMouseEvent>
 #include <QOpenGLFunctions>
 
+#include <QScreen>
+
 #include <vgc/core/os.h>
 #include <vgc/core/paths.h>
 #include <vgc/geometry/camera2d.h>
@@ -377,6 +379,14 @@ void Window::focusOutEvent(QFocusEvent* event) {
 }
 
 void Window::resizeEvent(QResizeEvent* event) {
+    // Here, we get the size in virtual pixels.
+    qDebug() << "dpi ratio = " << devicePixelRatio();
+    qDebug() << "event size = " << event->size();
+    qDebug() << "size = " << size();
+    qDebug() << "screen physical size = " << screen()->physicalSize();
+    qDebug() << "screen size = " << screen()->size();
+    qDebug() << "screen dpi ratio = " << screen()->devicePixelRatio();
+    qDebug() << "logical dots per inch = " << screen()->logicalDotsPerInch();
     QSize size = event->size();
     [[maybe_unused]] int w = size.width();
     [[maybe_unused]] int h = size.height();

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -185,7 +185,7 @@ Widget* prepareMouseEvent(Widget* root, MouseEvent* event, const Window* window)
 
     // Apply device pixel ratio
     geometry::Vec2f position = event->position();
-    position *= static_cast<float>(window->screen()->devicePixelRatio());
+    position *= static_cast<float>(window->devicePixelRatio());
     event->setPosition(position);
 
     // Handle mouse captor

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -379,14 +379,9 @@ void Window::focusOutEvent(QFocusEvent* event) {
 }
 
 void Window::resizeEvent(QResizeEvent* event) {
-    // Here, we get the size in virtual pixels.
-    qDebug() << "dpi ratio = " << devicePixelRatio();
-    qDebug() << "event size = " << event->size();
-    qDebug() << "size = " << size();
-    qDebug() << "screen physical size = " << screen()->physicalSize();
-    qDebug() << "screen size = " << screen()->size();
-    qDebug() << "screen dpi ratio = " << screen()->devicePixelRatio();
-    qDebug() << "logical dots per inch = " << screen()->logicalDotsPerInch();
+
+    updateScreenScaleRatio_();
+
     QSize size = event->size();
     [[maybe_unused]] int w = size.width();
     [[maybe_unused]] int h = size.height();
@@ -781,6 +776,25 @@ void Window::exposeEvent(QExposeEvent*) {
                 VGC_DEBUG(LogVgcUi, "paint from exposeEvent");
             }
             paint(true);
+        }
+    }
+}
+
+void Window::updateScreenScaleRatio_() {
+
+#ifdef VGC_CORE_OS_MACOS
+    float unscaledDpi = 72.0f;
+#else
+    float unscaledDpi = 96.0f;
+#endif
+    float newScreenScaleRatio = static_cast<float>(screen()->logicalDotsPerInch())
+                                * static_cast<float>(screen()->devicePixelRatio())
+                                / unscaledDpi;
+    if (screenScaleRatio_ != newScreenScaleRatio) {
+        if (widget_) {
+            screenScaleRatio_ = newScreenScaleRatio;
+            style::Metrics metrics(screenScaleRatio_);
+            widget_->setStyleMetrics(metrics);
         }
     }
 }

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -779,7 +779,7 @@ bool Window::nativeEvent(
 }
 #endif
 
-void Window::exposeEvent(QExposeEvent* event) {
+void Window::exposeEvent(QExposeEvent*) {
     if (isExposed()) {
         if (activeSizemove_) {
             // On Windows, Expose events happen on both WM_PAINT and WM_ERASEBKGND

--- a/libs/vgc/ui/window.h
+++ b/libs/vgc/ui/window.h
@@ -125,8 +125,9 @@ private:
     float logicalDotsPerInch_ = detail::baseLogicalDpi;
     float devicePixelRatio_ = 1.0;
     float screenScaleRatio_ = 1.0;
-    void updateScreenScaleRatio_();
+    bool updateScreenScaleRatio_();
     void updateScreenScaleRatioAndWindowSize_(int unscaledWidth, int unscaledHeight);
+    void updateViewportSize_();
 
     geometry::Mat4f proj_;
     core::Color clearColor_;

--- a/libs/vgc/ui/window.h
+++ b/libs/vgc/ui/window.h
@@ -111,6 +111,9 @@ private:
     bool deferredResize_ = false;
     bool entered_ = false;
 
+    float screenScaleRatio_ = 1.0;
+    void updateScreenScaleRatio_();
+
     geometry::Mat4f proj_;
     core::Color clearColor_;
 

--- a/libs/vgc/ui/window.h
+++ b/libs/vgc/ui/window.h
@@ -20,6 +20,7 @@
 #include <QWindow>
 
 #include <vgc/core/array.h>
+#include <vgc/core/os.h>
 #include <vgc/core/stopwatch.h>
 #include <vgc/graphics/engine.h>
 #include <vgc/ui/widget.h>
@@ -28,6 +29,16 @@ class QInputMethodEvent;
 class QInputMethodQueryEvent;
 
 namespace vgc::ui {
+
+namespace detail {
+
+#ifdef VGC_CORE_OS_MACOS
+constexpr float baseLogicalDpi = 72.0f;
+#else
+constexpr float baseLogicalDpi = 96.0f;
+#endif
+
+} // namespace detail
 
 VGC_DECLARE_OBJECT(Window);
 
@@ -56,7 +67,7 @@ public:
     }
 
 protected:
-#if defined(VGC_CORE_COMPILER_MSVC)
+#if defined(VGC_CORE_OS_WINDOWS)
     HWND hwnd_ = {};
     static LRESULT WINAPI WndProc(HWND, UINT, WPARAM, LPARAM);
 #endif
@@ -111,8 +122,11 @@ private:
     bool deferredResize_ = false;
     bool entered_ = false;
 
+    float logicalDotsPerInch_ = detail::baseLogicalDpi;
+    float devicePixelRatio_ = 1.0;
     float screenScaleRatio_ = 1.0;
     void updateScreenScaleRatio_();
+    void updateScreenScaleRatioAndWindowSize_(int unscaledWidth, int unscaledHeight);
 
     geometry::Mat4f proj_;
     core::Color clearColor_;


### PR DESCRIPTION
#953

With this PR, the user interface is properly scaled based on system preferences:
- On Windows, the scale factor that can be controlled in Settings > System > Display
- On macOS, the scale factor that can be controlled in System Settings > Displays
- On Linux (tested on Kubuntu 22.04 / KDE / X11), the scale factor in Settings > Display Configuration > Global scale

On Windows, a multi-monitor setting with a different scale per-monitor has been tested: the scaling is updated appropriately when dragging the window from one screen to the other. Also, the app is properly updated when modifying the scale in the system settings, no need to restart the app.

On X11, there only seems to be a global scale (i.e., no per-monitor scale possible), unless a per-monitor scale is faked by providing a different resolution via xrandr, but in this case there's nothing we can control within our app. The app must be restarted for the scale to take effect.

On macOS, more tests still need to be done.