### PR TITLE
Fix top-left corner position flickering when resizing ui::Window on Linux and macOS (#980)

### DIFF
--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -520,6 +520,7 @@ void Window::resizeEvent(QResizeEvent* event) {
     height_ = oldHeight;
 #else
     deferredResize_ = true;
+    updateViewportSize_();
     requestUpdate();
 #endif
 }


### PR DESCRIPTION
#980