### PR TITLE
Fix missing padding in VGC Illustration's color palette (#919, #1014)

### DIFF
--- a/libs/vgc/ui/stylesheets/default.vgcss
+++ b/libs/vgc/ui/stylesheets/default.vgcss
@@ -23,7 +23,8 @@
     column-gap: 10dp;
 }
 
-.Panel.with-padding {
+.Panel.with-padding,
+.root.Flex {
     padding-top: 10dp;
     padding-right: 10dp;
     padding-bottom: 10dp;


### PR DESCRIPTION
#919, #1014

The PR #1014 removed more padding than intended. This fixes the problem.