### PR TITLE
Remove ability to disable scissor test in Engine, as in Vulkan, D3D12, Metal (#789)

### DIFF
--- a/libs/vgc/graphics/d3d11/d3d11engine.cpp
+++ b/libs/vgc/graphics/d3d11/d3d11engine.cpp
@@ -1698,7 +1698,7 @@ void D3d11Engine::initRasterizerState_(RasterizerState* state) {
     //desc.DepthBiasClamp;
     //desc.SlopeScaledDepthBias;
     desc.DepthClipEnable = state->isDepthClippingEnabled();
-    desc.ScissorEnable = state->isScissoringEnabled();
+    desc.ScissorEnable = true; // scissor test always enabled in graphics::Engine
     desc.MultisampleEnable = state->isMultisamplingEnabled();
     desc.AntialiasedLineEnable = state->isLineAntialiasingEnabled();
     device_->CreateRasterizerState(

--- a/libs/vgc/graphics/engine.cpp
+++ b/libs/vgc/graphics/engine.cpp
@@ -762,11 +762,13 @@ bool Engine::beginFrame(const SwapChainPtr& swapChain, FrameKind kind) {
     frameStartTime_ = std::chrono::steady_clock::now();
     dirtyBuiltinConstantBuffer_ = true;
     if (kind == FrameKind::QWidget) {
+        // XXX Maybe we'd want to move this to preBeginFrame_, but we do not
+        // have access to dirtyPipelineParameters_ there.
         dirtyPipelineParameters_ |= PipelineParameter::All;
         dirtyPipelineParameters_.unset(PipelineParameter::Framebuffer);
         dirtyPipelineParameters_.unset(PipelineParameter::Viewport);
-        setStateDirty_();
     }
+    preBeginFrame_(swapChain.get(), kind);
 
     // XXX check every stack has size one !
 
@@ -882,6 +884,9 @@ void Engine::clear(const core::Color& color) {
     syncState_();
     queueLambdaCommandWithParameters_<core::Color>(
         "clear", [](Engine* engine, const core::Color& c) { engine->clear_(c); }, color);
+}
+
+void Engine::preBeginFrame_(SwapChain*, FrameKind) {
 }
 
 void Engine::init_() {

--- a/libs/vgc/graphics/engine.h
+++ b/libs/vgc/graphics/engine.h
@@ -467,6 +467,8 @@ protected:
 
     virtual void onWindowResize_(SwapChain* swapChain, UInt32 width, UInt32 height) = 0;
 
+    virtual void preBeginFrame_(SwapChain* swapChain, FrameKind kind);
+
     virtual bool shouldPresentWaitFromSyncedUserThread_() {
         return false;
     }
@@ -523,8 +525,6 @@ protected:
 
     virtual UInt64
     present_(SwapChain* swapChain, UInt32 syncInterval, PresentFlags flags) = 0;
-
-    virtual void setStateDirty_(){};
 
 protected:
     detail::ResourceRegistry* resourceRegistry_ = nullptr;

--- a/libs/vgc/graphics/rasterizerstate.h
+++ b/libs/vgc/graphics/rasterizerstate.h
@@ -65,10 +65,6 @@ public:
         isDepthClippingEnabled_ = enabled;
     }
 
-    bool isScissoringEnabled() const {
-        return true;
-    }
-
     bool isMultisamplingEnabled() const {
         return isMultisamplingEnabled_;
     }

--- a/libs/vgc/graphics/rasterizerstate.h
+++ b/libs/vgc/graphics/rasterizerstate.h
@@ -66,11 +66,7 @@ public:
     }
 
     bool isScissoringEnabled() const {
-        return isScissoringEnabled_;
-    }
-
-    void setScissoringEnabled(bool enabled) {
-        isScissoringEnabled_ = enabled;
+        return true;
     }
 
     bool isMultisamplingEnabled() const {
@@ -97,7 +93,6 @@ private:
     //float depthBiasClamp_;
     //float slopeScaledDepthBias_;
     bool isDepthClippingEnabled_ = false;
-    bool isScissoringEnabled_ = false;
     bool isMultisamplingEnabled_ = true;
     bool isLineAntialiasingEnabled_ = true;
 };
@@ -127,10 +122,6 @@ public:
 
     bool isDepthClippingEnabled() const {
         return info_.isDepthClippingEnabled();
-    }
-
-    bool isScissoringEnabled() const {
-        return info_.isScissoringEnabled();
     }
 
     bool isMultisamplingEnabled() const {

--- a/libs/vgc/ui/canvas.h
+++ b/libs/vgc/ui/canvas.h
@@ -215,7 +215,6 @@ private:
     std::list<CurveGraphics> removedCurveGraphics_;
     std::map<dom::Element*, CurveGraphicsIterator> curveGraphicsMap_;
     graphics::GeometryViewPtr bgGeometry_;
-    graphics::RasterizerStatePtr bgFillRS_;
 
     struct unwrapped_less {
         template<typename It>

--- a/libs/vgc/ui/detail/qopenglengine.h
+++ b/libs/vgc/ui/detail/qopenglengine.h
@@ -135,6 +135,8 @@ protected:
 
     void onWindowResize_(SwapChain* swapChain, UInt32 width, UInt32 height) override;
 
+    void preBeginFrame_(SwapChain* swapChain, FrameKind kind) override;
+
     //--  RENDER THREAD implementation functions --
 
     void initContext_() override;
@@ -185,8 +187,6 @@ protected:
 
     UInt64
     present_(SwapChain* swapChain, UInt32 syncInterval, PresentFlags flags) override;
-
-    void setStateDirty_() override;
 
     void updateViewportAndScissorRect_(GLsizei rtHeight);
 

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -598,6 +598,7 @@ void Window::paint(bool sync) {
     engine_->setRasterizerState(rasterizerState_);
     engine_->setBlendState(blendState_, geometry::Vec4f());
     engine_->setViewport(0, 0, width_, height_);
+    engine_->setScissorRect(rect());
     engine_->clear(clearColor_);
     engine_->setProgram(graphics::BuiltinProgram::Simple);
     engine_->setProjectionMatrix(proj_);

--- a/libs/vgc/ui/window.h
+++ b/libs/vgc/ui/window.h
@@ -45,27 +45,46 @@ VGC_DECLARE_OBJECT(Window);
 /// \class vgc::ui::Window
 /// \brief A window able to contain a vgc::ui::widget.
 ///
+/// Note: for now, `vgc::ui::Window` inherits from `QWindow`, but we may change
+/// this in the future, so clients of `vgc::ui::Window` should avoid calling
+/// methods inherited from `QWindow`.
+///
 class VGC_UI_API Window : public core::Object, public QWindow {
     VGC_OBJECT(Window, core::Object)
 
 protected:
-    /// Constructs a Window containing the given vgc::ui::Widget.
+    /// Constructs a `Window` containing the given `Widget`.
     ///
     Window(const WidgetPtr& widget);
 
-    /// Destructs the Window.
+    /// Destructs the `Window`.
     ///
     void onDestroyed() override;
 
 public:
+    /// Creates a `Window` containing the given `Widget`.
+    ///
     static WindowPtr create(const WidgetPtr& widget);
 
-    /// Returns the contained vgc::ui::Widget
+    /// Returns the contained `Widget`
     ///
     Widget* widget() {
         return widget_.get();
     }
 
+    /// Returns the geometry of this `Window` as a rectangle.
+    ///
+    // TODO: we want this to be equivalent to `Rect2f::fromPositionSize(0, 0,
+    // size())` (see comment in Widget::rect()), but currently `Window::size()`
+    // is a QSize instead of a Vec2f like in Widget.
+    //
+    geometry::Rect2f rect() const {
+        return geometry::Rect2f::fromPositionSize(
+            0, 0, static_cast<float>(width_), static_cast<float>(height_));
+    }
+
+    ///
+    /// Returns
     // ===================== Handle mouse/tablet input ========================
 
 protected:

--- a/libs/vgc/widgets/uiwidget.cpp
+++ b/libs/vgc/widgets/uiwidget.cpp
@@ -335,38 +335,31 @@ void UiWidget::resizeGL(int w, int h) {
     // Set new widget geometry
     widget()->updateGeometry(0, 0, static_cast<float>(w), static_cast<float>(h));
 
-    // Note: paintGL will automatically be called after this
+    // Simulate a window resize
     if (engine_) {
         engine_->onWindowResize(swapChain_, width(), height());
     }
+
+    // Note: paintGL will automatically be called after this
 }
 
 void UiWidget::paintGL() {
+
+    // Note: setViewport() and present() is already done by Qt
+
     if (!engine_) {
         throw core::LogicError("engine_ is null.");
     }
 
-    // setViewport & present is done by Qt
-
-    //engine_->onWindowResize(swapChain_, width(), height());
     engine_->beginFrame(swapChain_, graphics::FrameKind::QWidget);
-
     engine_->setRasterizerState(rasterizerState_);
     engine_->setBlendState(blendState_, geometry::Vec4f());
-
-    // XXX split to beginFrame() and qopenglengine-only beginInlineFrame
-
-    //engine_->clear(core::Color(0.f, 0.f, 0.f));
-
-    // Note: clear calls syncState_, and since it's the first time it is
-    // called, all parameters are dirty, so setScissorRect_() is called
-    // with the top of the scissorRectStackto
-    // engine->
+    // Note: engine_->setViewport(...) would normally be here
+    engine_->setScissorRect(widget()->rect());
     engine_->clear(core::Color(0.251f, 0.259f, 0.267f));
     engine_->setProgram(graphics::BuiltinProgram::Simple);
     engine_->setProjectionMatrix(proj_);
     engine_->setViewMatrix(geometry::Mat4f::identity);
-    engine_->setScissorRect(widget()->rect());
     widget_->paint(engine_.get());
     isRepaintRequested_ = false;
     engine_->endFrame();

--- a/libs/vgc/widgets/uiwidget.cpp
+++ b/libs/vgc/widgets/uiwidget.cpp
@@ -336,6 +336,9 @@ void UiWidget::resizeGL(int w, int h) {
     widget()->updateGeometry(0, 0, static_cast<float>(w), static_cast<float>(h));
 
     // Note: paintGL will automatically be called after this
+    if (engine_) {
+        engine_->onWindowResize(swapChain_, width(), height());
+    }
 }
 
 void UiWidget::paintGL() {
@@ -345,6 +348,7 @@ void UiWidget::paintGL() {
 
     // setViewport & present is done by Qt
 
+    //engine_->onWindowResize(swapChain_, width(), height());
     engine_->beginFrame(swapChain_, graphics::FrameKind::QWidget);
 
     engine_->setRasterizerState(rasterizerState_);
@@ -353,10 +357,16 @@ void UiWidget::paintGL() {
     // XXX split to beginFrame() and qopenglengine-only beginInlineFrame
 
     //engine_->clear(core::Color(0.f, 0.f, 0.f));
+
+    // Note: clear calls syncState_, and since it's the first time it is
+    // called, all parameters are dirty, so setScissorRect_() is called
+    // with the top of the scissorRectStackto
+    // engine->
     engine_->clear(core::Color(0.251f, 0.259f, 0.267f));
     engine_->setProgram(graphics::BuiltinProgram::Simple);
     engine_->setProjectionMatrix(proj_);
     engine_->setViewMatrix(geometry::Mat4f::identity);
+    engine_->setScissorRect(widget()->rect());
     widget_->paint(engine_.get());
     isRepaintRequested_ = false;
     engine_->endFrame();


### PR DESCRIPTION
#789

All modern graphics API don't allow to disable scissor test, see for example: https://github.com/gpuweb/gpuweb/issues/120

So it makes more sense to not allow it either in Engine for easier porting to these API.

Note that this change also fixes a bug that went unnoticed until now because we never used scissor clipping in `UiWidget`: the member variable `QglEngine::viewportRect_` was never initialized, causing incorrect values passed to `glViewport()` and `glScissor()`.