### PR TITLE
Fix color picker Esc key not working (keyboard captor bug) (#994, #986)

### DIFF
--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -321,7 +321,14 @@ std::pair<Widget*, KeyEventPtr> prepareKeyboardEvent(Widget* root, QKeyEvent* ev
 
 void Window::keyPressEvent(QKeyEvent* event) {
     auto [receiver, vgcEvent] = prepareKeyboardEvent(widget_.get(), event);
-    bool isHandled = receiver->keyPress(vgcEvent.get());
+    bool isHandled = false;
+    if (!receiver->isRoot()) {
+        // keyboard captor
+        isHandled = receiver->onKeyPress(vgcEvent.get());
+    }
+    else {
+        isHandled = receiver->keyPress(vgcEvent.get());
+    }
 
     // Handle window-wide shortcuts
     if (!isHandled) {
@@ -344,7 +351,15 @@ void Window::keyPressEvent(QKeyEvent* event) {
 
 void Window::keyReleaseEvent(QKeyEvent* event) {
     auto [receiver, vgcEvent] = prepareKeyboardEvent(widget_.get(), event);
-    event->setAccepted(receiver->keyRelease(vgcEvent.get()));
+    bool isHandled = false;
+    if (!receiver->isRoot()) {
+        // keyboard captor
+        isHandled = receiver->onKeyRelease(vgcEvent.get());
+    }
+    else {
+        isHandled = receiver->keyRelease(vgcEvent.get());
+    }
+    event->setAccepted(isHandled);
 }
 
 void Window::inputMethodEvent(QInputMethodEvent* event) {

--- a/libs/vgc/widgets/uiwidget.cpp
+++ b/libs/vgc/widgets/uiwidget.cpp
@@ -203,12 +203,28 @@ prepareKeyboardEvent(ui::Widget* root, QKeyEvent* event) {
 
 void UiWidget::keyPressEvent(QKeyEvent* event) {
     auto [receiver, vgcEvent] = prepareKeyboardEvent(widget_.get(), event);
-    event->setAccepted(receiver->keyPress(vgcEvent.get()));
+    bool isHandled = false;
+    if (!receiver->isRoot()) {
+        // keyboard captor
+        isHandled = receiver->onKeyPress(vgcEvent.get());
+    }
+    else {
+        isHandled = receiver->keyPress(vgcEvent.get());
+    }
+    event->setAccepted(isHandled);
 }
 
 void UiWidget::keyReleaseEvent(QKeyEvent* event) {
     auto [receiver, vgcEvent] = prepareKeyboardEvent(widget_.get(), event);
-    event->setAccepted(receiver->keyRelease(vgcEvent.get()));
+    bool isHandled = false;
+    if (!receiver->isRoot()) {
+        // keyboard captor
+        isHandled = receiver->onKeyRelease(vgcEvent.get());
+    }
+    else {
+        isHandled = receiver->keyRelease(vgcEvent.get());
+    }
+    event->setAccepted(isHandled);
 }
 
 QVariant UiWidget::inputMethodQuery(Qt::InputMethodQuery) const {


### PR DESCRIPTION
#994

This bug was introduced by #986: forgot to directly call `onKeyPress()` (instead of `keyPress()`) when there is a keyboard captor.