### PR TITLE
Fix color picker not working outside window (mouse captor bug) (#994, #894)

### DIFF
--- a/libs/vgc/ui/window.h
+++ b/libs/vgc/ui/window.h
@@ -104,9 +104,9 @@ protected:
 
 private:
     bool isTabletInUse_() const;
-    bool mouseMoveEvent_(Widget* receiver, MouseEvent* event);
-    bool mousePressEvent_(Widget* receiver, MouseEvent* event);
-    bool mouseReleaseEvent_(Widget* receiver, MouseEvent* event);
+    bool mouseMoveEvent_(MouseEvent* event);
+    bool mousePressEvent_(MouseEvent* event);
+    bool mouseReleaseEvent_(MouseEvent* event);
 
     // ==================== Handle keyboard input =============================
 


### PR DESCRIPTION
#994

This bug was introduced by #894, line 3 of the following code:

```
void Window::mouseMoveEvent(QMouseEvent* event) {
    auto [receiver, vgcEvent] = prepareMouseEvent(widget_.get(), event);
    if (!widget_->isHovered()) {
        if (widget_->geometry().contains(vgcEvent->position())) {
            widget_->setHovered(true);
            entered_ = true;
        }
        else {
            return;
        }
    }
    if (receiver != widget_.get()) {
        // mouse captor
        event->setAccepted(receiver->onMouseMove(vgcEvent.get()));
    }
    else {
        event->setAccepted(receiver->mouseMove(vgcEvent.get()));
    }
}
```

It should have been:

```
    if (!widget_->mouseCaptor() && !widget_->isHovered()) {
```

So the actual change fixing the bug is very small, but this PR also make a cleanup pass: it removes the "receiver" abstraction in `prepareMouseEvent()` and `prepareKeyboardEvent()`, which didn't make much sense anymore if the rest of the code needs anyway to do things differently when there is a captor or not (and the abstraction makes it more likely to forget about the captor case, as seen here).