### PR TITLE
Fix window resize glitch on macOS (#929)

### DIFF
--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -107,7 +107,7 @@ private:
 
 namespace vgc::ui {
 
-static constexpr bool debugEvents = true;
+static constexpr bool debugEvents = false;
 
 //#define VGC_DISABLE_WINDOWS_WINDOW_ARTIFACTS_ON_RESIZE_FIX
 
@@ -885,7 +885,12 @@ void Window::initEngine_() {
         engineCreateInfo.windowSwapChainFormat();
     windowSwapChainFormat.setNumBuffers(2);
     windowSwapChainFormat.setNumSamples(8);
+
+#if defined(VGC_CORE_OS_MACOS)
+    engineCreateInfo.setMultithreadingEnabled(false);
+#else
     engineCreateInfo.setMultithreadingEnabled(true);
+#endif
 
 #if defined(VGC_CORE_OS_WINDOWS) && TRUE
 


### PR DESCRIPTION
#929

There was visual artefacts on macOS when resizing the window, which are fixed by not doing OpenGL rendering in a separate thread.

Indeed, rendering in a separate thread is not supported on macOS (at least with Qt, but it seems to be generally true even without Qt). In particular, `QOpenGLContext::supportsThreadedOpenGL()` returns false, and there is the following comment in the [implementation](https://github.com/qt/qtbase/blob/f192ddad8b862d7ad2d80f28d265ea9f96142a3d/src/plugins/platforms/cocoa/qcocoaintegration.mm#L223):

```
bool QCocoaIntegration::hasCapability(QPlatformIntegration::Capability cap) const
{
    switch (cap) {
#ifndef QT_NO_OPENGL
    case ThreadedOpenGL:
        // AppKit expects rendering to happen on the main thread, and we can
        // easily end up in situations where rendering on secondary threads
        // will result in visual artifacts, bugs, or even deadlocks, when
        // layer-backed.
        return false;
    case OpenGL:
    case BufferQueueingOpenGL:
#endif
   [...]
    }
}
```