### PR TITLE
Fix bug in findOrCreateListenedObjectInfo_(); Moved definitions to cpp file (#675)

### DIFF
--- a/libs/vgc/core/detail/signal.cpp
+++ b/libs/vgc/core/detail/signal.cpp
@@ -53,6 +53,180 @@ Object* currentEmitter() {
     return emitter;
 }
 
+// Must be called after sender `onDestroyed()` call.
+void SignalHub::disconnectSignals(const Object* sender) {
+
+    auto& hub = access(sender);
+    if (!hub.emitting_) {
+        // We sort connections by receiver so that we can fully disconnect each
+        // receiver only once (getListenedObjectInfoRef_ is slow).
+        struct {
+            bool operator()(const Connection_& a, const Connection_& b) const {
+                if (std::holds_alternative<ObjectSlotId>(a.to)) {
+                    if (std::holds_alternative<ObjectSlotId>(b.to)) {
+                        return std::get<ObjectSlotId>(a.to).first
+                               < std::get<ObjectSlotId>(b.to).first;
+                    }
+                    return true;
+                }
+                return false;
+            }
+        } ByReceiver;
+        std::sort(hub.connections_.begin(), hub.connections_.end(), ByReceiver);
+    }
+
+    Object* prevDisconnectedReceiver = nullptr;
+    for (auto& c : hub.connections_) {
+        if (c.pendingRemoval) {
+            continue;
+        }
+        c.pendingRemoval = true;
+        hub.pendingRemovals_ = true;
+        // Let's reset the info about this object which is stored in receiver object.
+        if (std::holds_alternative<ObjectSlotId>(c.to)) {
+            const auto& osid = std::get<ObjectSlotId>(c.to);
+            if (osid.first != prevDisconnectedReceiver) {
+                prevDisconnectedReceiver = osid.first;
+                auto& info = access(osid.first).getListenedObjectInfoRef_(sender);
+                info.numInboundConnections = 0;
+            }
+        }
+    }
+
+    // If possible clear connections_ now.
+    if (!hub.emitting_) {
+        hub.connections_.clear();
+        hub.pendingRemovals_ = false;
+    }
+}
+
+ConnectionHandle SignalHub::connect(
+    const Object* sender,
+    SignalId from,
+    SignalTransmitter&& transmitter,
+    const SlotId& to) {
+
+    auto& hub = access(sender);
+    auto handle = ConnectionHandle::generate();
+
+    if (std::holds_alternative<ObjectSlotId>(to)) {
+        // Increment numInboundConnections in the receiver's info about sender.
+        const auto& bsid = std::get<ObjectSlotId>(to);
+        auto& info = access(bsid.first).findOrCreateListenedObjectInfo_(sender);
+        info.numInboundConnections++;
+    }
+
+    hub.connections_.emplaceLast(std::move(transmitter), handle, from, to);
+    return handle;
+}
+
+void SignalHub::debugInboundConnections(const Object* receiver) {
+    auto& hub = access(receiver);
+    for (auto& info : hub.listenedObjectInfos_) {
+        if (info.numInboundConnections <= 0) {
+            continue;
+        }
+        const Object* sender = info.object;
+        auto& shub = access(sender);
+        Int count = 0;
+        for (auto& c : shub.connections_) {
+            if (c.pendingRemoval) {
+                continue;
+            }
+            if (std::holds_alternative<ObjectSlotId>(c.to)) {
+                const auto& bsid = std::get<ObjectSlotId>(c.to);
+                if (bsid.first == receiver) {
+                    ++count;
+                }
+            }
+        }
+        //VGC_DEBUG_TMP(
+        //    "{}/{} connections of {} are to {}",
+        //    count,
+        //    shub.connections_.length(),
+        //    sender->className(),
+        //    receiver->className());
+        VGC_ASSERT(count == info.numInboundConnections);
+    }
+}
+
+Int SignalHub::numOutboundConnections_() {
+    if (pendingRemovals_) {
+        Int count = 0;
+        for (auto& c : connections_) {
+            if (!c.pendingRemoval) {
+                ++count;
+            }
+        }
+        return count;
+    }
+    return connections_.length();
+}
+
+Int SignalHub::numOutboundConnectionsTo_(const Object* receiver) {
+    if (pendingRemovals_) {
+        Int count = 0;
+        for (auto& c : connections_) {
+            if (!c.pendingRemoval && std::holds_alternative<ObjectSlotId>(c.to)
+                && std::get<ObjectSlotId>(c.to).first == receiver) {
+                ++count;
+            }
+        }
+        return count;
+    }
+    return connections_.length();
+}
+
+Int SignalHub::disconnectListenedObject_(
+    const Object* receiver,
+    ListenedObjectInfo_& info) {
+
+    if (info.numInboundConnections <= 0) {
+        return 0;
+    }
+
+    const Object* sender = info.object;
+    auto& hub = access(sender);
+    Int count = 0;
+    for (auto& c : hub.connections_) {
+        bool shouldRemove = std::holds_alternative<ObjectSlotId>(c.to)
+                            && std::get<ObjectSlotId>(c.to).first == receiver;
+        if (shouldRemove && !c.pendingRemoval) {
+            c.pendingRemoval = true;
+            ++count;
+        }
+    }
+    if (count > 0) {
+        hub.pendingRemovals_ = true;
+    }
+
+#ifdef VGC_DEBUG_BUILD
+    if (count != info.numInboundConnections) {
+        throw LogicError("Erased connections count != info.numInboundConnections.");
+    }
+#endif
+
+    info.numInboundConnections = 0;
+    return count;
+}
+
+SignalHub::ListenedObjectInfo_&
+SignalHub::findOrCreateListenedObjectInfo_(const Object* object) {
+
+    ListenedObjectInfo_* freeInfo = nullptr;
+    for (ListenedObjectInfo_& x : listenedObjectInfos_) {
+        if (x.object == object) {
+            return x;
+        }
+        if (x.numInboundConnections == 0) {
+            freeInfo = &x;
+        }
+    }
+    auto& info = freeInfo ? *freeInfo : listenedObjectInfos_.emplaceLast();
+    info.object = object;
+    return info;
+}
+
 void SignalHub::emit_(SignalId from, const TransmitArgs& args) {
     auto& connections = connections_;
     bool outermostEmit = (emitting_ == false);
@@ -78,6 +252,7 @@ void SignalHub::emit_(SignalId from, const TransmitArgs& args) {
         // we remove connections that have been disconnected and pending for removal.
         if (pendingRemovals_) {
             connections.removeIf([](const Connection_& c) { return c.pendingRemoval; });
+            pendingRemovals_ = false;
         }
         emitting_ = false;
     }


### PR DESCRIPTION
#675
- Fixes bug in findOrCreateListenedObjectInfo_():

```cpp
for (ListenedObjectInfo_& x : listenedObjectInfos_) {
    if (x.object == object) {
        return x;
    }
    if (x.numInboundConnections == 0) {
        // that was wrong, we can keep a reference to this free entry
        // but we must finish iterating on listenedObjectInfos_ to check
        // for a `x.object == object` match.
        x.object = object;
        return x;
    }
}
```
- Fixes bug in disconnectSignals(): we cannot sort nor clear `hub.connections_` if `hub.emitting_` is true.
- Fixes missing `pendingRemovals_ = false` in `SignalHub::emit_`
- Moved long non-template methods implementation to signal.cpp.