### PR TITLE
Improve fullscreen support for D3D11 engine backend (#789)

### DIFF
--- a/libs/vgc/graphics/d3d11/d3d11engine.h
+++ b/libs/vgc/graphics/d3d11/d3d11engine.h
@@ -96,6 +96,10 @@ protected:
 
     void onWindowResize_(SwapChain* swapChain, UInt32 width, UInt32 height) override;
 
+    bool shouldPresentWaitFromSyncedUserThread_() override {
+        return true;
+    }
+
     //--  RENDER THREAD implementation functions --
 
     void initContext_() override;


### PR DESCRIPTION
#789

With D3D11, in order to avoid deadlocks (which we noticed in fullscreen mode), it is necessary to call `present()` directly from the user thread, rather than queuing it as a command to be executed in the render thread.

See: https://learn.microsoft.com/en-us/windows/win32/direct3darticles/dxgi-best-practices#multithreading-and-dxgi

> If the DXGI call and message pump are on different threads, care must be taken to avoid deadlocks. When the message pump and SendMessage are on different threads, [SendMessage](https://learn.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-sendmessage) adds a message to the window's message queue, and waits for the window to process that message. If the window procedure is busy or is not called by the message pump, the message may never get processed and DXGI will wait indefinitely.

We do this via a virtual function `shouldPresentWaitFromSyncedUserThread_()` which returns true in the case of D3d11.

When calling  `endFrame()` (from the user thread), it would normally add a command that calls `present()` to the command list, then submit the command list.

Instead, if `shouldPresentWaitFromSyncedUserThread_()` returns true, then the command list is submitted right away, then the user thread waits for it to complete, then the user thread calls `present()` itself.