### PR TITLE
Fix OpenGL non-indexed draw (#789)

### DIFF
--- a/libs/vgc/ui/detail/qopenglengine.h
+++ b/libs/vgc/ui/detail/qopenglengine.h
@@ -222,6 +222,7 @@ private:
     RasterizerStatePtr boundRasterizerState_;
     ProgramPtr boundProgram_;
     GLenum lastIndexFormat_ = GL_NONE;
+    bool isPrimitiveRestartEnabled_ = false;
 
     static constexpr UInt32 numTextureUnits = maxSamplersPerStage * numShaderStages;
     static_assert(maxSamplersPerStage == maxImageViewsPerStage);


### PR DESCRIPTION
#789

Primitive restart index was always enabled and its default value was zero.
This caused the first vertex of non-indexed draws to be skipped by a restart and jumble up the primitives.
The artifacts were disappearing as soon as an indexed draw happened since it sets the restart index to -1.