### PR TITLE
Array: Add isCallable requirement for predicate arguments (#38)

### DIFF
--- a/libs/vgc/core/array.h
+++ b/libs/vgc/core/array.h
@@ -1045,7 +1045,7 @@ public:
     /// Returns an iterator to the first element for which `predicate(element)`
     /// returns `true`, or the end iterator if there is no such element.
     ///
-    template<typename UnaryPredicate>
+    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
     iterator find(UnaryPredicate predicate) {
         T* p = data_;
         T* end = p + length_;
@@ -1061,7 +1061,7 @@ public:
     /// `predicate(element)` returns `true`, or the end const iterator if there
     /// is no such element.
     ///
-    template<typename UnaryPredicate>
+    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
     const_iterator find(UnaryPredicate predicate) const {
         return const_cast<Array*>(this)->search(predicate);
     }
@@ -1090,7 +1090,7 @@ public:
     /// Returns a pointer to the first element for which `predicate(element)`
     /// returns `true`, or `nullptr` if there is no such element.
     ///
-    template<typename UnaryPredicate>
+    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
     T* search(UnaryPredicate predicate) {
         T* p = data_;
         T* end = p + length_;
@@ -1106,7 +1106,7 @@ public:
     /// `predicate(element)` returns `true`, or `nullptr` if there is no such
     /// element.
     ///
-    template<typename UnaryPredicate>
+    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
     const T* search(UnaryPredicate predicate) const {
         return const_cast<Array*>(this)->search(predicate);
     }
@@ -1129,7 +1129,7 @@ public:
     /// Returns the index of the first element for which `predicate(element)`
     /// returns `true`, or `-1` if there is no such element.
     ///
-    template<typename UnaryPredicate>
+    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
     Int index(UnaryPredicate predicate) const {
         const T* p = data_;
         const T* end = p + length_;

--- a/libs/vgc/core/array.h
+++ b/libs/vgc/core/array.h
@@ -1045,12 +1045,12 @@ public:
     /// Returns an iterator to the first element for which `predicate(element)`
     /// returns `true`, or the end iterator if there is no such element.
     ///
-    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
+    template<typename UnaryPredicate, VGC_REQUIRES(isUnaryPredicate<UnaryPredicate, T>)>
     iterator find(UnaryPredicate predicate) {
         T* p = data_;
         T* end = p + length_;
         for (; p != end; ++p) {
-            if (predicate(*p)) {
+            if (predicate(*const_cast<const T*>(p))) {
                 break;
             }
         }
@@ -1061,7 +1061,7 @@ public:
     /// `predicate(element)` returns `true`, or the end const iterator if there
     /// is no such element.
     ///
-    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
+    template<typename UnaryPredicate, VGC_REQUIRES(isUnaryPredicate<UnaryPredicate, T>)>
     const_iterator find(UnaryPredicate predicate) const {
         return const_cast<Array*>(this)->search(predicate);
     }
@@ -1090,12 +1090,12 @@ public:
     /// Returns a pointer to the first element for which `predicate(element)`
     /// returns `true`, or `nullptr` if there is no such element.
     ///
-    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
+    template<typename UnaryPredicate, VGC_REQUIRES(isUnaryPredicate<UnaryPredicate, T>)>
     T* search(UnaryPredicate predicate) {
         T* p = data_;
         T* end = p + length_;
         for (; p != end; ++p) {
-            if (predicate(*p)) {
+            if (predicate(*const_cast<const T*>(p))) {
                 return p;
             }
         }
@@ -1106,7 +1106,7 @@ public:
     /// `predicate(element)` returns `true`, or `nullptr` if there is no such
     /// element.
     ///
-    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
+    template<typename UnaryPredicate, VGC_REQUIRES(isUnaryPredicate<UnaryPredicate, T>)>
     const T* search(UnaryPredicate predicate) const {
         return const_cast<Array*>(this)->search(predicate);
     }
@@ -1115,8 +1115,8 @@ public:
     /// `value`, or `-1` if there is no such element.
     ///
     Int index(const T& value) const {
-        const T* p = data_;
-        const T* end = p + length_;
+        T* p = data_;
+        T* end = p + length_;
         for (; p != end; ++p) {
             if (*p == value) {
                 // invariant: smaller than length()
@@ -1129,12 +1129,12 @@ public:
     /// Returns the index of the first element for which `predicate(element)`
     /// returns `true`, or `-1` if there is no such element.
     ///
-    template<typename UnaryPredicate, VGC_REQUIRES(isCallable<UnaryPredicate>)>
+    template<typename UnaryPredicate, VGC_REQUIRES(isUnaryPredicate<UnaryPredicate, T>)>
     Int index(UnaryPredicate predicate) const {
-        const T* p = data_;
-        const T* end = p + length_;
+        T* p = data_;
+        T* end = p + length_;
         for (; p != end; ++p) {
-            if (predicate(*p)) {
+            if (predicate(*const_cast<const T*>(p))) {
                 // invariant: smaller than length()
                 return static_cast<Int>(p - data_);
             }

--- a/libs/vgc/core/templateutil.h
+++ b/libs/vgc/core/templateutil.h
@@ -772,6 +772,23 @@ struct IsCallable<T, RequiresValid<typename CallableTraits<T>::CallSignature>>
 template<typename T>
 inline constexpr bool isCallable = IsCallable<T>::value;
 
+/// Type trait for `isUnaryPredicate<T>`.
+///
+template<typename Pred, typename T, typename SFINAE = void>
+struct IsUnaryPredicate : std::false_type {};
+
+template<typename Pred, typename T>
+struct IsUnaryPredicate<Pred, T, Requires<std::is_invocable_r_v<bool, Pred, const T&>>>
+    : std::true_type {};
+
+/// Checks whether the given type `Pred` is a unary predicate callable for type `T`,
+/// that is: returns a type convertible to `bool` and accepts a single argument `const T&`.
+///
+/// \sa `IsUnaryPredicate<T>`.
+///
+template<typename Pred, typename T>
+inline constexpr bool isUnaryPredicate = IsUnaryPredicate<Pred, T>::value;
+
 namespace detail {
 
 template<template<typename...> typename Base, typename... Ts>


### PR DESCRIPTION
#38
This is necessary for `find(const T&)` to be selected over `find(UnaryPredicate)` when conversion is possible.
Question: If T is callable and Y a callable convertible to T, do we want `find(UnaryPredicate)` to be selected ?