### PR TITLE
Fix RichText::setText() did not update shapedText_ when providing an empty text (#534)

### DIFF
--- a/libs/vgc/graphics/richtext.h
+++ b/libs/vgc/graphics/richtext.h
@@ -389,7 +389,7 @@ private:
     geometry::Vec2f advance_(Int position) const;
     float maxCursorHorizontalAdvance_() const;
     void updateScroll_();
-    void insertText_(std::string_view text);
+    bool insertText_(std::string_view text);
 };
 
 } // namespace vgc::graphics


### PR DESCRIPTION
#534