### PR TITLE
Replace Array::removeOneIf() return type by bool (#748)

### DIFF
--- a/libs/vgc/core/array.h
+++ b/libs/vgc/core/array.h
@@ -1656,7 +1656,7 @@ public:
     /// ```
     ///
     template<typename Pred>
-    Int removeOneIf(Pred pred) {
+    bool removeOneIf(Pred pred) {
         const auto end_ = end();
         auto it = std::find_if(begin(), end_, pred);
         if (it != end_) {


### PR DESCRIPTION
#748

This is a typo that slipped in with #1098.