### PR TITLE
Use internal IDs to store selected elements instead of raw pointers; Let selection survive dom changes (#1159)

### DIFF
--- a/libs/vgc/ui/canvas.cpp
+++ b/libs/vgc/ui/canvas.cpp
@@ -208,7 +208,6 @@ void deleteElement(workspace::Element* element, workspace::Workspace* workspace)
 
 void Canvas::clearSelection_() {
     selectionCandidateElements_.clear();
-    canMergeColorChange_ = false;
     selectedElementId_ = 0;
 }
 

--- a/libs/vgc/ui/canvas.cpp
+++ b/libs/vgc/ui/canvas.cpp
@@ -206,6 +206,12 @@ void deleteElement(workspace::Element* element, workspace::Workspace* workspace)
 
 } // namespace
 
+void Canvas::clearSelection_() {
+    selectionCandidateElements_.clear();
+    canMergeColorChange_ = false;
+    selectedElementId_ = 0;
+}
+
 bool Canvas::onKeyPress(KeyEvent* event) {
 
     using workspace::EdgeSubdivisionQuality;
@@ -262,8 +268,8 @@ bool Canvas::onKeyPress(KeyEvent* event) {
 
 void Canvas::onWorkspaceChanged_() {
 
-    selectionCandidateElements_.clear();
-    selectedElementId_ = 0;
+    //selectionCandidateElements_.clear();
+    //selectedElementId_ = 0;
 
     // ask for redraw
     requestRepaint();
@@ -398,7 +404,7 @@ bool Canvas::onMousePress(MouseEvent* event) {
                         }
                         double dist = 0;
                         if (e->isSelectableAt(worldCoords, false, tol, &dist)) {
-                            selectionCandidateElements_.emplaceLast(e, dist);
+                            selectionCandidateElements_.emplaceLast(e->id(), dist);
                         }
                     });
                 // order from front to back
@@ -420,6 +426,8 @@ bool Canvas::onMousePress(MouseEvent* event) {
         return true;
     }
 
+    selectionCandidateElements_.clear();
+    selectedElementId_ = 0;
     return false;
 }
 
@@ -572,7 +580,7 @@ void Canvas::updateChildrenGeometry() {
 
 workspace::Element* Canvas::selectedElement_() const {
     if (selectionCandidateElements_.size()) {
-        return selectionCandidateElements_[selectedElementId_].first;
+        return workspace()->find(selectionCandidateElements_[selectedElementId_].first);
     }
     else {
         return nullptr;

--- a/libs/vgc/ui/canvas.h
+++ b/libs/vgc/ui/canvas.h
@@ -110,6 +110,9 @@ public:
 
     VGC_SIGNAL(changed);
 
+    // temporary method
+    void clearSelection_();
+
 protected:
     // Reimplementation of Widget virtual methods
     bool onKeyPress(KeyEvent* event) override;
@@ -152,7 +155,7 @@ protected:
     geometry::Camera2d cameraAtPress_;
 
     // Selection
-    core::Array<std::pair<workspace::Element*, double>> selectionCandidateElements_;
+    core::Array<std::pair<core::Id, double>> selectionCandidateElements_;
     Int selectedElementId_ = 0;
     workspace::Element* selectedElement_() const;
 

--- a/libs/vgc/ui/sketchtool.cpp
+++ b/libs/vgc/ui/sketchtool.cpp
@@ -97,6 +97,7 @@ bool SketchTool::onMousePress(MouseEvent* event) {
     if (!canvas) {
         return false;
     }
+    canvas->clearSelection_();
 
     isSketching_ = true;
 


### PR DESCRIPTION
#1159