### PR TITLE
Move ScopedTemporaryBoolSet from workspace to core as BoolGuard; Improve API and doc (#748)

### DIFF
--- a/libs/vgc/core/CMakeLists.txt
+++ b/libs/vgc/core/CMakeLists.txt
@@ -52,6 +52,7 @@ vgc_add_library(core
         algorithm.cpp
         animtime.cpp
         arithmetic.cpp
+        boolguard.cpp
         color.cpp
         datetime.cpp
         exceptions.cpp

--- a/libs/vgc/core/CMakeLists.txt
+++ b/libs/vgc/core/CMakeLists.txt
@@ -13,6 +13,7 @@ vgc_add_library(core
         arithmetic.h
         array.h
         assert.h
+        boolguard.h
         color.h
         colors.h
         compiler.h

--- a/libs/vgc/core/boolguard.cpp
+++ b/libs/vgc/core/boolguard.cpp
@@ -1,0 +1,20 @@
+// Copyright 2023 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vgc/core/boolguard.h>
+
+// If you implement methods of BoolGuard here, don't forget to
+// add VGC_CORE_API to the class and remove this paragraph.

--- a/libs/vgc/core/boolguard.cpp
+++ b/libs/vgc/core/boolguard.cpp
@@ -16,5 +16,5 @@
 
 #include <vgc/core/boolguard.h>
 
-// If you implement methods of BoolGuard here, don't forget to
-// add VGC_CORE_API to the class and remove this paragraph.
+// This file ensures that boolguard.h is in at least in one compilation unit of
+// the vgc::core module, so that its exported symbols are indeed exported.

--- a/libs/vgc/core/boolguard.h
+++ b/libs/vgc/core/boolguard.h
@@ -1,0 +1,109 @@
+// Copyright 2023 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VGC_CORE_BOOLGUARD_H
+#define VGC_CORE_BOOLGUARD_H
+
+#include <vgc/core/api.h>
+
+namespace vgc::core {
+
+/// \class vgc::core::BoolGuard
+/// \brief Sets a boolean to true on construction and restore it on destruction.
+///
+/// `BoolGuard` is a helper class following RAII principles for managing a
+/// shared boolean status flag.
+///
+/// The `BoolGuard` constructor takes as input a non-const reference to a
+/// boolean (i.e., a "shared boolean"), saves its current value `v`, and
+/// modifies its value to `true`. Then, the `BoolGuard` destructor restores the
+/// value of the shared boolean back to `v`.
+///
+/// Using a `BoolGuard` is often useful to protect potentially recursive or
+/// mutually-recursive methods, by detecting whether there is already on the
+/// call stack a call to a given method, for a given object.
+///
+/// Example:
+///
+/// ```cpp
+/// class Printer {
+/// public:
+///     void print() {
+///         if (isPrinting_) {
+///             VGC_WARNING(LogPrinter, "Cannot call print(): already printing.");
+///             return;
+///         }
+///         BoolGuard guard(isPrinting_); // BoolGuard constructor: sets isPrinting_ to true
+///         [... do something ...]
+///                                       // BoolGuard destructor: sets isPrinting_ to false
+///     }
+///
+/// private:
+///     bool isPrinting_ = false;
+/// };
+/// ```
+///
+class VGC_CORE_API BoolGuard {
+public:
+    /// Constructs a `BoolGuard` managing the shared boolean `ref`.
+    ///
+    /// This sets the value of `ref` to true.
+    ///
+    BoolGuard(bool& ref)
+        : ref_(ref)
+        , previousValue_(ref) {
+
+        ref_ = true;
+    }
+
+    /// Destructs the `BoolGuard`.
+    ///
+    /// This restores the value of `ref` back to `previousValue()`, that is,
+    /// the value that the boolean had before constructing this `BoolGuard`.
+    ///
+    ~BoolGuard() {
+        ref_ = previousValue_;
+    }
+
+    /// Returns a non-const reference to the shared boolean managed by this
+    /// `BoolGuard`.
+    ///
+    bool& ref() {
+        return ref_;
+    }
+
+    /// Returns a const reference to the shared boolean managed by this
+    /// `BoolGuard`.
+    ///
+    const bool& ref() const {
+        return ref_;
+    }
+
+    /// Returns the value that the shared boolean had before being managed by
+    /// this `BoolGuard`.
+    ///
+    bool previousValue() const {
+        return previousValue_;
+    }
+
+private:
+    bool& ref_;
+    bool previousValue_;
+};
+
+} // namespace vgc::core
+
+#endif // VGC_CORE_BOOLGUARD_H

--- a/libs/vgc/workspace/workspace.cpp
+++ b/libs/vgc/workspace/workspace.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 
+#include <vgc/core/boolguard.h>
 #include <vgc/dom/strings.h>
 #include <vgc/topology/operations.h>
 #include <vgc/topology/vac.h>
@@ -41,33 +42,6 @@ struct VacElementLists {
     core::Array<Element*> inbetweenVertices;
     core::Array<Element*> inbetweenEdges;
     core::Array<Element*> inbetweenFaces;
-};
-
-// This is a helper to manage a shared boolean status flag.
-//
-// Sets the given shared boolean to true on construction and restores it to its previous
-// value on destruction.
-//
-// For instance if function A and B want to signal that they are being executed, you can
-// construct a ScopedTemporaryBoolSet with the same boolean in both scopes. Whenever this
-// boolean is true, it means that either A or B is in the callstack.
-//
-class ScopedTemporaryBoolSet {
-public:
-    ScopedTemporaryBoolSet(bool& ref)
-        : old_(ref)
-        , ref_(ref) {
-
-        ref_ = true;
-    }
-
-    ~ScopedTemporaryBoolSet() {
-        ref_ = old_;
-    }
-
-private:
-    bool old_;
-    bool& ref_;
 };
 
 } // namespace detail
@@ -744,7 +718,7 @@ void Workspace::rebuildWorkspaceTreeFromDom_() {
 
     // reset vac
     {
-        detail::ScopedTemporaryBoolSet bgVac(isUpdatingVacFromDom_);
+        core::BoolGuard bgVac(isUpdatingVacFromDom_);
         vac_->clear();
         //vac_->emitPendingDiff();
     }
@@ -776,7 +750,7 @@ void Workspace::rebuildVacFromWorkspaceTree_() {
         return;
     }
 
-    detail::ScopedTemporaryBoolSet bgVac(isUpdatingVacFromDom_);
+    core::BoolGuard bgVac(isUpdatingVacFromDom_);
 
     // reset vac
     vac_->clear();
@@ -883,7 +857,7 @@ void Workspace::updateVacFromDom_(const dom::Diff& diff) {
     if (!document_) {
         return;
     }
-    detail::ScopedTemporaryBoolSet bgVac(isUpdatingVacFromDom_);
+    core::BoolGuard bgVac(isUpdatingVacFromDom_);
 
     // impl goal: we want to keep as much cached data as possible.
     //            we want the vac to be valid -> using only its operators


### PR DESCRIPTION
#748