### PR TITLE
Allow reparenting a widget to nullptr, that is, make it a root widget (#995)

### DIFF
--- a/libs/vgc/ui/widget.cpp
+++ b/libs/vgc/ui/widget.cpp
@@ -136,7 +136,15 @@ bool Widget::canReparent(Widget* newParent) {
 }
 
 void Widget::reparent(Widget* newParent) {
-    newParent->addChild(this);
+    if (newParent) {
+        newParent->addChild(this);
+    }
+    else {
+        // Make the widget a root widget.
+        // This will destroy the widget if no ObjPtr manages it.
+        // XXX have a dedicated widget function for that, e.g. Widget::removeChild()?
+        removeObjectFromParent_();
+    }
 }
 
 namespace {


### PR DESCRIPTION
#995