### PR TITLE
Centralize responsibility of ID generation in createNode_<T>() (#1262)

### DIFF
--- a/libs/vgc/vacomplex/cell.h
+++ b/libs/vgc/vacomplex/cell.h
@@ -475,14 +475,8 @@ public:
     ~Group() override = default;
 
 protected:
-    explicit Group(Complex* complex, core::Id id) noexcept
+    explicit Group(core::Id id, Complex* complex) noexcept
         : Node(id)
-        , complex_(complex) {
-    }
-
-    // Root Node constructor.
-    explicit Group(Complex* complex) noexcept
-        : Node(0)
         , complex_(complex) {
     }
 

--- a/libs/vgc/vacomplex/detail/operationsimpl.cpp
+++ b/libs/vgc/vacomplex/detail/operationsimpl.cpp
@@ -33,9 +33,8 @@ Operations::Operations(Complex* complex)
 }
 
 Group* Operations::createRootGroup() {
-    const core::Id id = core::genId();
 
-    Group* group = createNode_<Group>(complex(), id);
+    Group* group = createNode_<Group>(complex());
 
     // diff
     if (complex()->isDiffEnabled_) {
@@ -47,9 +46,8 @@ Group* Operations::createRootGroup() {
 }
 
 Group* Operations::createGroup(Group* parentGroup, Node* nextSibling) {
-    const core::Id id = core::genId();
 
-    Group* group = createNode_<Group>(complex(), id);
+    Group* group = createNode_<Group>(complex());
     parentGroup->insertChildUnchecked(nextSibling, group);
 
     // diff
@@ -69,9 +67,7 @@ KeyVertex* Operations::createKeyVertex(
     core::Span<Node*> operationSourceNodes,
     core::AnimTime t) {
 
-    const core::Id id = core::genId();
-
-    KeyVertex* kv = createNode_<KeyVertex>(id, t);
+    KeyVertex* kv = createNode_<KeyVertex>(t);
     kv->position_ = position;
     parentGroup->insertChildUnchecked(nextSibling, kv);
 
@@ -95,9 +91,7 @@ KeyEdge* Operations::createKeyOpenEdge(
     core::Span<Node*> operationSourceNodes,
     core::AnimTime t) {
 
-    const core::Id id = core::genId();
-
-    KeyEdge* ke = createNode_<KeyEdge>(id, t);
+    KeyEdge* ke = createNode_<KeyEdge>(t);
     parentGroup->insertChildUnchecked(nextSibling, ke);
 
     // init cell
@@ -132,9 +126,7 @@ KeyEdge* Operations::createKeyClosedEdge(
     core::Span<Node*> operationSourceNodes,
     core::AnimTime t) {
 
-    const core::Id id = core::genId();
-
-    KeyEdge* ke = createNode_<KeyEdge>(id, t);
+    KeyEdge* ke = createNode_<KeyEdge>(t);
     parentGroup->insertChildUnchecked(nextSibling, ke);
 
     ke->points_ = points.getShared();
@@ -162,9 +154,7 @@ KeyFace* Operations::createKeyFace(
     core::Span<Node*> operationSourceNodes,
     core::AnimTime t) {
 
-    const core::Id id = core::genId();
-
-    KeyFace* kf = createNode_<KeyFace>(id, t);
+    KeyFace* kf = createNode_<KeyFace>(t);
     parentGroup->insertChildUnchecked(nextSibling, kf);
 
     // init cell

--- a/libs/vgc/vacomplex/detail/operationsimpl.h
+++ b/libs/vgc/vacomplex/detail/operationsimpl.h
@@ -117,10 +117,10 @@ private:
     //
     template<class T, typename... Args>
     T* createNode_(Args&&... args) {
-        T* node = new T(args...);
+        core::Id id = core::genId();
+        T* node = new T(id, std::forward<Args>(args)...);
         std::unique_ptr<T> nodePtr(node);
         Complex::NodePtrMap& nodes = complex()->nodes_;
-        core::Id id = node->id();
         bool emplaced = nodes.try_emplace(id, std::move(nodePtr)).second;
         if (!emplaced) {
             throw LogicError("Id collision error.");


### PR DESCRIPTION
#1262