### PR TITLE
[skip ci] Fix formatting (#395, #1315)

### DIFF
--- a/libs/vgc/geometry/curve.cpp
+++ b/libs/vgc/geometry/curve.cpp
@@ -627,7 +627,7 @@ bool testLine_(
     return true;
 }
 
-// Samples the segment [data.segmentIndex, data.segmentIndex + 1], and append the 
+// Samples the segment [data.segmentIndex, data.segmentIndex + 1], and append the
 // result to outAppend.
 //
 // The first sample of the segment is appended only if the cache `data` is new.


### PR DESCRIPTION
#395

Formatting issue coming from last commit of PR #1315, which skipped ci.