### PR TITLE
Call onMouseHover() at more appropriate times (e.g., at the end of a MouseDrag action) (#540)

### DIFF
--- a/libs/vgc/ui/widget.h
+++ b/libs/vgc/ui/widget.h
@@ -1541,6 +1541,9 @@ private:
     Widget* mouseCaptor_ = nullptr; // TODO: move to future class WidgetTree
     Widget* hoverChainParent_ = nullptr;
     Widget* hoverChainChild_ = nullptr;
+    geometry::Vec2f lastMouseHoverPosition_;
+    ModifierKeys lastMouseHoverModifierKeys_;
+    bool forceNextMouseHover_ = true;
     bool isHovered_ = false;
     bool isInHoveredRow_ = false;
     bool isInHoveredColumn_ = false;


### PR DESCRIPTION
#540