### PR TITLE
Fix Array::shrinkToFit() deallocating storage without updating pointer and reservedLength (#38)

### DIFF
--- a/libs/vgc/core/array.h
+++ b/libs/vgc/core/array.h
@@ -2031,12 +2031,6 @@ private:
         }
     }
 
-    // Resets the container to its default constructed state (empty, no storage).
-    //
-    void reset_() noexcept {
-        destroyStorage_();
-    }
-
     // Leaves length_ unchanged!
     // Expects: (data_ == nullptr) and (n <= maxLength()).
     //
@@ -2071,7 +2065,9 @@ private:
         const Int len = length_;
         if (len != reservedLength_) {
             if (len == 0) {
-                reset_();
+                destroyStorage_();
+                data_ = nullptr;
+                reservedLength_ = 0;
             }
             else {
                 reallocateExactly_(len);

--- a/libs/vgc/core/tests/test_array.cpp
+++ b/libs/vgc/core/tests/test_array.cpp
@@ -1289,6 +1289,11 @@ TEST(TestArray, ShrinkToFit) {
         a.shrinkToFit();
         EXPECT_EQ(a.reservedLength(), 3);
         EXPECT_EQ(a[2], 42);
+        a.clear();
+        a.shrinkToFit();
+        EXPECT_EQ(a.data(), nullptr);
+        EXPECT_EQ(a.length(), 0);
+        EXPECT_EQ(a.reservedLength(), 0);
     }
     EXPECT_NO_THROW(TestObj::doPostTestChecks());
 }


### PR DESCRIPTION
#38