### PR TITLE
Implement context-dependent enabling of IMEs (input method editors) (#949)

### DIFF
--- a/libs/vgc/ui/lineedit.cpp
+++ b/libs/vgc/ui/lineedit.cpp
@@ -58,6 +58,7 @@ LineEdit::LineEdit(std::string_view text)
     , richText_(graphics::RichText::create()) {
 
     setFocusPolicy(FocusPolicy::Click | FocusPolicy::Tab);
+    setTextInputReceiver(true);
     addStyleClass(strings::LineEdit);
     appendChildStylableObject(richText_.get());
     setText(text);

--- a/libs/vgc/ui/widget.cpp
+++ b/libs/vgc/ui/widget.cpp
@@ -1798,6 +1798,13 @@ void Widget::setTreeActive(bool active, FocusReason reason) {
     }
 }
 
+void Widget::setTextInputReceiver(bool isTextInputReceiver) {
+    if (isTextInputReceiver != isTextInputReceiver_) {
+        isTextInputReceiver_ = isTextInputReceiver;
+        textInputReceiverChanged().emit(isTextInputReceiver_);
+    }
+}
+
 void Widget::setFocus(FocusReason reason) {
     if (!isFocusedWidget()) {
         clearFocus(reason);

--- a/libs/vgc/ui/widget.h
+++ b/libs/vgc/ui/widget.h
@@ -1087,6 +1087,32 @@ public:
         focusPolicy_ = policy;
     }
 
+    /// Returns whether this widget accepts text input.
+    ///
+    /// \sa `setTextInputReceiver()`.
+    ///
+    bool isTextInputReceiver() const {
+        return isTextInputReceiver_;
+    }
+
+    /// Sets whether this widget accepts text input.
+    ///
+    /// This should be set to `true` for widgets that behave like text editors
+    /// (e.g., `LineEdit`), so that dead keys can be combined with the
+    /// follow-up characters before being transmitted to the widget, and so
+    /// that virtual keyboards can appear in contexts where it makes sense
+    /// (e.g., mobile operating systems, Chinese input, accessibility
+    /// settings).
+    ///
+    /// \sa `isTextInputReceiver()`.
+    ///
+    void setTextInputReceiver(bool isTextInputReceiver);
+
+    /// This signal is emitted whenever the value of `isTextInputReceiver()`
+    /// changes.
+    ///
+    VGC_SIGNAL(textInputReceiverChanged, (bool, newValue))
+
     /// This signal is emitted whenever this widget, or any of its descendants,
     /// became the focused widget.
     ///
@@ -1631,6 +1657,7 @@ private:
     //
     bool isTreeActive_ = false; // TODO: move to future class WidgetTree
     FocusPolicyFlags focusPolicy_ = FocusPolicy::Never;
+    bool isTextInputReceiver_ = false;
     Widget* focus_ = nullptr;
     Widget* keyboardCaptor_ = nullptr; // TODO: move to future class WidgetTree
 

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -1263,7 +1263,7 @@ void Window::onFocusWidgetChanged_() {
         focusedWidget_->textInputReceiverChanged().connect(
             onTextInputReceiverChangedSlot_());
     }
-    onTextInputReceiverChangedSlot_();
+    onTextInputReceiverChanged_();
 }
 
 void Window::onTextInputReceiverChanged_() {

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -1263,6 +1263,7 @@ void Window::onFocusWidgetChanged_() {
         focusedWidget_->textInputReceiverChanged().connect(
             onTextInputReceiverChangedSlot_());
     }
+    onTextInputReceiverChangedSlot_();
 }
 
 void Window::onTextInputReceiverChanged_() {

--- a/libs/vgc/ui/window.cpp
+++ b/libs/vgc/ui/window.cpp
@@ -131,6 +131,8 @@ Window::Window(const WidgetPtr& widget)
 
     //setMouseTracking(true);
     widget_->repaintRequested().connect(onRepaintRequestedSlot_());
+    widget_->focusSet().connect(onFocusWidgetChangedSlot_());
+    widget_->focusCleared().connect(onFocusWidgetChangedSlot_());
     widget_->mouseCaptureStarted().connect(onMouseCaptureStartedSlot_());
     widget_->mouseCaptureStopped().connect(onMouseCaptureStoppedSlot_());
     widget_->keyboardCaptureStarted().connect(onKeyboardCaptureStartedSlot_());
@@ -145,11 +147,7 @@ Window::Window(const WidgetPtr& widget)
 
     // Handle dead keys and complex input methods.
     //
-    // XXX TODO: We should enable/disable this property based on whether the
-    // current keyboard-focused widget is a text-editing widget, similarly to
-    // what Qt::WA_InputMethodEnabled is used for.
-    //
-    QGuiApplication::inputMethod()->update(Qt::ImEnabled);
+    onTextInputReceiverChanged_();
 
     // Sets this Window as an application-wide filter to listen to events not
     // redirected to Window by default (e.g., TabletProximity).
@@ -580,11 +578,11 @@ QVariant Window::inputMethodQuery(Qt::InputMethodQuery query) {
     //
     // https://github.com/qt/qtbase/blob/ec7ff5cede92412b929ff30207b0eeafce93ee3b/src/widgets/widgets/qlineedit.cpp#L1849
     //
-    // For now, we simply return `true` for the `Enabled` query (to ensure that
-    // we receive further queries and input method events), and return an empty
-    // QVariant for all other queries. Most likely, this means that many
-    // (most?) IME won't work with our app, but at least dead keys work. Fixing
-    // this is left for future work.
+    // For now, we simply return something relevant for the `Enabled` query (to
+    // ensure that we receive further queries and input method events), and
+    // return an empty QVariant for all other queries. Most likely, this means
+    // that many (most?) IME won't work with our app, but at least dead keys
+    // work. Fixing this is left for future work.
     //
     // Also see:
     //
@@ -593,8 +591,11 @@ QVariant Window::inputMethodQuery(Qt::InputMethodQuery query) {
     // - https://stackoverflow.com/questions/434048/how-do-you-use-ime
     //
     if (query == Qt::ImEnabled) {
-        // TODO: return true only if the current focus widget accepts text input.
-        return QVariant(true);
+        bool res = false;
+        if (focusedWidget_ && focusedWidget_->isTextInputReceiver()) {
+            res = true;
+        }
+        return QVariant(res);
     }
     else {
         // TODO: handle other queries more appropriately.
@@ -1250,6 +1251,22 @@ void Window::onKeyboardCaptureStarted_() {
 
 void Window::onKeyboardCaptureStopped_() {
     setKeyboardGrabEnabled(false);
+}
+
+void Window::onFocusWidgetChanged_() {
+    if (focusedWidget_) {
+        focusedWidget_->textInputReceiverChanged().disconnect(
+            onTextInputReceiverChangedSlot_());
+    }
+    focusedWidget_ = widget_->focusedWidget();
+    if (focusedWidget_) {
+        focusedWidget_->textInputReceiverChanged().connect(
+            onTextInputReceiverChangedSlot_());
+    }
+}
+
+void Window::onTextInputReceiverChanged_() {
+    QGuiApplication::inputMethod()->update(Qt::ImEnabled);
 }
 
 void Window::onWidgetAddedToTree_(Widget* widget) {

--- a/libs/vgc/ui/window.h
+++ b/libs/vgc/ui/window.h
@@ -291,6 +291,8 @@ private:
     bool isBackgroundPainted_ = true;
     core::Color backgroundColor_ = {};
 
+    WidgetPtr focusedWidget_;
+
     MouseButtons pressedMouseButtons_;
     MouseButtons pressedTabletButtons_;
     geometry::Vec2f accumulatedScrollDelta_ = {};
@@ -325,6 +327,8 @@ private:
     void onMouseCaptureStopped_();
     void onKeyboardCaptureStarted_();
     void onKeyboardCaptureStopped_();
+    void onFocusWidgetChanged_();
+    void onTextInputReceiverChanged_();
     void onWidgetAddedToTree_(Widget* widget);
     void onWidgetRemovedFromTree_(Widget* widget);
     void onActionAdded_(Action* action);
@@ -334,6 +338,8 @@ private:
     VGC_SLOT(onRepaintRequestedSlot_, onRepaintRequested_);
     VGC_SLOT(onMouseCaptureStartedSlot_, onMouseCaptureStarted_);
     VGC_SLOT(onMouseCaptureStoppedSlot_, onMouseCaptureStopped_);
+    VGC_SLOT(onFocusWidgetChangedSlot_, onFocusWidgetChanged_);
+    VGC_SLOT(onTextInputReceiverChangedSlot_, onTextInputReceiverChanged_);
     VGC_SLOT(onKeyboardCaptureStartedSlot_, onKeyboardCaptureStarted_);
     VGC_SLOT(onKeyboardCaptureStoppedSlot_, onKeyboardCaptureStopped_);
     VGC_SLOT(onWidgetAddedToTreeSlot_, onWidgetAddedToTree_);


### PR DESCRIPTION
#949

In particular, this makes it possible to enable dead key handling only when we are in a line edit or similar text-input widget. This is important, otherwise the application wouldn't receive some key events: for example, Option+U in macOS is used as dead key for `¨`, but we don't want to treat it as a dead key when we are not in a line edit, so that we can use it as a shortcut for Unglue.

This also prepares the work for properly handling virtual keyboards (e.g., on mobile platform, for Chinese input, or accessibility settings), so that the virtual keyboard only shows up when appropriate.