### PR TITLE
Prevent recreating an Icon when calling IconWidget::setFilePath() with an identical path (#1406)

### DIFF
--- a/libs/vgc/ui/iconwidget.cpp
+++ b/libs/vgc/ui/iconwidget.cpp
@@ -28,6 +28,10 @@ IconWidget::IconWidget(CreateKey key, std::string_view filePath)
 }
 
 void IconWidget::setFilePath(std::string_view filePath) {
+    if (filePath_ == filePath) {
+        return;
+    }
+    filePath_ = filePath;
     if (icon_.get()) {
         removeChildStylableObject(icon_.get());
     }

--- a/libs/vgc/ui/iconwidget.h
+++ b/libs/vgc/ui/iconwidget.h
@@ -54,6 +54,7 @@ protected:
     geometry::Vec2f computePreferredSize() const override;
 
 private:
+    std::string filePath_;
     graphics::IconPtr icon_;
 
     // Cache computation of icon position/size


### PR DESCRIPTION
#1406