### PR TITLE
SVG Parser: issue warning instead of throwing when encountering 'url()' color or unknown color name (#1403)

### DIFF
--- a/libs/vgc/core/color.h
+++ b/libs/vgc/core/color.h
@@ -112,7 +112,9 @@ public:
     /// core::Color c = core::Color::fromName("red");
     /// ```
     ///
-    static Color fromName(std::string_view hex);
+    /// Throws `ParseError` if the name is unknown.
+    ///
+    static Color fromName(std::string_view name);
 
     /// Accesses the i-th channel of the Color.
     ///

--- a/libs/vgc/graphics/svg.cpp
+++ b/libs/vgc/graphics/svg.cpp
@@ -1031,9 +1031,18 @@ std::optional<core::Color> parseColor(std::string_view s) {
         s = trimmed(s);
         return core::Color::fromHex(s);
     }
+    else if (startsWith(s, "url") && endsWith(s, ")") && contains(s, "(")) {
+        VGC_WARNING(LogVgcGraphicsSvg, "Unsupported color type: {}", s);
+        return std::nullopt;
+    }
     else {
-        s = trimmed(s);
-        return core::Color::fromName(s);
+        try {
+            s = trimmed(s);
+            return core::Color::fromName(s);
+        }
+        catch (core::ParseError&) {
+            return std::nullopt;
+        }
     }
 }
 


### PR DESCRIPTION
#1403