### PR TITLE
Return copy of element instead of reference when iterating a SharedConstArray in Python (#38)

### DIFF
--- a/libs/vgc/core/wraps/array.h
+++ b/libs/vgc/core/wraps/array.h
@@ -274,7 +274,7 @@ void defineSharedConstArrayCommonMethods(
     c.def(
         "__iter__",
         [](const SharedConstArrayType& a) {
-            return py::make_iterator<rvp::reference_internal, It, It, const T&>(
+            return py::make_iterator<rvp::automatic, It, It, const T&>(
                 a.get().begin(), a.get().end());
         },
         // Keep object alive while iterator exists.


### PR DESCRIPTION
#38

Otherwise, the following was possible:

```
>>> a = SharedConstVec2dArray(Vec2dArray([(1, 2), (3, 4)]))
>>> for v in a:
...     v.x = 42
... 
>>> a
vgc.geometry.SharedConstVec2dArray('[(42, 2), (42, 4)]')
```

The new behavior is:

```
>>> a = SharedConstVec2dArray(Vec2dArray([(1, 2), (3, 4)]))
>>> for v in a:
...     v.x = 42
... 
>>> a
vgc.geometry.SharedConstVec2dArray('[(1, 2), (3, 4)]')
```

Alternatively, it might even be preferable if `v.x = 42` was throwing a Python exception (instead of silently modifying a copy), but this would require more work.
