### PR TITLE
Don't use ObjPtr to parent in TransformBox; Fixes settings not saved on close (#1362)

### DIFF
--- a/libs/vgc/tools/transform.cpp
+++ b/libs/vgc/tools/transform.cpp
@@ -455,7 +455,7 @@ public:
     detail::TopologyAwareTransformer transformer_;
 
     bool getPointers_(canvas::Canvas*& canvas, workspace::Workspace*& workspace) {
-        if (!box_->canvasTool_->isAlive()) {
+        if (!box_->canvasTool_) {
             return false;
         }
         canvas = box_->canvasTool_->canvas();
@@ -956,7 +956,7 @@ void TransformBox::onMouseHover(ui::MouseHoverEvent* event) {
     }
 
     // Recompute which mouse actions are available.
-    canvas::Canvas* canvas = canvasTool_.isAlive() ? canvasTool_->canvas() : nullptr;
+    canvas::Canvas* canvas = canvasTool_ ? canvasTool_->canvas() : nullptr;
     if (canvas && isHoverDataUpdateRequired_) {
         computeHoverData_(canvas);
     }
@@ -1153,7 +1153,7 @@ void TransformBox::onPaintDraw(graphics::Engine* engine, ui::PaintOptions option
 
     SuperClass::onPaintDraw(engine, options);
 
-    canvas::Canvas* canvas = canvasTool_.isAlive() ? canvasTool_->canvas() : nullptr;
+    canvas::Canvas* canvas = canvasTool_ ? canvasTool_->canvas() : nullptr;
     if (!canvas) {
         return;
     }
@@ -1472,8 +1472,7 @@ void TransformBox::show_() {
 bool TransformBox::updateWorkspacePointer_() {
     workspace::Workspace* oldWorkspace = workspace_.getIfAlive();
 
-    workspace::Workspace* newWorkspace =
-        canvasTool_.isAlive() ? canvasTool_->workspace() : nullptr;
+    workspace::Workspace* newWorkspace = canvasTool_ ? canvasTool_->workspace() : nullptr;
     if (oldWorkspace != newWorkspace) {
         if (oldWorkspace != nullptr) {
             oldWorkspace->disconnect(this);

--- a/libs/vgc/tools/transform.h
+++ b/libs/vgc/tools/transform.h
@@ -141,7 +141,7 @@ protected:
 private:
     friend detail::TransformDragAction;
 
-    canvas::CanvasToolPtr canvasTool_ = {};
+    canvas::CanvasTool* canvasTool_ = {};
     // we assume that the workspace will not change.
     // if we support that later, we could use a signal/slot.
     workspace::WorkspacePtr workspace_ = {};


### PR DESCRIPTION
#1362

The settings were not properly saved on close. How to reproduce:
- Open VGC
- Go to Select Tool
- Change the "Show Transform Box" settings from false to true
- Go to Sketch Tool
- Close VGC
- Open VGC: the Transform Box settings is back to false. None of the other settings are saved either.

The problem was that `TransformBox` had a data member `CanvasToolPtr canvasTool_`, pointing to its parent. In some cases, this is not an issue, because the parent of the canvas tool (the canvas) would explicitly destroy the canvas tool, which would explicitly destroy the TransformBox, which would destruct the `CanvasToolPtr`, decreasing the refCount and everything would be fine.

Unfortunately, the way canvas tools are implemented, if `SelectTool` is not the current tool, then it isn’t a child widget, but instead it is a root widget kept alive thanks to the `std::map<ui::Action*, canvas::CanvasToolPtr> toolMap_;` stored in the canvas application. Therefore, after going to the Sketch Tool, we have:

- SelectTool is a root Object, with TransformBox as child
- TransformBox stores an ObjPtr to SelectTool.

Therefore, we have a cycle and the SelectTool never gets deleted. In turn, its `WidgetPtr optionsWidget_` data member (inherited from CanvasTool) never gets deleted either. This keeps alive the `BoolSettingEdit` of the "show transform box" setting, which keeps alive the corresponding `BoolSetting`, which keeps alive the whole `Settings` object. Since it is never destructed, it was not saved on application close.