### PR TITLE
Homogenize LineEdit/NumberEdit behavior: clear focus on Enter; restore value on Escape (#539, #1111)

### DIFF
--- a/libs/vgc/ui/lineedit.cpp
+++ b/libs/vgc/ui/lineedit.cpp
@@ -261,6 +261,7 @@ void LineEdit::onMouseLeave() {
 }
 
 bool LineEdit::onFocusIn(FocusReason) {
+    oldText_ = text();
     richText_->setSelectionVisible(true);
     richText_->setCursorVisible(true);
     reload_ = true;
@@ -295,10 +296,6 @@ bool LineEdit::onKeyPress(KeyPressEvent* event) {
     bool needsRepaint = true;
     bool isMoveOperation = false;
 
-    if (key == Key::Enter || key == Key::Return) {
-        needsRepaint = true;
-        editingFinished().emit();
-    }
     if (key == Key::Delete || key == Key::Backspace) {
         if (key == Key::Delete) {
             richText_->deleteFromCursor(ctrl ? Op::NextWord : Op::NextCharacter);
@@ -357,8 +354,11 @@ bool LineEdit::onKeyPress(KeyPressEvent* event) {
         richText_->selectAll();
     }
     else if (key == Key::Escape) {
+        setText(oldText_);
         clearFocus(FocusReason::Other);
-        handled = true;
+    }
+    else if (event->key() == Key::Enter || event->key() == Key::Return) {
+        clearFocus(FocusReason::Other);
     }
     else if (key == Key::Tab) {
         handled = false;

--- a/libs/vgc/ui/lineedit.h
+++ b/libs/vgc/ui/lineedit.h
@@ -108,6 +108,9 @@ private:
     ui::CursorChanger cursorChanger_;
     ui::MouseButton mouseButton_ = ui::MouseButton::None;
 
+    // Text value before editing starts
+    std::string oldText_;
+
     // Handle double/triple clicks
     core::Stopwatch leftMouseButtonStopwatch_;
     Int numLeftMouseButtonClicks_ = 0;

--- a/libs/vgc/ui/numberedit.cpp
+++ b/libs/vgc/ui/numberedit.cpp
@@ -314,7 +314,7 @@ bool NumberEdit::onKeyPress(KeyPressEvent* event) {
         setTextFromValue_();
         setTextMode_(false);
     }
-    if (event->key() == Key::Enter || event->key() == Key::Return) {
+    else if (event->key() == Key::Enter || event->key() == Key::Return) {
         setValueFromText_(oldValue_);
         setTextFromValue_();
         setTextMode_(false);


### PR DESCRIPTION
#539, #1111