### PR TITLE
Fix keyboard shortcuts not working on NumberEdit (#1111)

### DIFF
--- a/libs/vgc/ui/numberedit.cpp
+++ b/libs/vgc/ui/numberedit.cpp
@@ -299,20 +299,21 @@ bool NumberEdit::onKeyPress(KeyPressEvent* event) {
     if (!isTextMode_) {
         return false;
     }
-    if (event->key() == Key::Escape) {
+    else if (event->key() == Key::Escape) {
         setValue(oldValue_);
         setTextFromValue_();
         setTextMode_(false);
+        return true;
     }
     else if (event->key() == Key::Enter || event->key() == Key::Return) {
         setValueFromText_(oldValue_);
         setTextFromValue_();
         setTextMode_(false);
+        return true;
     }
     else {
-        LineEdit::onKeyPress(event);
+        return LineEdit::onKeyPress(event);
     }
-    return true;
 }
 
 double NumberEdit::roundedValue_(double v) {


### PR DESCRIPTION
#1111

The problem was that `NumberEdit::onKeyPress()` was incorrectly returning `true` even when not handling anything, therefore the widget system was tricked into thinking that nothing more should be done. Copy-pasting with Ctrl+X/C/V was previously working by "chance", because these were hard-coded in `LineEdit::onKeyPress()` which was indeed called, even though the return value was unused.

This is a good example why porting all keyboard interaction to the new action system will be more robust, less bug-prone.