### PR TITLE
Fix incorrect argument order in insertChildObject() documentation (#1116)

### DIFF
--- a/libs/vgc/core/exceptions.h
+++ b/libs/vgc/core/exceptions.h
@@ -118,8 +118,7 @@
 #if defined(VGC_CORE_COMPILER_CLANG)
 #    define VGC_CORE_EXCEPTIONS_DECLARE_ANCHOR virtual void anchor();
 #    define VGC_CORE_EXCEPTIONS_DEFINE_ANCHOR(T)                                         \
-        void T::anchor() {                                                               \
-        }
+        void T::anchor() {}
 #else
 #    define VGC_CORE_EXCEPTIONS_DECLARE_ANCHOR
 #    define VGC_CORE_EXCEPTIONS_DEFINE_ANCHOR(T)
@@ -485,7 +484,7 @@ public:
 ///
 /// This exception is raised when a given Object is expected to be a child of
 /// another Object, but isn't. For example, it is raised when the `nextSibling`
-/// argument of `obj->insertChildObject(node, nextSibling)` is non-null and
+/// argument of `obj->insertChildObject(nextSibling, node)` is non-null and
 /// isn't a child of `obj`.
 ///
 /// \sa Object::insertChildObject().

--- a/libs/vgc/core/exceptions.h
+++ b/libs/vgc/core/exceptions.h
@@ -117,8 +117,10 @@
 ///
 #if defined(VGC_CORE_COMPILER_CLANG)
 #    define VGC_CORE_EXCEPTIONS_DECLARE_ANCHOR virtual void anchor();
-#    define VGC_CORE_EXCEPTIONS_DEFINE_ANCHOR(T)                                         \
-        void T::anchor() {}
+// clang-format off
+// clang format bug: `void T::anchor() {}` bin-packed since Clang 15.0
+#    define VGC_CORE_EXCEPTIONS_DEFINE_ANCHOR(T) void T::anchor() {}
+// clang-format on
 #else
 #    define VGC_CORE_EXCEPTIONS_DECLARE_ANCHOR
 #    define VGC_CORE_EXCEPTIONS_DEFINE_ANCHOR(T)

--- a/libs/vgc/core/object.h
+++ b/libs/vgc/core/object.h
@@ -1079,9 +1079,9 @@ protected:
     /// allows `Foo` children may define:
     ///
     /// ```cpp
-    /// void Foo::insertChildBefore(Foo* child, Foo* nextSibling)
+    /// void Foo::insertChildBefore(Foo* nextSibling, Foo* child)
     /// {
-    ///     Object::insertChildObject_(child, nextSibling);
+    ///     Object::insertChildObject_(nextSibling, child);
     /// }
     /// ```
     ///


### PR DESCRIPTION
#1116