### PR TITLE
Fix uncutAtKeyVertex() generating invalid cycles; Fix prepareUncutAtKeyVertex_() returning false-negatives; Check vertices match in KeyCycle::isValid() (#1161)

### DIFF
--- a/libs/vgc/vacomplex/keycycle.h
+++ b/libs/vgc/vacomplex/keycycle.h
@@ -98,7 +98,7 @@ public:
 
     bool isValid() const {
         if (steinerVertex_) {
-            return !halfedges_.isEmpty();
+            return halfedges_.isEmpty();
         }
         else if (!halfedges_.isEmpty()) {
             KeyVertex* kv = halfedges_.last().endVertex();

--- a/libs/vgc/vacomplex/keycycle.h
+++ b/libs/vgc/vacomplex/keycycle.h
@@ -97,7 +97,20 @@ public:
     }
 
     bool isValid() const {
-        return steinerVertex_ || !halfedges_.isEmpty();
+        if (steinerVertex_) {
+            return !halfedges_.isEmpty();
+        }
+        else if (!halfedges_.isEmpty()) {
+            KeyVertex* kv = halfedges_.last().endVertex();
+            for (const KeyHalfedge& khe : halfedges_) {
+                if (kv != khe.startVertex()) {
+                    return false;
+                }
+                kv = khe.endVertex();
+            }
+            return true;
+        }
+        return false;
     }
 
     void debugPrint(core::StringWriter& out) const;


### PR DESCRIPTION
#1161