### PR TITLE
Enforce order of qualifiers with clang-format (#797)

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -15,10 +15,10 @@ jobs:
           clang-format --version
           cd libs
           find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -i
-          find . -iname '*.h' -o -iname '*.cpp' | sed -i 's/explicit\ constexpr/constexpr\ explicit/g'
+          find . -iname '*.h' -o -iname '*.cpp' | xargs sed -i 's/explicit\ constexpr/constexpr\ explicit/g'
           cd ../apps
           find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -i
-          find . -iname '*.h' -o -iname '*.cpp' | sed -i 's/explicit\ constexpr/constexpr\ explicit/g'
+          find . -iname '*.h' -o -iname '*.cpp' | xargs sed -i 's/explicit\ constexpr/constexpr\ explicit/g'
           cd ..
 
       - name: Compute and save diff

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -15,8 +15,10 @@ jobs:
           clang-format --version
           cd libs
           find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -i
+          find . -iname '*.h' -o -iname '*.cpp' | sed -i 's/explicit\ constexpr/constexpr\ explicit/g'
           cd ../apps
           find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -i
+          find . -iname '*.h' -o -iname '*.cpp' | sed -i 's/explicit\ constexpr/constexpr\ explicit/g'
           cd ..
 
       - name: Compute and save diff

--- a/.github/workflows/clang-format-comment.yml
+++ b/.github/workflows/clang-format-comment.yml
@@ -47,7 +47,7 @@ jobs:
                      + "This is an automated message to let you know that there are a few formatting changes "
                      + "that should be made in order to adhere to our [C++ Style Guide](https://github.com/vgc/vgc/blob/master/cppstyleguide.md).\n\n"
                      + "You can either:\n\n"
-                     + "1. call `clang-format -i somefile.cpp` on each of the `*.cpp` and `*.h` files that you changed, or\n"
+                     + "1. manually modify and/or call `clang-format -i somefile.cpp` on the files with non-conforming style, or\n"
                      + "2. copy-paste the patch below in a text file (make sure that it ends with a newline), save it and call `git apply clangformat.patch`\n\n"
                      + "Then make a new commit that contains the formatting changes, and push again.\n\n"
                      + "If clang-format makes your code ugly, it can usually be solved with minimal refactoring, such as using temporary variables or helper functions to make lines of code shorter. "

--- a/apps/.clang-format
+++ b/apps/.clang-format
@@ -50,6 +50,10 @@ ForEachMacros:
 IndentPPDirectives: AfterHash
 IndentWidth: 4
 PointerAlignment: Left
+QualifierAlignment: Custom
+QualifierOrder: ['static', 'inline', 'volatile', 'restrict', 'constexpr', 'const', 'type']
+# Note: the above are the only qualifiers supported in clang-format 14.
+# 'friend' is added to v16. As of v18, no other qualifiers are added.
 ReflowComments:  false
 SpaceAfterTemplateKeyword: false
 StatementAttributeLikeMacros:

--- a/apps/.clang-format
+++ b/apps/.clang-format
@@ -50,10 +50,15 @@ ForEachMacros:
 IndentPPDirectives: AfterHash
 IndentWidth: 4
 PointerAlignment: Left
+
+# Order of qualifiers/specifiers. Notes:
+# - The qualifiers/specifiers used below are the only ones supported in clang-format 14.
+# - 'friend' is added to clang-format 16. No others added as of clang-format 18.
+# - 'restrict' is a C keyword, not standard in C++.
+#
 QualifierAlignment: Custom
-QualifierOrder: ['static', 'inline', 'volatile', 'restrict', 'constexpr', 'const', 'type']
-# Note: the above are the only qualifiers supported in clang-format 14.
-# 'friend' is added to v16. As of v18, no other qualifiers are added.
+QualifierOrder: ['static', 'inline', 'constexpr', 'const', 'volatile', 'type', 'restrict']
+
 ReflowComments:  false
 SpaceAfterTemplateKeyword: false
 StatementAttributeLikeMacros:

--- a/cppstyleguide.md
+++ b/cppstyleguide.md
@@ -440,60 +440,35 @@ T int_cast(U value) {
 }
 ```
 
-## Keyword Order
+## Ordering of Type Qualifiers and Specifiers
 
-Follow this [keyword order convention](https://quuxplusone.github.io/blog/2021/04/03/static-constexpr-whittling-knife/):
+There is no concensus in the C++ community regarding the best order to use for type qualifiers and specifiers.
 
-```
-attributes-friendness-storage-constness-virtualness-explicitness-signedness-length-type
-```
+Some opinions with rationale are given below:
+- [Arthur O’Dwyer' article](https://quuxplusone.github.io/blog/2021/04/03/static-constexpr-whittling-knife/)
+- [Reddit thread 1](https://www.reddit.com/r/cpp/comments/ml73y3/arthur_odwyer_static_constexpr_unsigned_long_is/)
+- [Reddit thread 2](https://www.reddit.com/r/cpp/comments/12w0k42/is_there_an_accepted_way_to_order_qualifiers/)
 
+Our order is the following (from left to right, including within categories):
+
+Specifiers:
 - attributes: `[[maybe_unused]]`, `[[nodiscard]]`, etc.
 - friendness: `friend`
-- storage: `extern`, `static`, `inline`, `thread_local`, `mutable`
-- constness: `const`, `constexpr`, `consteval`, `constinit`
-- virtualness: `virtual`
-- explicitness: `explicit`
+- storage: `extern`, `static`, `inline`, `thread_local`
+- constexprness: `constexpr`, `consteval`, `constinit`
+- class member specifiers: `virtual`, `explicit`, `mutable`
+
+Type qualifiers:
+- cv-qualifiers: `const`, `volatile`
 - signedness: `signed`, `unsigned`
 - length: `short`, `long`, `long long`
 - type: `int`, etc.
 
-The idea is that the "most important" qualifiers must be placed closer to the variable/function name.
-
-Examples:
-
-```cpp
-template<int dimension>
-class Foo {
-public:
-    static constexpr dimension = 1;
-    static constexpr createFoo();
-    constexpr explicit Foo(const Bar& bar);
-};
-
-void foo() {
-    static constexpr unsigned long int x = 10;
-}
-```
-
-Note that the keyword `static` has [three meanings](https://en.cppreference.com/w/cpp/keyword/static):
-
-- For namespace members: specifies static storage duration and internal linkage
-- For block-scope variables: specifies static storage duration and initialized once
-- For class members: specifies that it is not bound to a specific instance
-
-Only the first two meanings are about storage, so it would make sense, when
-used for the third meaning, to place the keywork `static` at the same level
-as "virtualness". Inded, for class methods, both `virtual` and `static` have
-the same level of importance and are definitely more important than `constexpr`
-since they affect the API.
-
-However, since the order `static constexpr` is in practice heavilly preferred
-by the community in template metaprogramming, and since it would be harder
-both for humans and machines (e.g., a Python script) to enforce consistent
-keyword order if it was context-dependent, our policy is to always use the
-order `static constexpr` even in situations where the opposite order would
-make more sense.
+The general idea is that we prefer "more important" specifiers/qualifiers to
+be placed closer to the identifier name, except when there is already a
+widespread convention. For example example, `static constexpr` is idiomatic
+in template metaprogramming, even though `static` is arguably more important
+than `constexpr`.
 
 ## Polymorphic Classes
 

--- a/libs/.clang-format
+++ b/libs/.clang-format
@@ -50,6 +50,10 @@ ForEachMacros:
 IndentPPDirectives: AfterHash
 IndentWidth: 4
 PointerAlignment: Left
+QualifierAlignment: Custom
+QualifierOrder: ['static', 'inline', 'volatile', 'restrict', 'constexpr', 'const', 'type']
+# Note: the above are the only qualifiers supported in clang-format 14.
+# 'friend' is added to v16. As of v18, no other qualifiers are added.
 ReflowComments:  false
 SpaceAfterTemplateKeyword: false
 StatementAttributeLikeMacros:

--- a/libs/.clang-format
+++ b/libs/.clang-format
@@ -50,10 +50,15 @@ ForEachMacros:
 IndentPPDirectives: AfterHash
 IndentWidth: 4
 PointerAlignment: Left
+
+# Order of qualifiers/specifiers. Notes:
+# - The qualifiers/specifiers used below are the only ones supported in clang-format 14.
+# - 'friend' is added to clang-format 16. No others added as of clang-format 18.
+# - 'restrict' is a C keyword, not standard in C++.
+#
 QualifierAlignment: Custom
-QualifierOrder: ['static', 'inline', 'volatile', 'restrict', 'constexpr', 'const', 'type']
-# Note: the above are the only qualifiers supported in clang-format 14.
-# 'friend' is added to v16. As of v18, no other qualifiers are added.
+QualifierOrder: ['static', 'inline', 'constexpr', 'const', 'volatile', 'type', 'restrict']
+
 ReflowComments:  false
 SpaceAfterTemplateKeyword: false
 StatementAttributeLikeMacros:

--- a/libs/vgc/core/flags.h
+++ b/libs/vgc/core/flags.h
@@ -47,7 +47,7 @@ public:
         return ::vgc::core::toUnderlying(v_);
     }
 
-    explicit constexpr operator bool() const noexcept {
+    constexpr explicit operator bool() const noexcept {
         return toUnderlying() != 0;
     }
 

--- a/libs/vgc/core/logging.h
+++ b/libs/vgc/core/logging.h
@@ -176,20 +176,20 @@ private:
     class VGC_PP_EXPAND(API) ClassName VGC_DECLARE_LOG_CATEGORY_IMPL_(                   \
         ClassName, compileTimeEnabledLevels)
 
+// clang-format off
+// clang format bug: `name) {}` and `{ return instance_; }` bin-packed since Clang 15.0
 #define VGC_DECLARE_LOG_CATEGORY_IMPL_(ClassName, compileTimeEnabledLevels)              \
     : public ::vgc::core::LogCategory<::vgc::core::LogLevel::compileTimeEnabledLevels> { \
         friend class ::vgc::core::LogCategoryRegistry;                                   \
         static ClassName* instance_;                                                     \
         ClassName(::vgc::core::StringId name)                                            \
             : ::vgc::core::LogCategory<::vgc::core::LogLevel::compileTimeEnabledLevels>( \
-                name) {                                                                  \
-        }                                                                                \
+                name) {}                                                                 \
                                                                                          \
     public:                                                                              \
-        static ClassName* instance() {                                                   \
-            return instance_;                                                            \
-        }                                                                                \
+        static ClassName* instance() { return instance_; }                               \
     };
+// clang-format on
 
 /// Declares a log category of type `ClassName` whose enabled levels can be can
 /// be controlled at compile-time. For example, if we give `Warning` to the

--- a/libs/vgc/core/span.h
+++ b/libs/vgc/core/span.h
@@ -138,7 +138,7 @@ public:
         typename IntType,
         Int e_ = extent,
         VGC_REQUIRES(e_ != dynamicExtent && std::is_arithmetic_v<IntType>)>
-    explicit constexpr Span(T* first, IntType length)
+    constexpr explicit Span(T* first, IntType length)
         : pair_(first, int_cast<Int>(length)) {
 
         checkLengthForInit_(length);
@@ -163,7 +163,7 @@ public:
     }
     /// \overload
     template<Int e_ = extent, VGC_REQUIRES(e_ != dynamicExtent)>
-    explicit constexpr Span(T* first, T* last)
+    constexpr explicit Span(T* first, T* last)
         : pair_(first, int_cast<Int>(std::distance(first, last))) {
 
         checkLengthForInit_(std::distance(first, last));

--- a/libs/vgc/dom/value.h
+++ b/libs/vgc/dom/value.h
@@ -139,7 +139,7 @@ public:
     using Base::Base;
 
     template<typename U = T>
-    explicit constexpr NoneOr(U&& value)
+    constexpr explicit NoneOr(U&& value)
         : Base(std::forward<U>(value)) {
     }
 
@@ -931,7 +931,7 @@ public:
     }
 
 private:
-    explicit constexpr Value(InvalidValue x)
+    constexpr explicit Value(InvalidValue x)
         : var_(x) {
     }
 

--- a/libs/vgc/geometry/fillstyle.h
+++ b/libs/vgc/geometry/fillstyle.h
@@ -53,7 +53,7 @@ public:
 
     /// Creates a `FillStyle` with the given winding rule.
     ///
-    explicit constexpr FillStyle(WindingRule windingRule) noexcept
+    constexpr explicit FillStyle(WindingRule windingRule) noexcept
         : windingRule_(windingRule) {
     }
 

--- a/libs/vgc/geometry/fillstyle.h
+++ b/libs/vgc/geometry/fillstyle.h
@@ -53,7 +53,7 @@ public:
 
     /// Creates a `FillStyle` with the given winding rule.
     ///
-    constexpr explicit FillStyle(WindingRule windingRule) noexcept
+    explicit constexpr FillStyle(WindingRule windingRule) noexcept
         : windingRule_(windingRule) {
     }
 

--- a/libs/vgc/geometry/mat2d.h
+++ b/libs/vgc/geometry/mat2d.h
@@ -76,7 +76,7 @@ public:
     /// value. As specific cases, the null matrix is Mat2d(0), and the identity
     /// matrix is Mat2d(1).
     ///
-    explicit constexpr Mat2d(double d) noexcept
+    constexpr explicit Mat2d(double d) noexcept
         : data_{{d, 0},
                 {0, d}} {
     }
@@ -89,7 +89,7 @@ public:
             isMat<TMat2>
          && TMat2::dimension == 2
          && !std::is_same_v<TMat2, Mat2d>)>
-    explicit constexpr Mat2d(const TMat2& other) noexcept
+    constexpr explicit Mat2d(const TMat2& other) noexcept
         : data_{{static_cast<double>(other(0, 0)),
                  static_cast<double>(other(1, 0))},
                 {static_cast<double>(other(0, 1)),

--- a/libs/vgc/geometry/mat2f.h
+++ b/libs/vgc/geometry/mat2f.h
@@ -76,7 +76,7 @@ public:
     /// value. As specific cases, the null matrix is Mat2f(0), and the identity
     /// matrix is Mat2f(1).
     ///
-    explicit constexpr Mat2f(float d) noexcept
+    constexpr explicit Mat2f(float d) noexcept
         : data_{{d, 0},
                 {0, d}} {
     }
@@ -89,7 +89,7 @@ public:
             isMat<TMat2>
          && TMat2::dimension == 2
          && !std::is_same_v<TMat2, Mat2f>)>
-    explicit constexpr Mat2f(const TMat2& other) noexcept
+    constexpr explicit Mat2f(const TMat2& other) noexcept
         : data_{{static_cast<float>(other(0, 0)),
                  static_cast<float>(other(1, 0))},
                 {static_cast<float>(other(0, 1)),

--- a/libs/vgc/geometry/mat3d.h
+++ b/libs/vgc/geometry/mat3d.h
@@ -84,7 +84,7 @@ public:
     /// value. As specific cases, the null matrix is Mat3d(0), and the identity
     /// matrix is Mat3d(1).
     ///
-    explicit constexpr Mat3d(double d) noexcept
+    constexpr explicit Mat3d(double d) noexcept
         : data_{{d, 0, 0},
                 {0, d, 0},
                 {0, 0, d}} {
@@ -98,7 +98,7 @@ public:
             isMat<TMat3>
          && TMat3::dimension == 3
          && !std::is_same_v<TMat3, Mat3d>)>
-    explicit constexpr Mat3d(const TMat3& other) noexcept
+    constexpr explicit Mat3d(const TMat3& other) noexcept
         : data_{{static_cast<double>(other(0, 0)),
                  static_cast<double>(other(1, 0)),
                  static_cast<double>(other(2, 0))},

--- a/libs/vgc/geometry/mat3f.h
+++ b/libs/vgc/geometry/mat3f.h
@@ -84,7 +84,7 @@ public:
     /// value. As specific cases, the null matrix is Mat3f(0), and the identity
     /// matrix is Mat3f(1).
     ///
-    explicit constexpr Mat3f(float d) noexcept
+    constexpr explicit Mat3f(float d) noexcept
         : data_{{d, 0, 0},
                 {0, d, 0},
                 {0, 0, d}} {
@@ -98,7 +98,7 @@ public:
             isMat<TMat3>
          && TMat3::dimension == 3
          && !std::is_same_v<TMat3, Mat3f>)>
-    explicit constexpr Mat3f(const TMat3& other) noexcept
+    constexpr explicit Mat3f(const TMat3& other) noexcept
         : data_{{static_cast<float>(other(0, 0)),
                  static_cast<float>(other(1, 0)),
                  static_cast<float>(other(2, 0))},

--- a/libs/vgc/geometry/mat4d.h
+++ b/libs/vgc/geometry/mat4d.h
@@ -89,7 +89,7 @@ public:
     /// value. As specific cases, the null matrix is Mat4d(0), and the identity
     /// matrix is Mat4d(1).
     ///
-    explicit constexpr Mat4d(double d) noexcept
+    constexpr explicit Mat4d(double d) noexcept
         : data_{{d, 0, 0, 0},
                 {0, d, 0, 0},
                 {0, 0, d, 0},
@@ -104,7 +104,7 @@ public:
             isMat<TMat4>
          && TMat4::dimension == 4
          && !std::is_same_v<TMat4, Mat4d>)>
-    explicit constexpr Mat4d(const TMat4& other) noexcept
+    constexpr explicit Mat4d(const TMat4& other) noexcept
         : data_{{static_cast<double>(other(0, 0)),
                  static_cast<double>(other(1, 0)),
                  static_cast<double>(other(2, 0)),

--- a/libs/vgc/geometry/mat4f.h
+++ b/libs/vgc/geometry/mat4f.h
@@ -89,7 +89,7 @@ public:
     /// value. As specific cases, the null matrix is Mat4f(0), and the identity
     /// matrix is Mat4f(1).
     ///
-    explicit constexpr Mat4f(float d) noexcept
+    constexpr explicit Mat4f(float d) noexcept
         : data_{{d, 0, 0, 0},
                 {0, d, 0, 0},
                 {0, 0, d, 0},
@@ -104,7 +104,7 @@ public:
             isMat<TMat4>
          && TMat4::dimension == 4
          && !std::is_same_v<TMat4, Mat4f>)>
-    explicit constexpr Mat4f(const TMat4& other) noexcept
+    constexpr explicit Mat4f(const TMat4& other) noexcept
         : data_{{static_cast<float>(other(0, 0)),
                  static_cast<float>(other(1, 0)),
                  static_cast<float>(other(2, 0)),

--- a/libs/vgc/geometry/strokestyle.h
+++ b/libs/vgc/geometry/strokestyle.h
@@ -89,13 +89,13 @@ public:
 
     /// Creates `StrokeStyle` with the given cap style.
     ///
-    explicit constexpr StrokeStyle(StrokeCap cap) noexcept
+    constexpr explicit StrokeStyle(StrokeCap cap) noexcept
         : cap_(cap) {
     }
 
     /// Creates `StrokeStyle` with the given join style.
     ///
-    explicit constexpr StrokeStyle(StrokeJoin join, double miterLimit = 4.0) noexcept
+    constexpr explicit StrokeStyle(StrokeJoin join, double miterLimit = 4.0) noexcept
         : miterLimit_(miterLimit)
         , join_(join) {
     }

--- a/libs/vgc/geometry/tools/mat2x.h
+++ b/libs/vgc/geometry/tools/mat2x.h
@@ -76,7 +76,7 @@ public:
     /// value. As specific cases, the null matrix is Mat2x(0), and the identity
     /// matrix is Mat2x(1).
     ///
-    explicit constexpr Mat2x(float d) noexcept
+    constexpr explicit Mat2x(float d) noexcept
         : data_{{d, 0},
                 {0, d}} {
     }
@@ -89,7 +89,7 @@ public:
             isMat<TMat2>
          && TMat2::dimension == 2
          && !std::is_same_v<TMat2, Mat2x>)>
-    explicit constexpr Mat2x(const TMat2& other) noexcept
+    constexpr explicit Mat2x(const TMat2& other) noexcept
         : data_{{static_cast<float>(other(0, 0)),
                  static_cast<float>(other(1, 0))},
                 {static_cast<float>(other(0, 1)),

--- a/libs/vgc/geometry/tools/mat3x.h
+++ b/libs/vgc/geometry/tools/mat3x.h
@@ -84,7 +84,7 @@ public:
     /// value. As specific cases, the null matrix is Mat3x(0), and the identity
     /// matrix is Mat3x(1).
     ///
-    explicit constexpr Mat3x(float d) noexcept
+    constexpr explicit Mat3x(float d) noexcept
         : data_{{d, 0, 0},
                 {0, d, 0},
                 {0, 0, d}} {
@@ -98,7 +98,7 @@ public:
             isMat<TMat3>
          && TMat3::dimension == 3
          && !std::is_same_v<TMat3, Mat3x>)>
-    explicit constexpr Mat3x(const TMat3& other) noexcept
+    constexpr explicit Mat3x(const TMat3& other) noexcept
         : data_{{static_cast<float>(other(0, 0)),
                  static_cast<float>(other(1, 0)),
                  static_cast<float>(other(2, 0))},

--- a/libs/vgc/geometry/tools/mat4x.h
+++ b/libs/vgc/geometry/tools/mat4x.h
@@ -89,7 +89,7 @@ public:
     /// value. As specific cases, the null matrix is Mat4x(0), and the identity
     /// matrix is Mat4x(1).
     ///
-    explicit constexpr Mat4x(float d) noexcept
+    constexpr explicit Mat4x(float d) noexcept
         : data_{{d, 0, 0, 0},
                 {0, d, 0, 0},
                 {0, 0, d, 0},
@@ -104,7 +104,7 @@ public:
             isMat<TMat4>
          && TMat4::dimension == 4
          && !std::is_same_v<TMat4, Mat4x>)>
-    explicit constexpr Mat4x(const TMat4& other) noexcept
+    constexpr explicit Mat4x(const TMat4& other) noexcept
         : data_{{static_cast<float>(other(0, 0)),
                  static_cast<float>(other(1, 0)),
                  static_cast<float>(other(2, 0)),

--- a/libs/vgc/geometry/tools/vec2x.h
+++ b/libs/vgc/geometry/tools/vec2x.h
@@ -84,7 +84,7 @@ public:
             isVec<TVec2>
          && TVec2::dimension == 2
          && !std::is_same_v<TVec2, Vec2x>)>
-    explicit constexpr Vec2x(const TVec2& other) noexcept
+    constexpr explicit Vec2x(const TVec2& other) noexcept
         : data_{static_cast<float>(other[0]),
                 static_cast<float>(other[1])} {
     }

--- a/libs/vgc/geometry/tools/vec3x.h
+++ b/libs/vgc/geometry/tools/vec3x.h
@@ -79,7 +79,7 @@ public:
             isVec<TVec3>
          && TVec3::dimension == 3
          && !std::is_same_v<TVec3, Vec3x>)>
-    explicit constexpr Vec3x(const TVec3& other) noexcept
+    constexpr explicit Vec3x(const TVec3& other) noexcept
         : data_{static_cast<float>(other[0]),
                 static_cast<float>(other[1]),
                 static_cast<float>(other[2])} {

--- a/libs/vgc/geometry/tools/vec4x.h
+++ b/libs/vgc/geometry/tools/vec4x.h
@@ -82,7 +82,7 @@ public:
             isVec<TVec4>
          && TVec4::dimension == 4
          && !std::is_same_v<TVec4, Vec4x>)>
-    explicit constexpr Vec4x(const TVec4& other) noexcept
+    constexpr explicit Vec4x(const TVec4& other) noexcept
         : data_{static_cast<float>(other[0]),
                 static_cast<float>(other[1]),
                 static_cast<float>(other[2]),

--- a/libs/vgc/geometry/vec2d.h
+++ b/libs/vgc/geometry/vec2d.h
@@ -84,7 +84,7 @@ public:
             isVec<TVec2>
          && TVec2::dimension == 2
          && !std::is_same_v<TVec2, Vec2d>)>
-    explicit constexpr Vec2d(const TVec2& other) noexcept
+    constexpr explicit Vec2d(const TVec2& other) noexcept
         : data_{static_cast<double>(other[0]),
                 static_cast<double>(other[1])} {
     }

--- a/libs/vgc/geometry/vec2f.h
+++ b/libs/vgc/geometry/vec2f.h
@@ -84,7 +84,7 @@ public:
             isVec<TVec2>
          && TVec2::dimension == 2
          && !std::is_same_v<TVec2, Vec2f>)>
-    explicit constexpr Vec2f(const TVec2& other) noexcept
+    constexpr explicit Vec2f(const TVec2& other) noexcept
         : data_{static_cast<float>(other[0]),
                 static_cast<float>(other[1])} {
     }

--- a/libs/vgc/geometry/vec3d.h
+++ b/libs/vgc/geometry/vec3d.h
@@ -79,7 +79,7 @@ public:
             isVec<TVec3>
          && TVec3::dimension == 3
          && !std::is_same_v<TVec3, Vec3d>)>
-    explicit constexpr Vec3d(const TVec3& other) noexcept
+    constexpr explicit Vec3d(const TVec3& other) noexcept
         : data_{static_cast<double>(other[0]),
                 static_cast<double>(other[1]),
                 static_cast<double>(other[2])} {

--- a/libs/vgc/geometry/vec3f.h
+++ b/libs/vgc/geometry/vec3f.h
@@ -79,7 +79,7 @@ public:
             isVec<TVec3>
          && TVec3::dimension == 3
          && !std::is_same_v<TVec3, Vec3f>)>
-    explicit constexpr Vec3f(const TVec3& other) noexcept
+    constexpr explicit Vec3f(const TVec3& other) noexcept
         : data_{static_cast<float>(other[0]),
                 static_cast<float>(other[1]),
                 static_cast<float>(other[2])} {

--- a/libs/vgc/geometry/vec4d.h
+++ b/libs/vgc/geometry/vec4d.h
@@ -82,7 +82,7 @@ public:
             isVec<TVec4>
          && TVec4::dimension == 4
          && !std::is_same_v<TVec4, Vec4d>)>
-    explicit constexpr Vec4d(const TVec4& other) noexcept
+    constexpr explicit Vec4d(const TVec4& other) noexcept
         : data_{static_cast<double>(other[0]),
                 static_cast<double>(other[1]),
                 static_cast<double>(other[2]),

--- a/libs/vgc/geometry/vec4f.h
+++ b/libs/vgc/geometry/vec4f.h
@@ -82,7 +82,7 @@ public:
             isVec<TVec4>
          && TVec4::dimension == 4
          && !std::is_same_v<TVec4, Vec4f>)>
-    explicit constexpr Vec4f(const TVec4& other) noexcept
+    constexpr explicit Vec4f(const TVec4& other) noexcept
         : data_{static_cast<float>(other[0]),
                 static_cast<float>(other[1]),
                 static_cast<float>(other[2]),

--- a/libs/vgc/graphics/resource.h
+++ b/libs/vgc/graphics/resource.h
@@ -276,7 +276,7 @@ public:
         return static_cast<U*>(p_);
     }
 
-    explicit constexpr operator bool() const noexcept {
+    constexpr explicit operator bool() const noexcept {
         return p_ != nullptr;
     }
 

--- a/libs/vgc/ui/margins.h
+++ b/libs/vgc/ui/margins.h
@@ -69,7 +69,7 @@ public:
     /// Constructs a `Margins` with top, right, bottom, and left respectively
     /// set to x, y, z, and w of `v`.
     ///
-    explicit constexpr Margins(const geometry::Vec4f& v)
+    constexpr explicit Margins(const geometry::Vec4f& v)
         : v_(v) {
     }
 

--- a/libs/vgc/vacomplex/cell.h
+++ b/libs/vgc/vacomplex/cell.h
@@ -994,7 +994,7 @@ private:
     friend detail::Operations;
 
 protected:
-    explicit constexpr KeyCell(const core::AnimTime& time) noexcept
+    constexpr explicit KeyCell(const core::AnimTime& time) noexcept
         : CellProxy<KeyCell>()
         , time_(time) {
     }
@@ -1032,7 +1032,7 @@ private:
     friend detail::Operations;
 
 protected:
-    explicit constexpr InbetweenCell() noexcept
+    constexpr explicit InbetweenCell() noexcept
         : CellProxy<InbetweenCell>() {
     }
 


### PR DESCRIPTION
#797

Our preferred qualifier order is:

```
attributes-friendness-storage-constness-virtualness-explicitness-signedness-length-type
```
- attributes: `[[maybe_unused]]`, `[[nodiscard]]`, etc.
- friendness: `friend`
- storage: `extern`, `static`, `inline`, `thread_local`, `mutable`
- constness: `const`, `constexpr`, `consteval`, `constinit`
- virtualness: `virtual`
- explicitness: `explicit`
- signedness: `signed`, `unsigned`
- length: `short`, `long`, `long long`
- type: `int`, etc.

(see our C++ guidelines and this commit: https://github.com/vgc/vgc/commit/a878dbe918e2d70aa4d4a205a8b0a8f4eaef89ae)

Note however that `clang-format` only supports a limited number of qualifiers, see:

https://clang.llvm.org/docs/ClangFormatStyleOptions.html#qualifierorder

Notably, `explicit` is not supported, so I manually reordered the instances of `explicit constexpr` to `constexpr explicit`.