### PR TITLE
Fix geometry snapping after glue: BoundaryGeometryChanged must be set whenever BoundaryChanged is set (#992)

### DIFF
--- a/libs/vgc/vacomplex/complex.h
+++ b/libs/vgc/vacomplex/complex.h
@@ -153,7 +153,7 @@ enum class NodeModificationFlag : UInt32 {
     //TransformChanged        = 0x80,
 
     /// This flag is set whenever:
-    /// - `BoundaryChanged` is set on this cell, or
+    /// - `BoundaryChanged` is set on the cell, or
     /// - `GeometryChanged` is set on at least one cell in the boundary of the
     ///    cell.
     ///

--- a/libs/vgc/vacomplex/complex.h
+++ b/libs/vgc/vacomplex/complex.h
@@ -152,8 +152,10 @@ enum class NodeModificationFlag : UInt32 {
     //
     //TransformChanged        = 0x80,
 
-    /// This flag is set whenever `GeometryChanged` is set on at least one cell in
-    /// the boundary of the cell.
+    /// This flag is set whenever:
+    /// - `BoundaryChanged` is set on this cell, or
+    /// - `GeometryChanged` is set on at least one cell in the boundary of the
+    ///    cell.
     ///
     BoundaryGeometryChanged = 0x100,
 

--- a/libs/vgc/vacomplex/detail/operationsimpl.cpp
+++ b/libs/vgc/vacomplex/detail/operationsimpl.cpp
@@ -2852,6 +2852,7 @@ void Operations::onBoundaryChanged_(Cell* boundedCell, Cell* boundingCell) {
     onNodeModified_(
         boundedCell,
         {NodeModificationFlag::BoundaryChanged,
+         NodeModificationFlag::BoundaryGeometryChanged,
          NodeModificationFlag::BoundaryMeshChanged});
     onNodeModified_(boundingCell, NodeModificationFlag::StarChanged);
     dirtyMesh_(boundedCell);


### PR DESCRIPTION
#992