### PR TITLE
Fix Enum::fullName() doesn't include namespace with AppleClang 15 (#517)

### DIFF
--- a/libs/vgc/core/tests/test_format.cpp
+++ b/libs/vgc/core/tests/test_format.cpp
@@ -659,6 +659,20 @@ TEST(TestFormat, Enum) {
     using vgc::foo::MyEnum;
     using vgc::foo::VeryLongEnum;
 
+    // clang-format off
+    std::string_view prettyFunction1 =
+        "const class vgc::core::detail::EnumData &__cdecl vgc::ui::enumData_(enum vgc::ui::Key)";
+    std::string_view prettyFunction2 =
+        "const ::vgc::core::detail::EnumData &vgc::ui::enumData_(Key)";
+    // clang-format on
+
+    EXPECT_EQ(vgc::core::detail::fullEnumClassName(prettyFunction1), "vgc::ui::Key");
+    EXPECT_EQ(vgc::core::detail::fullEnumClassName(prettyFunction2), "vgc::ui::Key");
+
+    EXPECT_EQ(Enum::shortName(MyEnum::MyValue), "MyValue");
+    EXPECT_EQ(Enum::fullName(MyEnum::MyValue), "vgc::foo::MyEnum::MyValue");
+    EXPECT_EQ(Enum::prettyName(MyEnum::MyValue), "My Value");
+
     std::string s1 = format("{:-^29}", MyEnum::MyValue);
     std::string_view s2 = Enum::prettyName(MyEnum::MyOtherValue);
     std::string_view s3 = Enum::prettyName(LongEnum::V1);


### PR DESCRIPTION
#517

The problem was that `PRETTY_FUNCTION` was returning a different format, hence our parsing failed. This was caught by test_format.cpp which didn't pass. Now fixed.