### PR TITLE
Make semicolon mandatory after VGC_DECLARE_OBJECT; Remove warnings about superfluous semicolons (#709)

### DIFF
--- a/libs/vgc/core/object.h
+++ b/libs/vgc/core/object.h
@@ -1781,7 +1781,7 @@ inline Int Object::numChildObjects() const {
     using T##ConstPtr = ::vgc::core::ObjPtr<const T>;                                    \
     using T##List = ::vgc::core::ObjList<T>;                                             \
     using T##ListIterator = ::vgc::core::ObjListIterator<T>;                             \
-    using T##ListView = ::vgc::core::ObjListView<T>;
+    using T##ListView = ::vgc::core::ObjListView<T>
 
 namespace vgc::core {
 


### PR DESCRIPTION
#709