### PR TITLE
Fix StandardMenus::createEditMenu() uses fileMenu_ instead of editMenu_ (#1589)

### DIFF
--- a/libs/vgc/ui/standardmenus.cpp
+++ b/libs/vgc/ui/standardmenus.cpp
@@ -71,7 +71,7 @@ MenuWeakPtr StandardMenus::getOrCreateFileMenu() {
 }
 
 void StandardMenus::createEditMenu() {
-    createMenu(fileMenu_, menuBar_, "Edit");
+    createMenu(editMenu_, menuBar_, "Edit");
 }
 
 MenuWeakPtr StandardMenus::getOrCreateEditMenu() {


### PR DESCRIPTION
#1589