### PR TITLE
Remove CMake declaration that ui depends on dom and workspace (#994)

### DIFF
--- a/libs/vgc/ui/CMakeLists.txt
+++ b/libs/vgc/ui/CMakeLists.txt
@@ -5,8 +5,6 @@ vgc_add_library(ui
 
     VGC_DEPENDENCIES
         graphics
-        dom
-        workspace
 
     MACOS_DEPENDENCIES
         "-framework ApplicationServices"


### PR DESCRIPTION
Indeed, it doesn't and shouldn't depend on these libs.

#994