### PR TITLE
Remove NodeModificationFlag::MeshChanged and related (#1602)

### DIFF
--- a/libs/vgc/vacomplex/cell.cpp
+++ b/libs/vgc/vacomplex/cell.cpp
@@ -78,9 +78,6 @@ Complex* Cell::complex() const {
     return p ? p->complex() : nullptr;
 }
 
-void Cell::dirtyMesh() {
-}
-
 bool Cell::updateGeometryFromBoundary() {
     return false;
 }

--- a/libs/vgc/vacomplex/cell.h
+++ b/libs/vgc/vacomplex/cell.h
@@ -963,11 +963,6 @@ public:
     VGC_VACOMPLEX_DEFINE_CELL_CAST_METHOD(InbetweenFace)
 
 protected:
-    void onMeshQueried() const {
-        hasMeshBeenQueriedSinceLastDirtyEvent_ = true;
-    }
-
-    virtual void dirtyMesh();
     virtual bool updateGeometryFromBoundary();
 
 private:
@@ -985,12 +980,6 @@ private:
 private:
     core::Array<Cell*> star_;
     core::Array<Cell*> boundary_;
-
-    // This flag is used to not signal NodeModificationFlag::MeshChanged
-    // multiple times if no dependent nodes nor the user has queried
-    // the new mesh. It should be set to true (either directly
-    // or indirectly) in all mesh getters.
-    mutable bool hasMeshBeenQueriedSinceLastDirtyEvent_ = false;
 };
 
 inline Complex* Node::complex() const {

--- a/libs/vgc/vacomplex/complexdiff.h
+++ b/libs/vgc/vacomplex/complexdiff.h
@@ -83,65 +83,6 @@ enum class NodeModificationFlag : UInt32 {
     ///
     GeometryChanged = 0x10,
 
-    /// This flag is set whenever:
-    ///
-    /// 1. The "mesh" of a node has changed, and
-    ///
-    /// 2. The "mesh" of a node had been queried since the last time
-    ///    this flag was set for this node.
-    ///
-    /// By "mesh", we mean the position of a vertex, the sampling of an edge,
-    /// or the triangulation of a face.
-    ///
-    /// Note that it is possible that the `GeometryChanged` flag is set, while
-    /// the `MeshChanged` flag is not set. This happens when the geometry of
-    /// the node changed (and therefore, its mesh also changed), but had not b
-    ///
-    /// However, if the `MeshChanged` flag is set, then the `GeometryChanged`
-    /// flag is not necessarily set, for example the triangulation of a face
-    /// changes when the geometry of the boundary of the face changes, while
-    /// the geometry of the face itself hasn't necessarily changed.
-    ///
-    // TODO: rename `CachedGeometryChanged`? This would more explicitly conveys
-    // the idea that whether the flag is set or not depends on whether getter
-    // functions where called (there is a mutable state / cache mechanism
-    // involved).
-    //
-    // XXX: Do we actually still need this at all? It would make the API less
-    // confusing and/or error prone with just GeometryChanged (and
-    // BoundaryGeometryChanged). This flag was initially implemented before the
-    // flag BoundaryGeometryChanged existed, and a lot of the architecture has
-    // changed since. In particular, note that the virtual function
-    // `Cell::dirtyMesh()`, always called just before setting this flag,
-    // currently does nothing at all.
-    //
-    // However, we should keep in mind that this flag may still be useful for
-    // the following reasons:
-    //
-    // 1. The mechanism `hasMeshBeenQueriedSinceLastDirtyEvent_` may avoid
-    // recomputing data several times between repaints. But such optimization
-    // should also be achievable (arguable more cleanly) by using dirty flags
-    // in Workspace when receiving GeometryChanged.
-    //
-    // 2. In theory, it prevents writing attributes to the DOM when the
-    // "authored geometry" hasn't changed. But currently, this has no practical
-    // use. Indeed, when the boundary of a face changes, the fact that the face
-    // does not receive GeometryChanged isn't very useful, since nothing would
-    // be written to the DOM anyway (a face has no geometry).
-    //
-    // Note that currently, changing the `strokeSamplingQuality()` is
-    // considered neither a change of the geometry or a change of the mesh. If
-    // this was considered as a change of the mesh, then maybe there would be
-    // more benefits to keep the distinction between geometry change and mesh
-    // change.
-    //
-    // In conclusion, I think it would be worth investigating in more details
-    // and try to remove this with benchmarks and see if there is any benefits
-    // in keeping this. There is cleary a huge maintainance benefit in removing
-    // it: the simpler the better.
-    //
-    MeshChanged = 0x20,
-
     /// This flag is set whenever at least one of the node's properties
     /// has changed, that is, its `cell->data().properties()`
     ///
@@ -160,11 +101,6 @@ enum class NodeModificationFlag : UInt32 {
     ///    cell.
     ///
     BoundaryGeometryChanged = 0x100,
-
-    /// This flag is set whenever `MeshChanged` is set on at least one cell in
-    /// the boundary of the cell.
-    ///
-    BoundaryMeshChanged = 0x200,
 
     /// Convenient enum value with all flags set.
     ///

--- a/libs/vgc/vacomplex/detail/operationsimpl.h
+++ b/libs/vgc/vacomplex/detail/operationsimpl.h
@@ -275,9 +275,6 @@ private:
     friend vacomplex::KeyEdgeData;
 
     void onGeometryChanged_(Cell* cell);
-    void onBoundaryMeshChanged_(Cell* cell);
-    void dirtyMesh_(Cell* cell);
-    void doDirtyMesh_(Cell* cell);
 
     // Adds or remove the `boundingCell` to the boundary of the `boundedCell`.
     //

--- a/libs/vgc/vacomplex/keyedgedata.cpp
+++ b/libs/vgc/vacomplex/keyedgedata.cpp
@@ -362,9 +362,6 @@ KeyEdgeData::computeStrokeSampling_(geometry::CurveSamplingQuality quality) cons
         return geometry::StrokeSampling2d(fakeSamples);
     }
     geometry::StrokeSampling2d sampling = stroke_->computeSampling(quality);
-    if (KeyEdge* ke = keyEdge()) {
-        ke->onMeshQueried();
-    }
     return sampling;
 }
 

--- a/libs/vgc/vacomplex/keyvertex.h
+++ b/libs/vgc/vacomplex/keyvertex.h
@@ -99,12 +99,10 @@ public:
     VGC_VACOMPLEX_DEFINE_SPATIOTEMPORAL_CELL_CAST_METHODS(Key, Vertex)
 
     geometry::Vec2d position() const {
-        onMeshQueried();
         return position_;
     }
 
     geometry::Vec2d position(core::AnimTime /*t*/) const override {
-        onMeshQueried();
         return position_;
     }
 

--- a/libs/vgc/workspace/edge.cpp
+++ b/libs/vgc/workspace/edge.cpp
@@ -977,9 +977,6 @@ void VacKeyEdge::updateFromVac_(vacomplex::NodeModificationFlags flags) {
         // todo: dirty only if really changed ?
         dirtyPreJoinGeometry_(false);
     }
-    else if (flags.has(vacomplex::NodeModificationFlag::MeshChanged)) {
-        dirtyPreJoinGeometry_(false);
-    }
 
     if (flags.has(vacomplex::NodeModificationFlag::PropertyChanged)) {
         // TODO: forward changed property names, and do all only if element

--- a/libs/vgc/workspace/face.cpp
+++ b/libs/vgc/workspace/face.cpp
@@ -564,7 +564,7 @@ void VacKeyFace::updateFromVac_(vacomplex::NodeModificationFlags flags) {
         updateDependencies_(newDependencies);
     }
 
-    if (boundaryChanged || flags.has(NodeModificationFlag::BoundaryMeshChanged)) {
+    if (boundaryChanged || flags.has(NodeModificationFlag::BoundaryGeometryChanged)) {
         dirtyFillMesh_();
     }
 

--- a/libs/vgc/workspace/vertex.cpp
+++ b/libs/vgc/workspace/vertex.cpp
@@ -191,6 +191,8 @@ void VacKeyVertex::onPaintDraw(
                 posF,
                 selectionDiskRadius,
                 colors::selection);
+            // XXX Set data.isSelectionGeometryDirty_ to false?
+            //     This data member is always true at the moment...
         }
 
         core::Array<graphics::detail::ScreenSpaceInstanceData> pointInstData(2);
@@ -271,8 +273,6 @@ void VacKeyVertex::updateFromVac_(vacomplex::NodeModificationFlags flags) {
             domElement->setAttribute(ds::position, kv->position());
             dirtyPosition_();
         }
-    }
-    else if (flags.has(NodeModificationFlag::MeshChanged)) {
         frameData_.isSelectionGeometryDirty_ = true;
     }
 }


### PR DESCRIPTION
#1602

This was basically not used anymore and added unnecessary complexity. All the information (e.g., dirtying face mesh) is already properly propagated by the `onDependencyChanged` system integrated in Workspace.

Also, the current `MeshChanged` system was imperfect anyway: it was using a `hasMeshBeenQueriedSinceLastDirtyEvent_` property, which basically means that the content of the `ComplexDiff` depended on whether or not outside clients had called `vertex->position()` or `edge->computeStrokeSampling(quality)`, even with a different quality than the one cached in the edge data.

As per the (now-deleted by this PR) comment:
```
// This flag is used to not signal NodeModificationFlag::MeshChanged
// multiple times if no dependent nodes nor the user has queried
// the new mesh. It should be set to true (either directly
// or indirectly) in all mesh getters.
mutable bool hasMeshBeenQueriedSinceLastDirtyEvent_ = false;
```

This was initially useful to prevent signalling the mesh modification multiple time. This need was for a previous architecture,  where modifications of the Complex was signalled directly. Now, the modifications are only emitted at the end of the `Operation` (or `OperationGroup`), so this rationale doesn't apply anymore.

We may want to add back later some signalling mechanism to notify of changes in sampling quality, or in what is cached, but I think this should be separate to what's in the `ComplexDiff`.