### PR TITLE
Fix uncutAtKeyEdge() generating invalid cycles (#1161)

### DIFF
--- a/libs/vgc/vacomplex/detail/operationsimpl.cpp
+++ b/libs/vgc/vacomplex/detail/operationsimpl.cpp
@@ -2990,6 +2990,9 @@ Operations::subPath_(const KeyCycle& cycle, Int first, Int last, bool loopIfEmpt
     if (cycle.steinerVertex()) {
         return KeyPath(cycle.steinerVertex());
     }
+    Int n = cycle.halfedges_.length();
+    first = ((first % n) + n) % n;
+    last = ((last % n) + n) % n;
     if (first == last) {
         if (loopIfEmptyRange) {
             return rotatedCycleHalfedges_(cycle, first);
@@ -3000,9 +3003,6 @@ Operations::subPath_(const KeyCycle& cycle, Int first, Int last, bool loopIfEmpt
         }
     }
     else {
-        Int n = cycle.halfedges_.length();
-        first = ((first % n) + n) % n;
-        last = ((last % n) + n) % n;
         core::Array<KeyHalfedge> halfedges;
         for (Int i = first; i != last; i = (i + 1) % n) {
             halfedges.append(cycle.halfedges_[i]);


### PR DESCRIPTION
#1161

The bug was in `subPath_()`: calling `subPath_(cycle, n, 0)` was creating an invalid path instead of a path with a single vertex.

This caused crashes in some cases when using the delete or simplify topological operators. for example deleting this edge:

![image](https://github.com/vgc/vgc/assets/4809739/6d17400f-b8ce-4af5-a2b2-a364b3c2b4fe)

was changing the face from:

```xml
  <face
      cycles="[#e1* #e2 #e3 #e5 #e4 #e1]"
      color="rgb(213, 128, 213)">
  </face>
```

to:

```xml
  <face
      cycles="[#e2 #e3 #e5 #e4, ]"
      color="rgb(213, 128, 213)">
  </face>
```

which wouldn't cause a crash right away, but would indirectly cause crashes after further interactions.

The bug was first noticed when doing "simplify" on the following selection, which would crash the application:

![image](https://github.com/vgc/vgc/assets/4809739/8587c413-643b-429c-a8b5-3c582a20ed61)

It now correctly results in:

![image](https://github.com/vgc/vgc/assets/4809739/18cc0670-0387-4be9-a203-62d6cbb4074b)
