### PR TITLE
Change Explode shortcut from Alt+E to Alt+X to avoid conflict with Select Vertices (#1309)

### DIFF
--- a/libs/vgc/tools/topology.cpp
+++ b/libs/vgc/tools/topology.cpp
@@ -65,7 +65,7 @@ VGC_UI_DEFINE_WINDOW_COMMAND( //
     explode,
     "tools.topology.explode",
     "Explode",
-    Shortcut(alt, Key::E));
+    Shortcut(alt, Key::X));
 
 VGC_UI_DEFINE_WINDOW_COMMAND( //
     simplify,


### PR DESCRIPTION
#1309