### PR TITLE
Fix workspace::Element::tagName() when domElement() is null (#1107)

### DIFF
--- a/libs/vgc/workspace/element.h
+++ b/libs/vgc/workspace/element.h
@@ -161,7 +161,12 @@ public:
     inline vacomplex::Group* vacGroup() const;
 
     core::StringId tagName() const {
-        return domElement_->tagName();
+        if (domElement_) {
+            return domElement_->tagName();
+        }
+        else {
+            return {};
+        }
     }
 
     ElementFlags flags() const {


### PR DESCRIPTION
#1107