### PR TITLE
Update shortcut for Inspect Widgets to Ctrl+Alt+Shift+I (#481)

### DIFF
--- a/libs/vgc/ui/inspector.cpp
+++ b/libs/vgc/ui/inspector.cpp
@@ -28,6 +28,7 @@ namespace {
 
 namespace commands {
 
+using modifierkeys::alt;
 using modifierkeys::ctrl;
 using modifierkeys::shift;
 
@@ -35,7 +36,7 @@ VGC_UI_DEFINE_WINDOW_COMMAND(
     inspectWidgets,
     "ui.inspectWidgets",
     "Inspect Widgets",
-    Shortcut(ctrl | shift, Key::I))
+    Shortcut(ctrl | alt | shift, Key::I))
 
 } // namespace commands
 


### PR DESCRIPTION
#481

This is to prevent collision with Ctrl+Shift+I for invert selection.