### PR TITLE
Fix incorrect margins at the bottom of menus caused by separators (#900)

### DIFF
--- a/libs/vgc/ui/stylesheets/default.vgcss
+++ b/libs/vgc/ui/stylesheets/default.vgcss
@@ -88,7 +88,7 @@
 .Menu > .separator {
     margin-top: 3dp;
     margin-bottom: 3dp;
-    min-height: 1dp;
+    preferred-height: 1dp;
 }
 
 .Menu > .button,


### PR DESCRIPTION
#900