### PR TITLE
Always draw outline filled even when in wireframe mode (#1611)

### DIFF
--- a/libs/vgc/canvas/canvas.cpp
+++ b/libs/vgc/canvas/canvas.cpp
@@ -616,8 +616,6 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
     }
     engine->draw(bgGeometry_);
 
-    engine->setRasterizerState(isWireframeMode_ ? wireframeRS_ : fillRS_);
-
     geometry::Mat4f vm = engine->viewMatrix();
     geometry::Mat4f cameraViewf(camera().viewMatrix());
     engine->pushViewMatrix(vm * cameraViewf);
@@ -643,6 +641,7 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
 
         // Draw Normal
         if (isMeshEnabled) {
+            engine->setRasterizerState(isWireframeMode_ ? wireframeRS_ : fillRS_);
             workspace::PaintOptions paintOptions = commonPaintOptions;
             workspace->visitDepthFirst(
                 [](workspace::Element* /*e*/, Int /*depth*/) {
@@ -656,8 +655,14 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
                 });
         }
 
+        // Note: outline and selection shouldn't be drawn in wireframe, otherwise:
+        // - We cannot see which face is selected.
+        // - They don't look nice (seem to have "holes") while not providing any
+        //   useful data visualization anyway (too thin to see the triangles).
+
         // Draw Outline
         if (isOutlineEnabled) {
+            engine->setRasterizerState(fillRS_);
             workspace::PaintOptions paintOptions = commonPaintOptions;
             paintOptions.set(workspace::PaintOption::Outline);
             workspace->visitDepthFirst(
@@ -674,11 +679,8 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
 
         // Draw Selection
         //
-        // This should never be drawn in wireframe mode, otherwise we cannot
-        // see which face is selected.
-        //
-        engine->setRasterizerState(fillRS_);
         if (!selectedElements.isEmpty()) {
+            engine->setRasterizerState(fillRS_);
             workspace::PaintOptions paintOptions = commonPaintOptions;
             paintOptions.set(workspace::PaintOption::Selected);
             if (isOutlineEnabled) {

--- a/libs/vgc/canvas/canvas.cpp
+++ b/libs/vgc/canvas/canvas.cpp
@@ -640,6 +640,7 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
         bool isOutlineEnabled = (displayMode_ != DisplayMode::Normal);
 
         // Draw Normal
+        //
         if (isMeshEnabled) {
             engine->setRasterizerState(isWireframeMode_ ? wireframeRS_ : fillRS_);
             workspace::PaintOptions paintOptions = commonPaintOptions;
@@ -661,6 +662,7 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
         //   useful data visualization anyway (too thin to see the triangles).
 
         // Draw Outline
+        //
         if (isOutlineEnabled) {
             engine->setRasterizerState(fillRS_);
             workspace::PaintOptions paintOptions = commonPaintOptions;


### PR DESCRIPTION
The outline otherwise doesn't look nice (seem to have “holes”) while not providing any useful data visualization (triangles too thin).

Before:

![image](https://github.com/vgc/vgc/assets/4809739/57ab0816-e84e-4555-97c8-ea7a951bf56b)

After:

![image](https://github.com/vgc/vgc/assets/4809739/4c34af0d-bd35-4c5c-b091-367d53afa20b)
