### PR TITLE
Always draw control points filled even when in wireframe mode (#1611)

### DIFF
--- a/libs/vgc/workspace/edge.cpp
+++ b/libs/vgc/workspace/edge.cpp
@@ -327,7 +327,7 @@ void VacKeyEdge::onPaintDraw(
     constexpr core::Color offsetLine0Color(0.64f, 1.0f, 0.02f, 1.f);
     constexpr core::Color offsetLine1Color(1.0f, 0.02f, 0.64f, 1.f);
 
-    bool isPaintingStroke = !flags.hasAny({PaintOption::Outline, PaintOption::Selected});
+    bool isPaintingStroke = flags.has(PaintOption::Normal);
     bool isPaintingCPs = flags.has(PaintOption::Editing);
     bool isPaintingOutline = flags.has(PaintOption::Outline) || isPaintingCPs;
 

--- a/libs/vgc/workspace/element.h
+++ b/libs/vgc/workspace/element.h
@@ -71,6 +71,7 @@ struct Component {};
 ///
 enum class PaintOption : UInt64 {
     None = 0x00,
+    Normal = 0x01,
     Draft = 0x02,
     Hovered = 0x04,
     Selected = 0x08,

--- a/libs/vgc/workspace/face.cpp
+++ b/libs/vgc/workspace/face.cpp
@@ -209,7 +209,7 @@ void VacKeyFace::onPaintDraw(
         // in the next onPaintDraw(PaintOption::None), we go again in the code
         // path updating the face color.
     }
-    else if (!flags.has(PaintOption::Outline)) {
+    else if (flags.has(PaintOption::Normal)) {
         engine->setProgram(graphics::BuiltinProgram::Simple);
         engine->draw(graphics.fillGeometry());
     }


### PR DESCRIPTION
The control points otherwise don't look nice (seem to have “holes”) while not providing any useful data visualization (triangles too thin).

Also, before this commit, when selected, we would still see the overflowing red "non-selected" control points below the selected control point, since drawing in wireframe makes the drawing slightly wider as the wireframe edges have non-zero width.

Before:

![image](https://github.com/vgc/vgc/assets/4809739/3ac677fc-5c18-4941-a2f7-f2f8d811d901)

After:

![image](https://github.com/vgc/vgc/assets/4809739/cbb6aec1-52ae-42da-bb2b-de0feb7cc669)
