### PR TITLE
Change default matrix formatting from bracket to double parentheses (#673)

### DIFF
--- a/libs/vgc/geometry/mat2d.h
+++ b/libs/vgc/geometry/mat2d.h
@@ -365,8 +365,8 @@ inline void setZero(Mat2d& m) {
 template<typename OStream>
 void write(OStream& out, const Mat2d& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s,
-                    m(1,0), s, m(1,1), ']');
+    write(out, "((", m(0,0), s, m(0,1), "),",
+               " (", m(1,0), s, m(1,1), "))");
 }
 
 } // namespace vgc::geometry
@@ -383,8 +383,8 @@ struct fmt::formatter<vgc::geometry::Mat2d> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat2d& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {},"
-                                   " {}, {}]",
+        return format_to(ctx.out(),"(({}, {}),"
+                                   " ({}, {}))",
                          m(0,0), m(0,1),
                          m(1,0), m(1,1));
     }

--- a/libs/vgc/geometry/mat2f.h
+++ b/libs/vgc/geometry/mat2f.h
@@ -365,8 +365,8 @@ inline void setZero(Mat2f& m) {
 template<typename OStream>
 void write(OStream& out, const Mat2f& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s,
-                    m(1,0), s, m(1,1), ']');
+    write(out, "((", m(0,0), s, m(0,1), "),",
+               " (", m(1,0), s, m(1,1), "))");
 }
 
 } // namespace vgc::geometry
@@ -383,8 +383,8 @@ struct fmt::formatter<vgc::geometry::Mat2f> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat2f& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {},"
-                                   " {}, {}]",
+        return format_to(ctx.out(),"(({}, {}),"
+                                   " ({}, {}))",
                          m(0,0), m(0,1),
                          m(1,0), m(1,1));
     }

--- a/libs/vgc/geometry/mat3d.h
+++ b/libs/vgc/geometry/mat3d.h
@@ -532,9 +532,9 @@ inline void setZero(Mat3d& m) {
 template<typename OStream>
 void write(OStream& out, const Mat3d& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s, m(0,2), s,
-                    m(1,0), s, m(1,1), s, m(1,2), s,
-                    m(2,0), s, m(2,1), s, m(2,2), ']');
+    write(out, "((", m(0,0), s, m(0,1), s, m(0,2), "),",
+               " (", m(1,0), s, m(1,1), s, m(1,2), "),",
+               " (", m(2,0), s, m(2,1), s, m(2,2), "))");
 }
 
 } // namespace vgc::geometry
@@ -551,9 +551,9 @@ struct fmt::formatter<vgc::geometry::Mat3d> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat3d& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {}, {},"
-                                   " {}, {}, {},"
-                                   " {}, {}, {}]",
+        return format_to(ctx.out(),"(({}, {}, {}),"
+                                   " ({}, {}, {}),"
+                                   " ({}, {}, {}))",
                          m(0,0), m(0,1), m(0,2),
                          m(1,0), m(1,1), m(1,2),
                          m(2,0), m(2,1), m(2,2));

--- a/libs/vgc/geometry/mat3f.h
+++ b/libs/vgc/geometry/mat3f.h
@@ -532,9 +532,9 @@ inline void setZero(Mat3f& m) {
 template<typename OStream>
 void write(OStream& out, const Mat3f& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s, m(0,2), s,
-                    m(1,0), s, m(1,1), s, m(1,2), s,
-                    m(2,0), s, m(2,1), s, m(2,2), ']');
+    write(out, "((", m(0,0), s, m(0,1), s, m(0,2), "),",
+               " (", m(1,0), s, m(1,1), s, m(1,2), "),",
+               " (", m(2,0), s, m(2,1), s, m(2,2), "))");
 }
 
 } // namespace vgc::geometry
@@ -551,9 +551,9 @@ struct fmt::formatter<vgc::geometry::Mat3f> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat3f& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {}, {},"
-                                   " {}, {}, {},"
-                                   " {}, {}, {}]",
+        return format_to(ctx.out(),"(({}, {}, {}),"
+                                   " ({}, {}, {}),"
+                                   " ({}, {}, {}))",
                          m(0,0), m(0,1), m(0,2),
                          m(1,0), m(1,1), m(1,2),
                          m(2,0), m(2,1), m(2,2));

--- a/libs/vgc/geometry/mat4d.h
+++ b/libs/vgc/geometry/mat4d.h
@@ -641,10 +641,10 @@ inline void setZero(Mat4d& m) {
 template<typename OStream>
 void write(OStream& out, const Mat4d& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s, m(0,2), s, m(0,3), s,
-                    m(1,0), s, m(1,1), s, m(1,2), s, m(1,3), s,
-                    m(2,0), s, m(2,1), s, m(2,2), s, m(2,3), s,
-                    m(3,0), s, m(3,1), s, m(3,2), s, m(3,3), ']');
+    write(out, "((", m(0,0), s, m(0,1), s, m(0,2), s, m(0,3), "),",
+               " (", m(1,0), s, m(1,1), s, m(1,2), s, m(1,3), "),",
+               " (", m(2,0), s, m(2,1), s, m(2,2), s, m(2,3), "),",
+               " (", m(3,0), s, m(3,1), s, m(3,2), s, m(3,3), "))");
 }
 
 } // namespace vgc::geometry
@@ -661,10 +661,10 @@ struct fmt::formatter<vgc::geometry::Mat4d> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat4d& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {}, {}, {},"
-                                   " {}, {}, {}, {},"
-                                   " {}, {}, {}, {},"
-                                   " {}, {}, {}, {}]",
+        return format_to(ctx.out(),"(({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}))",
                          m(0,0), m(0,1), m(0,2), m(0,3),
                          m(1,0), m(1,1), m(1,2), m(1,3),
                          m(2,0), m(2,1), m(2,2), m(2,3),

--- a/libs/vgc/geometry/mat4f.h
+++ b/libs/vgc/geometry/mat4f.h
@@ -641,10 +641,10 @@ inline void setZero(Mat4f& m) {
 template<typename OStream>
 void write(OStream& out, const Mat4f& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s, m(0,2), s, m(0,3), s,
-                    m(1,0), s, m(1,1), s, m(1,2), s, m(1,3), s,
-                    m(2,0), s, m(2,1), s, m(2,2), s, m(2,3), s,
-                    m(3,0), s, m(3,1), s, m(3,2), s, m(3,3), ']');
+    write(out, "((", m(0,0), s, m(0,1), s, m(0,2), s, m(0,3), "),",
+               " (", m(1,0), s, m(1,1), s, m(1,2), s, m(1,3), "),",
+               " (", m(2,0), s, m(2,1), s, m(2,2), s, m(2,3), "),",
+               " (", m(3,0), s, m(3,1), s, m(3,2), s, m(3,3), "))");
 }
 
 } // namespace vgc::geometry
@@ -661,10 +661,10 @@ struct fmt::formatter<vgc::geometry::Mat4f> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat4f& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {}, {}, {},"
-                                   " {}, {}, {}, {},"
-                                   " {}, {}, {}, {},"
-                                   " {}, {}, {}, {}]",
+        return format_to(ctx.out(),"(({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}))",
                          m(0,0), m(0,1), m(0,2), m(0,3),
                          m(1,0), m(1,1), m(1,2), m(1,3),
                          m(2,0), m(2,1), m(2,2), m(2,3),

--- a/libs/vgc/geometry/tests/test_mat.py
+++ b/libs/vgc/geometry/tests/test_mat.py
@@ -18,8 +18,9 @@
 
 import unittest
 from math import pi, sqrt
-from vgc.geometry import Vec2d, Vec2f, Mat3d, Mat3f, Mat4d, Mat4f
+from vgc.geometry import Vec2d, Vec2f, Mat2d, Mat2f, Mat3d, Mat3f, Mat4d, Mat4f
 
+Mat2Types = [Mat2d, Mat2f]
 Mat3Types = [Mat3d, Mat3f]
 Mat4Types = [Mat4d, Mat4f]
 Mat3Vec2Types = [(Mat3d, Vec2d), (Mat3f, Vec2f)]
@@ -37,6 +38,13 @@ class TestMat(unittest.TestCase):
                 self.assertEqual(m[i][j], 0)
 
     def testInitializingConstructor(self):
+        for Mat in Mat2Types:
+            m = Mat(1, 2,
+                    3, 4)
+            self.assertEqual(m[0][0], 1)
+            self.assertEqual(m[0][1], 2)
+            self.assertEqual(m[1][0], 3)
+            self.assertEqual(m[1][1], 4)
         for Mat in Mat3Types:
             m = Mat(1, 2, 3,
                     4, 5, 6,
@@ -493,6 +501,30 @@ class TestMat(unittest.TestCase):
             self.assertTrue(m1 != m3)
             self.assertFalse(m1 != m2)
             self.assertFalse(m1 == m3)
+
+    def testToString(self):
+        for Mat2 in Mat2Types:
+            # Setup a French locale (if available on this system) to check that even
+            # when the decimal point is ',' according to the locale, numbers are
+            # still printed with '.' as decimal point.
+            #
+            try:
+                locale.setlocale(locale.LC_ALL, 'fr_FR.UTF8')
+            except:
+                pass
+            m = Mat2(1, 2, 3, 4.5)
+            self.assertEqual(str(m), "((1, 2), (3, 4.5))")
+        for Mat3 in Mat3Types:
+            m = Mat3(1, 2, 3,
+                     4, 5, 6,
+                     7, 8, 9)
+            self.assertEqual(str(m), "((1, 2, 3), (4, 5, 6), (7, 8, 9))")
+        for Mat4 in Mat4Types:
+            m = Mat4(1,  2,  3,  4,
+                     5,  6,  7,  8,
+                     9,  10, 11, 12,
+                     13, 14, 15, 16)
+            self.assertEqual(str(m), "((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16))")
 
 
 if __name__ == '__main__':

--- a/libs/vgc/geometry/tools/mat2x.h
+++ b/libs/vgc/geometry/tools/mat2x.h
@@ -365,8 +365,8 @@ inline void setZero(Mat2x& m) {
 template<typename OStream>
 void write(OStream& out, const Mat2x& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s,
-                    m(1,0), s, m(1,1), ']');
+    write(out, "((", m(0,0), s, m(0,1), "),",
+               " (", m(1,0), s, m(1,1), "))");
 }
 
 } // namespace vgc::geometry
@@ -383,8 +383,8 @@ struct fmt::formatter<vgc::geometry::Mat2x> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat2x& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {},"
-                                   " {}, {}]",
+        return format_to(ctx.out(),"(({}, {}),"
+                                   " ({}, {}))",
                          m(0,0), m(0,1),
                          m(1,0), m(1,1));
     }

--- a/libs/vgc/geometry/tools/mat3x.h
+++ b/libs/vgc/geometry/tools/mat3x.h
@@ -532,9 +532,9 @@ inline void setZero(Mat3x& m) {
 template<typename OStream>
 void write(OStream& out, const Mat3x& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s, m(0,2), s,
-                    m(1,0), s, m(1,1), s, m(1,2), s,
-                    m(2,0), s, m(2,1), s, m(2,2), ']');
+    write(out, "((", m(0,0), s, m(0,1), s, m(0,2), "),",
+               " (", m(1,0), s, m(1,1), s, m(1,2), "),",
+               " (", m(2,0), s, m(2,1), s, m(2,2), "))");
 }
 
 } // namespace vgc::geometry
@@ -551,9 +551,9 @@ struct fmt::formatter<vgc::geometry::Mat3x> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat3x& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {}, {},"
-                                   " {}, {}, {},"
-                                   " {}, {}, {}]",
+        return format_to(ctx.out(),"(({}, {}, {}),"
+                                   " ({}, {}, {}),"
+                                   " ({}, {}, {}))",
                          m(0,0), m(0,1), m(0,2),
                          m(1,0), m(1,1), m(1,2),
                          m(2,0), m(2,1), m(2,2));

--- a/libs/vgc/geometry/tools/mat4x.h
+++ b/libs/vgc/geometry/tools/mat4x.h
@@ -641,10 +641,10 @@ inline void setZero(Mat4x& m) {
 template<typename OStream>
 void write(OStream& out, const Mat4x& m) {
     static const char* s = ", ";
-    write(out, '[', m(0,0), s, m(0,1), s, m(0,2), s, m(0,3), s,
-                    m(1,0), s, m(1,1), s, m(1,2), s, m(1,3), s,
-                    m(2,0), s, m(2,1), s, m(2,2), s, m(2,3), s,
-                    m(3,0), s, m(3,1), s, m(3,2), s, m(3,3), ']');
+    write(out, "((", m(0,0), s, m(0,1), s, m(0,2), s, m(0,3), "),",
+               " (", m(1,0), s, m(1,1), s, m(1,2), s, m(1,3), "),",
+               " (", m(2,0), s, m(2,1), s, m(2,2), s, m(2,3), "),",
+               " (", m(3,0), s, m(3,1), s, m(3,2), s, m(3,3), "))");
 }
 
 } // namespace vgc::geometry
@@ -661,10 +661,10 @@ struct fmt::formatter<vgc::geometry::Mat4x> {
     }
     template <typename FormatContext>
     auto format(const vgc::geometry::Mat4x& m, FormatContext& ctx) {
-        return format_to(ctx.out(),"[{}, {}, {}, {},"
-                                   " {}, {}, {}, {},"
-                                   " {}, {}, {}, {},"
-                                   " {}, {}, {}, {}]",
+        return format_to(ctx.out(),"(({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}),"
+                                   " ({}, {}, {}, {}))",
                          m(0,0), m(0,1), m(0,2), m(0,3),
                          m(1,0), m(1,1), m(1,2), m(1,3),
                          m(2,0), m(2,1), m(2,2), m(2,3),

--- a/libs/vgc/geometry/wraps/wrap_mat.cpp
+++ b/libs/vgc/geometry/wraps/wrap_mat.cpp
@@ -132,6 +132,10 @@ void wrap_mat(py::module& m, const std::string& name) {
     // don't have this constraint, so there is no good reason to do the same.
     //
     // clang-format off
+    if constexpr (dimension == 2) {
+        cmat.def(py::init<T, T,
+                          T, T>());
+    }
     if constexpr (dimension == 3) {
         cmat.def(py::init<T, T, T,
                           T, T, T,


### PR DESCRIPTION
#673

This allows them to be disambiguated with arrays without having to provide an explicit type.