### PR TITLE
Implement skipWhitespacesAndExpectedCharacter() to simplify parsing Vec types (#673)

### DIFF
--- a/libs/vgc/core/parse.h
+++ b/libs/vgc/core/parse.h
@@ -174,6 +174,23 @@ void skipExpectedCharacter(IStream& in, char c) {
     }
 }
 
+/// Extracts all leading whitespace characters from the input stream, then
+/// extracts the next character from the input stream, and raises ParseError if
+/// this character is not the given character, or if the stream ends.
+///
+/// This is equivalent to:
+///
+/// ```cpp
+/// skipWhitespaceCharacters(in);
+/// skipExpectedCharacter(in, c);
+/// ```
+///
+template<typename IStream>
+void skipWhitespacesAndExpectedCharacter(IStream& in, char c) {
+    skipWhitespaceCharacters(in);
+    skipExpectedCharacter(in, c);
+}
+
 /// Attempts to read the string [begin, end) from the input stream.
 /// Raises ParseError if the input stream does not start with [begin, end).
 ///

--- a/libs/vgc/geometry/tools/vec2x.h
+++ b/libs/vgc/geometry/tools/vec2x.h
@@ -747,14 +747,11 @@ void write(OStream& out, const Vec2x& v) {
 ///
 template <typename IStream>
 void readTo(Vec2x& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/tools/vec3x.h
+++ b/libs/vgc/geometry/tools/vec3x.h
@@ -483,17 +483,13 @@ void write(OStream& out, const Vec3x& v) {
 ///
 template <typename IStream>
 void readTo(Vec3x& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[2], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/tools/vec4x.h
+++ b/libs/vgc/geometry/tools/vec4x.h
@@ -506,20 +506,15 @@ void write(OStream& out, const Vec4x& v) {
 ///
 template <typename IStream>
 void readTo(Vec4x& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[2], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[3], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/vec2d.h
+++ b/libs/vgc/geometry/vec2d.h
@@ -747,14 +747,11 @@ void write(OStream& out, const Vec2d& v) {
 ///
 template <typename IStream>
 void readTo(Vec2d& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/vec2f.h
+++ b/libs/vgc/geometry/vec2f.h
@@ -747,14 +747,11 @@ void write(OStream& out, const Vec2f& v) {
 ///
 template <typename IStream>
 void readTo(Vec2f& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/vec3d.h
+++ b/libs/vgc/geometry/vec3d.h
@@ -483,17 +483,13 @@ void write(OStream& out, const Vec3d& v) {
 ///
 template <typename IStream>
 void readTo(Vec3d& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[2], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/vec3f.h
+++ b/libs/vgc/geometry/vec3f.h
@@ -483,17 +483,13 @@ void write(OStream& out, const Vec3f& v) {
 ///
 template <typename IStream>
 void readTo(Vec3f& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[2], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/vec4d.h
+++ b/libs/vgc/geometry/vec4d.h
@@ -506,20 +506,15 @@ void write(OStream& out, const Vec4d& v) {
 ///
 template <typename IStream>
 void readTo(Vec4d& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[2], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[3], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry

--- a/libs/vgc/geometry/vec4f.h
+++ b/libs/vgc/geometry/vec4f.h
@@ -506,20 +506,15 @@ void write(OStream& out, const Vec4f& v) {
 ///
 template <typename IStream>
 void readTo(Vec4f& v, IStream& in) {
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, '(');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[1], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[2], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ',');
+    skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(v[3], in);
-    skipWhitespaceCharacters(in);
-    skipExpectedCharacter(in, ')');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry


### PR DESCRIPTION
#673