### PR TITLE
Add type name to Python repr() of Vec and Mat types (#673)

### DIFF
--- a/libs/vgc/geometry/tests/test_mat.py
+++ b/libs/vgc/geometry/tests/test_mat.py
@@ -761,7 +761,10 @@ class TestMat(unittest.TestCase):
             self.assertFalse(m1 == m3)
 
     def testToString(self):
-        for Mat2 in Mat2Types:
+        m = Mat2d(1, 2, 3, 4)
+        self.assertEqual(str(m), "((1, 2), (3, 4))")
+        self.assertEqual(repr(m), "vgc.geometry.Mat2d((1, 2), (3, 4))")
+        for Mat in Mat2Types:
             # Setup a French locale (if available on this system) to check that even
             # when the decimal point is ',' according to the locale, numbers are
             # still printed with '.' as decimal point.
@@ -770,43 +773,46 @@ class TestMat(unittest.TestCase):
                 locale.setlocale(locale.LC_ALL, 'fr_FR.UTF8')
             except:
                 pass
-            m = Mat2(1, 2,
-                     3, 4.5)
+            m = Mat(1, 2,
+                    3, 4.5)
             s = "((1, 2), (3, 4.5))"
             self.assertEqual(str(m), s)
-        for Mat3 in Mat3Types:
-            m = Mat3(1, 2, 3,
-                     4, 5, 6,
-                     7, 8, 9)
+            self.assertEqual(repr(m), "vgc.geometry." + Mat.__name__ + s)
+        for Mat in Mat3Types:
+            m = Mat(1, 2, 3,
+                    4, 5, 6,
+                    7, 8, 9)
             s = "((1, 2, 3), (4, 5, 6), (7, 8, 9))"
             self.assertEqual(str(m), s)
-        for Mat4 in Mat4Types:
-            m = Mat4(1,  2,  3,  4,
-                     5,  6,  7,  8,
-                     9,  10, 11, 12,
-                     13, 14, 15, 16)
+            self.assertEqual(repr(m), "vgc.geometry." + Mat.__name__ + s)
+        for Mat in Mat4Types:
+            m = Mat(1,  2,  3,  4,
+                    5,  6,  7,  8,
+                    9,  10, 11, 12,
+                    13, 14, 15, 16)
             s = "((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16))"
             self.assertEqual(str(m), s)
+            self.assertEqual(repr(m), "vgc.geometry." + Mat.__name__ + s)
 
     def testParse(self):
-        for Mat2 in Mat2Types:
-            m = Mat2(1, 2,
-                     3, 4.5)
+        for Mat in Mat2Types:
+            m = Mat(1, 2,
+                    3, 4.5)
             s = "  ( (1, 2)  ,\n(3, 4.5)) " # test various formatting variants
-            self.assertEqual(Mat2(s), m)
-        for Mat3 in Mat3Types:
-            m = Mat3(1, 2, 3,
-                     4, 5, 6,
-                     7, 8, 9)
+            self.assertEqual(Mat(s), m)
+        for Mat in Mat3Types:
+            m = Mat(1, 2, 3,
+                    4, 5, 6,
+                    7, 8, 9)
             s = "((1, 2, 3), (4, 5, 6), (7, 8, 9))"
-            self.assertEqual(Mat3(s), m)
-        for Mat4 in Mat4Types:
-            m = Mat4(1,  2,  3,  4,
-                     5,  6,  7,  8,
-                     9,  10, 11, 12,
-                     13, 14, 15, 16)
+            self.assertEqual(Mat(s), m)
+        for Mat in Mat4Types:
+            m = Mat(1,  2,  3,  4,
+                    5,  6,  7,  8,
+                    9,  10, 11, 12,
+                    13, 14, 15, 16)
             s = "((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16))"
-            self.assertEqual(Mat4(s), m)
+            self.assertEqual(Mat(s), m)
 
 if __name__ == '__main__':
     unittest.main()

--- a/libs/vgc/geometry/tests/test_vec.py
+++ b/libs/vgc/geometry/tests/test_vec.py
@@ -646,6 +646,9 @@ class TestVec(unittest.TestCase):
             self.assertFalse(Vec(1, 2, 3, 4).allNear(Vec(1, 2, 3, 5), absTol))
 
     def testToString(self):
+        v = Vec2d(1, 2)
+        self.assertEqual(str(v), "(1, 2)")
+        self.assertEqual(repr(v), "vgc.geometry.Vec2d(1, 2)")
         for Vec in Vec2Types:
             # Setup a French locale (if available on this system) to check that even
             # when the decimal point is ',' according to the locale, numbers are
@@ -658,14 +661,17 @@ class TestVec(unittest.TestCase):
             v = Vec(1, 2.5)
             s = "(1, 2.5)"
             self.assertEqual(str(v), s)
+            self.assertEqual(repr(v), "vgc.geometry." + Vec.__name__ + s)
         for Vec in Vec3Types:
             v = Vec(1, 2, 3)
             s = "(1, 2, 3)"
             self.assertEqual(str(v), s)
+            self.assertEqual(repr(v), "vgc.geometry." + Vec.__name__ + s)
         for Vec in Vec4Types:
             v = Vec(1,  2,  3,  4)
             s = "(1, 2, 3, 4)"
             self.assertEqual(str(v), s)
+            self.assertEqual(repr(v), "vgc.geometry." + Vec.__name__ + s)
 
     def testParse(self):
         for Vec in Vec2Types:

--- a/libs/vgc/geometry/wraps/wrap_mat.cpp
+++ b/libs/vgc/geometry/wraps/wrap_mat.cpp
@@ -406,7 +406,11 @@ void wrap_mat(py::module& m, const std::string& name) {
     }
 
     // Conversion to string
-    cmat.def("__repr__", [](const TMat& m) { return vgc::core::toString(m); });
+    cmat.def("__str__", [](const TMat& m) { return vgc::core::toString(m); });
+    cmat.def("__repr__", [name](const TMat& m) {
+        std::string str = vgc::core::toString(m);
+        return vgc::core::format("vgc.geometry.{}{}", name, str);
+    });
 }
 
 } // namespace

--- a/libs/vgc/geometry/wraps/wrap_vec.cpp
+++ b/libs/vgc/geometry/wraps/wrap_vec.cpp
@@ -222,7 +222,11 @@ void wrap_vec(py::module& m, const std::string& name) {
         .def("allNear", &TVec::allNear, "b"_a, "absTol"_a);
 
     // Conversion to string
-    cvec.def("__repr__", [](const TVec& v) { return vgc::core::toString(v); });
+    cvec.def("__str__", [](const TVec& v) { return vgc::core::toString(v); });
+    cvec.def("__repr__", [name](const TVec& v) {
+        std::string str = vgc::core::toString(v);
+        return vgc::core::format("vgc.geometry.{}{}", name, str);
+    });
 
     // Wrap Array type
     wrap_vecArray<TVec>(m, name);


### PR DESCRIPTION
#673