### PR TITLE
Fix extra whitespace before template parameters in 'clang-format off' sections (#1802)

### DIFF
--- a/libs/vgc/geometry/mat2d.h
+++ b/libs/vgc/geometry/mat2d.h
@@ -381,7 +381,7 @@ void write(OStream& out, const Mat2d& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat2d& m, Int i, IStream& in) {
     Vec2d v;
     readTo(v, in);
@@ -396,7 +396,7 @@ void readToMatRow(Mat2d& m, Int i, IStream& in) {
 /// stream does not start with a `Mat2d`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat2d& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -408,7 +408,7 @@ void readTo(Mat2d& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat2d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -417,7 +417,7 @@ struct fmt::formatter<vgc::geometry::Mat2d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat2d& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}),"
                                    " ({}, {}))",

--- a/libs/vgc/geometry/mat2f.h
+++ b/libs/vgc/geometry/mat2f.h
@@ -381,7 +381,7 @@ void write(OStream& out, const Mat2f& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat2f& m, Int i, IStream& in) {
     Vec2f v;
     readTo(v, in);
@@ -396,7 +396,7 @@ void readToMatRow(Mat2f& m, Int i, IStream& in) {
 /// stream does not start with a `Mat2f`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat2f& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -408,7 +408,7 @@ void readTo(Mat2f& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat2f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -417,7 +417,7 @@ struct fmt::formatter<vgc::geometry::Mat2f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat2f& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}),"
                                    " ({}, {}))",

--- a/libs/vgc/geometry/mat3d.h
+++ b/libs/vgc/geometry/mat3d.h
@@ -551,7 +551,7 @@ void write(OStream& out, const Mat3d& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat3d& m, Int i, IStream& in) {
     Vec3d v;
     readTo(v, in);
@@ -567,7 +567,7 @@ void readToMatRow(Mat3d& m, Int i, IStream& in) {
 /// stream does not start with a `Mat2d`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat3d& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -581,7 +581,7 @@ void readTo(Mat3d& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat3d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -590,7 +590,7 @@ struct fmt::formatter<vgc::geometry::Mat3d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat3d& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}, {}),"
                                    " ({}, {}, {}),"

--- a/libs/vgc/geometry/mat3f.h
+++ b/libs/vgc/geometry/mat3f.h
@@ -551,7 +551,7 @@ void write(OStream& out, const Mat3f& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat3f& m, Int i, IStream& in) {
     Vec3f v;
     readTo(v, in);
@@ -567,7 +567,7 @@ void readToMatRow(Mat3f& m, Int i, IStream& in) {
 /// stream does not start with a `Mat2f`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat3f& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -581,7 +581,7 @@ void readTo(Mat3f& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat3f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -590,7 +590,7 @@ struct fmt::formatter<vgc::geometry::Mat3f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat3f& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}, {}),"
                                    " ({}, {}, {}),"

--- a/libs/vgc/geometry/mat4d.h
+++ b/libs/vgc/geometry/mat4d.h
@@ -663,7 +663,7 @@ void write(OStream& out, const Mat4d& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat4d& m, Int i, IStream& in) {
     Vec4d v;
     readTo(v, in);
@@ -680,7 +680,7 @@ void readToMatRow(Mat4d& m, Int i, IStream& in) {
 /// stream does not start with a `Mat4d`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat4d& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -696,7 +696,7 @@ void readTo(Mat4d& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat4d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -705,7 +705,7 @@ struct fmt::formatter<vgc::geometry::Mat4d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat4d& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}, {}, {}),"
                                    " ({}, {}, {}, {}),"

--- a/libs/vgc/geometry/mat4f.h
+++ b/libs/vgc/geometry/mat4f.h
@@ -663,7 +663,7 @@ void write(OStream& out, const Mat4f& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat4f& m, Int i, IStream& in) {
     Vec4f v;
     readTo(v, in);
@@ -680,7 +680,7 @@ void readToMatRow(Mat4f& m, Int i, IStream& in) {
 /// stream does not start with a `Mat4f`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat4f& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -696,7 +696,7 @@ void readTo(Mat4f& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat4f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -705,7 +705,7 @@ struct fmt::formatter<vgc::geometry::Mat4f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat4f& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}, {}, {}),"
                                    " ({}, {}, {}, {}),"

--- a/libs/vgc/geometry/range1d.h
+++ b/libs/vgc/geometry/range1d.h
@@ -445,7 +445,7 @@ void write(OStream& out, const Range1d& r) {
 /// Raises `RangeError` if one of its coordinates is outside the representable
 /// range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Range1d& r, IStream& in) {
     double pMin, pMax;
     core::skipWhitespaceCharacters(in);
@@ -462,7 +462,7 @@ void readTo(Range1d& r, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Range1d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -471,7 +471,7 @@ struct fmt::formatter<vgc::geometry::Range1d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Range1d& r, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {})",
                          r.pMin(), r.pMax());

--- a/libs/vgc/geometry/range1f.h
+++ b/libs/vgc/geometry/range1f.h
@@ -445,7 +445,7 @@ void write(OStream& out, const Range1f& r) {
 /// Raises `RangeError` if one of its coordinates is outside the representable
 /// range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Range1f& r, IStream& in) {
     float pMin, pMax;
     core::skipWhitespaceCharacters(in);
@@ -462,7 +462,7 @@ void readTo(Range1f& r, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Range1f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -471,7 +471,7 @@ struct fmt::formatter<vgc::geometry::Range1f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Range1f& r, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {})",
                          r.pMin(), r.pMax());

--- a/libs/vgc/geometry/rect2d.h
+++ b/libs/vgc/geometry/rect2d.h
@@ -858,7 +858,7 @@ void write(OStream& out, const Rect2d& r) {
 /// Raises `RangeError` if one of its coordinates is outside the representable
 /// range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Rect2d& r, IStream& in) {
     double xMin, yMin, xMax, yMax;
     core::skipWhitespaceCharacters(in);
@@ -881,7 +881,7 @@ void readTo(Rect2d& r, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Rect2d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -890,7 +890,7 @@ struct fmt::formatter<vgc::geometry::Rect2d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Rect2d& r, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {}, {})",
                          r.xMin(), r.yMin(), r.xMax(), r.yMax());

--- a/libs/vgc/geometry/rect2f.h
+++ b/libs/vgc/geometry/rect2f.h
@@ -858,7 +858,7 @@ void write(OStream& out, const Rect2f& r) {
 /// Raises `RangeError` if one of its coordinates is outside the representable
 /// range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Rect2f& r, IStream& in) {
     float xMin, yMin, xMax, yMax;
     core::skipWhitespaceCharacters(in);
@@ -881,7 +881,7 @@ void readTo(Rect2f& r, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Rect2f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -890,7 +890,7 @@ struct fmt::formatter<vgc::geometry::Rect2f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Rect2f& r, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {}, {})",
                          r.xMin(), r.yMin(), r.xMax(), r.yMax());

--- a/libs/vgc/geometry/tools/mat2x.h
+++ b/libs/vgc/geometry/tools/mat2x.h
@@ -381,7 +381,7 @@ void write(OStream& out, const Mat2x& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat2x& m, Int i, IStream& in) {
     Vec2x v;
     readTo(v, in);
@@ -396,7 +396,7 @@ void readToMatRow(Mat2x& m, Int i, IStream& in) {
 /// stream does not start with a `Mat2x`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat2x& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -408,7 +408,7 @@ void readTo(Mat2x& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat2x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -417,7 +417,7 @@ struct fmt::formatter<vgc::geometry::Mat2x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat2x& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}),"
                                    " ({}, {}))",

--- a/libs/vgc/geometry/tools/mat3x.h
+++ b/libs/vgc/geometry/tools/mat3x.h
@@ -551,7 +551,7 @@ void write(OStream& out, const Mat3x& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat3x& m, Int i, IStream& in) {
     Vec3x v;
     readTo(v, in);
@@ -567,7 +567,7 @@ void readToMatRow(Mat3x& m, Int i, IStream& in) {
 /// stream does not start with a `Mat2x`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat3x& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -581,7 +581,7 @@ void readTo(Mat3x& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat3x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -590,7 +590,7 @@ struct fmt::formatter<vgc::geometry::Mat3x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat3x& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}, {}),"
                                    " ({}, {}, {}),"

--- a/libs/vgc/geometry/tools/mat4x.h
+++ b/libs/vgc/geometry/tools/mat4x.h
@@ -663,7 +663,7 @@ void write(OStream& out, const Mat4x& m) {
 
 namespace detail {
 
-template <typename IStream>
+template<typename IStream>
 void readToMatRow(Mat4x& m, Int i, IStream& in) {
     Vec4x v;
     readTo(v, in);
@@ -680,7 +680,7 @@ void readToMatRow(Mat4x& m, Int i, IStream& in) {
 /// stream does not start with a `Mat4x`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Mat4x& m, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     detail::readToMatRow(m, 0, in);
@@ -696,7 +696,7 @@ void readTo(Mat4x& m, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Mat4x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -705,7 +705,7 @@ struct fmt::formatter<vgc::geometry::Mat4x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Mat4x& m, FormatContext& ctx) {
         return format_to(ctx.out(),"(({}, {}, {}, {}),"
                                    " ({}, {}, {}, {}),"

--- a/libs/vgc/geometry/tools/range1x.h
+++ b/libs/vgc/geometry/tools/range1x.h
@@ -445,7 +445,7 @@ void write(OStream& out, const Range1x& r) {
 /// Raises `RangeError` if one of its coordinates is outside the representable
 /// range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Range1x& r, IStream& in) {
     float pMin, pMax;
     core::skipWhitespaceCharacters(in);
@@ -462,7 +462,7 @@ void readTo(Range1x& r, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Range1x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -471,7 +471,7 @@ struct fmt::formatter<vgc::geometry::Range1x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Range1x& r, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {})",
                          r.pMin(), r.pMax());

--- a/libs/vgc/geometry/tools/rect2x.h
+++ b/libs/vgc/geometry/tools/rect2x.h
@@ -858,7 +858,7 @@ void write(OStream& out, const Rect2x& r) {
 /// Raises `RangeError` if one of its coordinates is outside the representable
 /// range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Rect2x& r, IStream& in) {
     float xMin, yMin, xMax, yMax;
     core::skipWhitespaceCharacters(in);
@@ -881,7 +881,7 @@ void readTo(Rect2x& r, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Rect2x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -890,7 +890,7 @@ struct fmt::formatter<vgc::geometry::Rect2x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Rect2x& r, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {}, {})",
                          r.xMin(), r.yMin(), r.xMax(), r.yMax());

--- a/libs/vgc/geometry/tools/triangle2x.h
+++ b/libs/vgc/geometry/tools/triangle2x.h
@@ -334,7 +334,7 @@ void write(OStream& out, const Triangle2x& t) {
 /// stream does not start with a `Triangle2x`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Triangle2x& t, IStream& in) {
     skipWhitespaceCharacters(in);
     skipExpectedCharacter(in, '[');
@@ -352,7 +352,7 @@ void readTo(Triangle2x& t, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Triangle2x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -361,7 +361,7 @@ struct fmt::formatter<vgc::geometry::Triangle2x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Triangle2x& t, FormatContext& ctx) {
         return format_to(ctx.out(),"([{}, {}, {}])", t[0], t[1], t[2]);
     }

--- a/libs/vgc/geometry/tools/vec2x.h
+++ b/libs/vgc/geometry/tools/vec2x.h
@@ -745,7 +745,7 @@ void write(OStream& out, const Vec2x& v) {
 /// stream does not start with a `Vec2x`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec2x& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -757,7 +757,7 @@ void readTo(Vec2x& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec2x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -766,7 +766,7 @@ struct fmt::formatter<vgc::geometry::Vec2x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec2x& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {})", v[0], v[1]);
     }

--- a/libs/vgc/geometry/tools/vec3x.h
+++ b/libs/vgc/geometry/tools/vec3x.h
@@ -481,7 +481,7 @@ void write(OStream& out, const Vec3x& v) {
 /// stream does not start with a `Vec3x`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec3x& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -495,7 +495,7 @@ void readTo(Vec3x& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec3x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -504,7 +504,7 @@ struct fmt::formatter<vgc::geometry::Vec3x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec3x& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {})", v[0], v[1], v[2]);
     }

--- a/libs/vgc/geometry/tools/vec4x.h
+++ b/libs/vgc/geometry/tools/vec4x.h
@@ -504,7 +504,7 @@ void write(OStream& out, const Vec4x& v) {
 /// stream does not start with a `Vec4x`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec4x& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -520,7 +520,7 @@ void readTo(Vec4x& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec4x> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -529,7 +529,7 @@ struct fmt::formatter<vgc::geometry::Vec4x> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec4x& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {}, {})", v[0], v[1], v[2], v[3]);
     }

--- a/libs/vgc/geometry/triangle2d.h
+++ b/libs/vgc/geometry/triangle2d.h
@@ -334,7 +334,7 @@ void write(OStream& out, const Triangle2d& t) {
 /// stream does not start with a `Triangle2d`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Triangle2d& t, IStream& in) {
     skipWhitespaceCharacters(in);
     skipExpectedCharacter(in, '[');
@@ -352,7 +352,7 @@ void readTo(Triangle2d& t, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Triangle2d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -361,7 +361,7 @@ struct fmt::formatter<vgc::geometry::Triangle2d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Triangle2d& t, FormatContext& ctx) {
         return format_to(ctx.out(),"([{}, {}, {}])", t[0], t[1], t[2]);
     }

--- a/libs/vgc/geometry/triangle2f.h
+++ b/libs/vgc/geometry/triangle2f.h
@@ -334,7 +334,7 @@ void write(OStream& out, const Triangle2f& t) {
 /// stream does not start with a `Triangle2f`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Triangle2f& t, IStream& in) {
     skipWhitespaceCharacters(in);
     skipExpectedCharacter(in, '[');
@@ -352,7 +352,7 @@ void readTo(Triangle2f& t, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Triangle2f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -361,7 +361,7 @@ struct fmt::formatter<vgc::geometry::Triangle2f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Triangle2f& t, FormatContext& ctx) {
         return format_to(ctx.out(),"([{}, {}, {}])", t[0], t[1], t[2]);
     }

--- a/libs/vgc/geometry/vec2d.h
+++ b/libs/vgc/geometry/vec2d.h
@@ -745,7 +745,7 @@ void write(OStream& out, const Vec2d& v) {
 /// stream does not start with a `Vec2d`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec2d& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -757,7 +757,7 @@ void readTo(Vec2d& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec2d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -766,7 +766,7 @@ struct fmt::formatter<vgc::geometry::Vec2d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec2d& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {})", v[0], v[1]);
     }

--- a/libs/vgc/geometry/vec2f.h
+++ b/libs/vgc/geometry/vec2f.h
@@ -745,7 +745,7 @@ void write(OStream& out, const Vec2f& v) {
 /// stream does not start with a `Vec2f`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec2f& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -757,7 +757,7 @@ void readTo(Vec2f& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec2f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -766,7 +766,7 @@ struct fmt::formatter<vgc::geometry::Vec2f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec2f& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {})", v[0], v[1]);
     }

--- a/libs/vgc/geometry/vec3d.h
+++ b/libs/vgc/geometry/vec3d.h
@@ -481,7 +481,7 @@ void write(OStream& out, const Vec3d& v) {
 /// stream does not start with a `Vec3d`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec3d& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -495,7 +495,7 @@ void readTo(Vec3d& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec3d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -504,7 +504,7 @@ struct fmt::formatter<vgc::geometry::Vec3d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec3d& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {})", v[0], v[1], v[2]);
     }

--- a/libs/vgc/geometry/vec3f.h
+++ b/libs/vgc/geometry/vec3f.h
@@ -481,7 +481,7 @@ void write(OStream& out, const Vec3f& v) {
 /// stream does not start with a `Vec3f`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec3f& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -495,7 +495,7 @@ void readTo(Vec3f& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec3f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -504,7 +504,7 @@ struct fmt::formatter<vgc::geometry::Vec3f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec3f& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {})", v[0], v[1], v[2]);
     }

--- a/libs/vgc/geometry/vec4d.h
+++ b/libs/vgc/geometry/vec4d.h
@@ -504,7 +504,7 @@ void write(OStream& out, const Vec4d& v) {
 /// stream does not start with a `Vec4d`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a double.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec4d& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -520,7 +520,7 @@ void readTo(Vec4d& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec4d> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -529,7 +529,7 @@ struct fmt::formatter<vgc::geometry::Vec4d> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec4d& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {}, {})", v[0], v[1], v[2], v[3]);
     }

--- a/libs/vgc/geometry/vec4f.h
+++ b/libs/vgc/geometry/vec4f.h
@@ -504,7 +504,7 @@ void write(OStream& out, const Vec4f& v) {
 /// stream does not start with a `Vec4f`. Raises `RangeError` if one of its
 /// coordinates is outside the representable range of a float.
 ///
-template <typename IStream>
+template<typename IStream>
 void readTo(Vec4f& v, IStream& in) {
     skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(v[0], in);
@@ -520,7 +520,7 @@ void readTo(Vec4f& v, IStream& in) {
 } // namespace vgc::geometry
 
 // see https://fmt.dev/latest/api.html#formatting-user-defined-types
-template <>
+template<>
 struct fmt::formatter<vgc::geometry::Vec4f> {
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -529,7 +529,7 @@ struct fmt::formatter<vgc::geometry::Vec4f> {
         }
         return it;
     }
-    template <typename FormatContext>
+    template<typename FormatContext>
     auto format(const vgc::geometry::Vec4f& v, FormatContext& ctx) {
         return format_to(ctx.out(),"({}, {}, {}, {})", v[0], v[1], v[2], v[3]);
     }

--- a/libs/vgc/graphics/enums.h
+++ b/libs/vgc/graphics/enums.h
@@ -149,11 +149,11 @@ enum class PixelFormat : UInt8 {
 
 namespace detail {
 
-    template <PixelFormat Format>
+    template<PixelFormat Format>
     struct pixelFormatElementSizeInBytes_;
 
 #define VGC_PIXEL_FORMAT_MACRO_(Enumerator, ElemSizeInBytes, DXGIFormat, OpenGLInternalFormat, OpenGLPixelType, OpenGLPixelFormat) \
-    template <> \
+    template<> \
     struct pixelFormatElementSizeInBytes_<PixelFormat::Enumerator>\
         : std::integral_constant<UInt8, ElemSizeInBytes> {};
 #include <vgc/graphics/detail/pixelformats.h>


### PR DESCRIPTION
#1802