### PR TITLE
Rename Mat::inverted() to inverse() (#673)

### DIFF
--- a/libs/vgc/canvas/canvas.cpp
+++ b/libs/vgc/canvas/canvas.cpp
@@ -140,7 +140,7 @@ core::Array<SelectionCandidate> Canvas::computeSelectionCandidatesAboveOrAt(
     double worldTol = tolerance;
 
     if (coordinateSpace == CoordinateSpace::Widget) {
-        worldCoords = camera().viewMatrix().inverted().transformPointAffine(worldCoords);
+        worldCoords = camera().viewMatrix().inverse().transformPointAffine(worldCoords);
         worldTol /= camera().zoom();
     }
 
@@ -223,7 +223,7 @@ core::Array<core::Id> Canvas::computeRectangleSelectionCandidates(
     geometry::Vec2d a = a_;
     geometry::Vec2d b = b_;
     if (coordinateSpace == CoordinateSpace::Widget) {
-        geometry::Mat4d invView = camera().viewMatrix().inverted();
+        geometry::Mat4d invView = camera().viewMatrix().inverse();
         a = invView.transformPointAffine(a);
         b = invView.transformPointAffine(b);
     }
@@ -346,7 +346,7 @@ bool Canvas::onMouseMove(ui::MouseMoveEvent* event) {
         // Set new camera center so that rotation center = mouse pos at press
         geometry::Vec2d pivotViewCoords = mousePosAtPress;
         geometry::Vec2d pivotWorldCoords =
-            cameraAtPress_.viewMatrix().inverted().transformPointAffine(pivotViewCoords);
+            cameraAtPress_.viewMatrix().inverse().transformPointAffine(pivotViewCoords);
         geometry::Vec2d pivotViewCoordsNow =
             camera.viewMatrix().transformPointAffine(pivotWorldCoords);
         camera.setCenter(camera.center() - pivotViewCoords + pivotViewCoordsNow);
@@ -363,7 +363,7 @@ bool Canvas::onMouseMove(ui::MouseMoveEvent* event) {
         // Set new camera center so that zoom center = mouse pos at press
         geometry::Vec2d pivotViewCoords = mousePosAtPress;
         geometry::Vec2d pivotWorldCoords =
-            cameraAtPress_.viewMatrix().inverted().transformPointAffine(pivotViewCoords);
+            cameraAtPress_.viewMatrix().inverse().transformPointAffine(pivotViewCoords);
         geometry::Vec2d pivotViewCoordsNow =
             camera.viewMatrix().transformPointAffine(pivotWorldCoords);
         camera.setCenter(camera.center() - pivotViewCoords + pivotViewCoordsNow);
@@ -433,8 +433,7 @@ bool Canvas::onMouseRelease(ui::MouseReleaseEvent* event) {
 
         // Save mouse pos in world coords before modifying camera
         geometry::Vec2d mousePos(mousePosAtPress_);
-        geometry::Vec2d p1 =
-            camera.viewMatrix().inverted().transformPointAffine(mousePos);
+        geometry::Vec2d p1 = camera.viewMatrix().inverse().transformPointAffine(mousePos);
 
         // Reset camera rotation
         camera.setRotation(0);
@@ -531,8 +530,7 @@ bool Canvas::onMouseScroll(ui::ScrollEvent* event) {
 
         // Save mouse pos in world coords before applying zoom
         geometry::Vec2d mousePos = geometry::Vec2d(event->position());
-        geometry::Vec2d p1 =
-            camera.viewMatrix().inverted().transformPointAffine(mousePos);
+        geometry::Vec2d p1 = camera.viewMatrix().inverse().transformPointAffine(mousePos);
 
         camera.setZoom(newZoom);
 

--- a/libs/vgc/canvas/canvasmanager.cpp
+++ b/libs/vgc/canvas/canvasmanager.cpp
@@ -277,7 +277,7 @@ void fitViewToRect_(Canvas& canvas, const geometry::Rect2d& rect) {
     // Set rotation
     // TODO: improve Camera2d API to make this easier.
     geometry::Vec2d c0 = 0.5 * viewportSize;
-    geometry::Vec2d c1 = camera.viewMatrix().inverted().transformPointAffine(c0);
+    geometry::Vec2d c1 = camera.viewMatrix().inverse().transformPointAffine(c0);
     camera.setRotation(rotation);
     geometry::Vec2d c2 = camera.viewMatrix().transformPointAffine(c1);
     camera.setCenter(camera.center() - c0 + c2);

--- a/libs/vgc/geometry/mat2d.cpp
+++ b/libs/vgc/geometry/mat2d.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat2d Mat2d::inverted(bool* isInvertible, double epsilon_) const {
+Mat2d Mat2d::inverse(bool* isInvertible, double epsilon_) const {
 
     Mat2d res;
 

--- a/libs/vgc/geometry/mat2d.h
+++ b/libs/vgc/geometry/mat2d.h
@@ -337,7 +337,7 @@ public:
     /// has all its elements set to std::numeric_limits<double>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat2d inverted(bool* isInvertible = nullptr, double epsilon = 0) const;
+    Mat2d inverse(bool* isInvertible = nullptr, double epsilon = 0) const;
 
 private:
     double data_[2][2];

--- a/libs/vgc/geometry/mat2f.cpp
+++ b/libs/vgc/geometry/mat2f.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat2f Mat2f::inverted(bool* isInvertible, float epsilon_) const {
+Mat2f Mat2f::inverse(bool* isInvertible, float epsilon_) const {
 
     Mat2f res;
 

--- a/libs/vgc/geometry/mat2f.h
+++ b/libs/vgc/geometry/mat2f.h
@@ -337,7 +337,7 @@ public:
     /// has all its elements set to std::numeric_limits<float>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat2f inverted(bool* isInvertible = nullptr, float epsilon = 0) const;
+    Mat2f inverse(bool* isInvertible = nullptr, float epsilon = 0) const;
 
 private:
     float data_[2][2];

--- a/libs/vgc/geometry/mat3d.cpp
+++ b/libs/vgc/geometry/mat3d.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat3d Mat3d::inverted(bool* isInvertible, double epsilon_) const {
+Mat3d Mat3d::inverse(bool* isInvertible, double epsilon_) const {
 
     Mat3d res;
 

--- a/libs/vgc/geometry/mat3d.h
+++ b/libs/vgc/geometry/mat3d.h
@@ -394,7 +394,7 @@ public:
     /// has all its elements set to std::numeric_limits<double>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat3d inverted(bool* isInvertible = nullptr, double epsilon = 0) const;
+    Mat3d inverse(bool* isInvertible = nullptr, double epsilon = 0) const;
 
     /// Right-multiplies this matrix by the translation matrix given
     /// by vx and vy, that is:

--- a/libs/vgc/geometry/mat3f.cpp
+++ b/libs/vgc/geometry/mat3f.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat3f Mat3f::inverted(bool* isInvertible, float epsilon_) const {
+Mat3f Mat3f::inverse(bool* isInvertible, float epsilon_) const {
 
     Mat3f res;
 

--- a/libs/vgc/geometry/mat3f.h
+++ b/libs/vgc/geometry/mat3f.h
@@ -394,7 +394,7 @@ public:
     /// has all its elements set to std::numeric_limits<float>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat3f inverted(bool* isInvertible = nullptr, float epsilon = 0) const;
+    Mat3f inverse(bool* isInvertible = nullptr, float epsilon = 0) const;
 
     /// Right-multiplies this matrix by the translation matrix given
     /// by vx and vy, that is:

--- a/libs/vgc/geometry/mat4d.cpp
+++ b/libs/vgc/geometry/mat4d.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat4d Mat4d::inverted(bool* isInvertible, double epsilon_) const {
+Mat4d Mat4d::inverse(bool* isInvertible, double epsilon_) const {
 
     Mat4d res;
 

--- a/libs/vgc/geometry/mat4d.h
+++ b/libs/vgc/geometry/mat4d.h
@@ -490,7 +490,7 @@ public:
     /// has all its elements set to std::numeric_limits<double>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat4d inverted(bool* isInvertible = nullptr, double epsilon = 0) const;
+    Mat4d inverse(bool* isInvertible = nullptr, double epsilon = 0) const;
 
     /// Right-multiplies this matrix by the translation matrix given
     /// by vx, vy, and vy, that is:

--- a/libs/vgc/geometry/mat4f.cpp
+++ b/libs/vgc/geometry/mat4f.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat4f Mat4f::inverted(bool* isInvertible, float epsilon_) const {
+Mat4f Mat4f::inverse(bool* isInvertible, float epsilon_) const {
 
     Mat4f res;
 

--- a/libs/vgc/geometry/mat4f.h
+++ b/libs/vgc/geometry/mat4f.h
@@ -490,7 +490,7 @@ public:
     /// has all its elements set to std::numeric_limits<float>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat4f inverted(bool* isInvertible = nullptr, float epsilon = 0) const;
+    Mat4f inverse(bool* isInvertible = nullptr, float epsilon = 0) const;
 
     /// Right-multiplies this matrix by the translation matrix given
     /// by vx, vy, and vy, that is:

--- a/libs/vgc/geometry/tests/test_mat.py
+++ b/libs/vgc/geometry/tests/test_mat.py
@@ -656,14 +656,14 @@ class TestMat(unittest.TestCase):
                     4, 5, 6,
                     7, 8, 9)
             with self.assertRaises(ValueError):
-                m3 = m.inverted()
+                m3 = m.inverse()
             m = Mat(+1,  2,  4,
                     -4, -3, -2,
                     +5, -1,  3)
             m2 = (1.0 / 69) * Mat(-11, -10, 8,
                                   +2,  -17, -14,
                                   +19,  11, 5)
-            m3 = m.inverted()
+            m3 = m.inverse()
             self.assertEqual(m2, m3)
 
         for Mat in Mat4Types:
@@ -675,7 +675,7 @@ class TestMat(unittest.TestCase):
                                    +347, 50, 135, 207,
                                    -104, -71, -15, -23,
                                    +143, 24, -53, -42)
-            m3 = m.inverted()
+            m3 = m.inverse()
             self.assertEqual(m2, m3)
 
     def testTranslate(self):

--- a/libs/vgc/geometry/tools/mat2x.cpp
+++ b/libs/vgc/geometry/tools/mat2x.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat2x Mat2x::inverted(bool* isInvertible, float epsilon_) const {
+Mat2x Mat2x::inverse(bool* isInvertible, float epsilon_) const {
 
     Mat2x res;
 

--- a/libs/vgc/geometry/tools/mat2x.h
+++ b/libs/vgc/geometry/tools/mat2x.h
@@ -337,7 +337,7 @@ public:
     /// has all its elements set to std::numeric_limits<float>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat2x inverted(bool* isInvertible = nullptr, float epsilon = 0) const;
+    Mat2x inverse(bool* isInvertible = nullptr, float epsilon = 0) const;
 
 private:
     float data_[2][2];

--- a/libs/vgc/geometry/tools/mat3x.cpp
+++ b/libs/vgc/geometry/tools/mat3x.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat3x Mat3x::inverted(bool* isInvertible, float epsilon_) const {
+Mat3x Mat3x::inverse(bool* isInvertible, float epsilon_) const {
 
     Mat3x res;
 

--- a/libs/vgc/geometry/tools/mat3x.h
+++ b/libs/vgc/geometry/tools/mat3x.h
@@ -394,7 +394,7 @@ public:
     /// has all its elements set to std::numeric_limits<float>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat3x inverted(bool* isInvertible = nullptr, float epsilon = 0) const;
+    Mat3x inverse(bool* isInvertible = nullptr, float epsilon = 0) const;
 
     /// Right-multiplies this matrix by the translation matrix given
     /// by vx and vy, that is:

--- a/libs/vgc/geometry/tools/mat4x.cpp
+++ b/libs/vgc/geometry/tools/mat4x.cpp
@@ -25,7 +25,7 @@
 
 namespace vgc::geometry {
 
-Mat4x Mat4x::inverted(bool* isInvertible, float epsilon_) const {
+Mat4x Mat4x::inverse(bool* isInvertible, float epsilon_) const {
 
     Mat4x res;
 

--- a/libs/vgc/geometry/tools/mat4x.h
+++ b/libs/vgc/geometry/tools/mat4x.h
@@ -490,7 +490,7 @@ public:
     /// has all its elements set to std::numeric_limits<float>::infinity().
     ///
     VGC_GEOMETRY_API
-    Mat4x inverted(bool* isInvertible = nullptr, float epsilon = 0) const;
+    Mat4x inverse(bool* isInvertible = nullptr, float epsilon = 0) const;
 
     /// Right-multiplies this matrix by the translation matrix given
     /// by vx, vy, and vy, that is:

--- a/libs/vgc/geometry/wraps/wrap_mat.cpp
+++ b/libs/vgc/geometry/wraps/wrap_mat.cpp
@@ -365,9 +365,9 @@ void wrap_mat(py::module& m, const std::string& name) {
         .def("setToDiagonal", &TMat::setToDiagonal)
         .def("setToZero", &TMat::setToZero)
         .def("setToIdentity", &TMat::setToIdentity)
-        .def("inverted", [](const TMat& m) {
+        .def("inverse", [](const TMat& m) {
             bool isInvertible;
-            TMat res = m.inverted(&isInvertible);
+            TMat res = m.inverse(&isInvertible);
             if (!isInvertible) {
                 throw py::value_error("The matrix is not invertible.");
             }

--- a/libs/vgc/tools/colorpalette.cpp
+++ b/libs/vgc/tools/colorpalette.cpp
@@ -155,7 +155,7 @@ core::Color xyzToSrgb(const geometry::Vec3f& c) {
         0.0193f, 0.1192f, 0.9505f
     };
     // clang-format on
-    static geometry::Mat3f invM = m.inverted();
+    static geometry::Mat3f invM = m.inverse();
     return srgbLinearToGamma(invM * c);
 }
 

--- a/libs/vgc/tools/paintbucket.cpp
+++ b/libs/vgc/tools/paintbucket.cpp
@@ -61,7 +61,7 @@ void PaintBucket::onMouseHover(ui::MouseHoverEvent* event) {
     geometry::Vec2d mousePos = geometry::Vec2d(mousePosf.x(), mousePosf.y());
     geometry::Vec2d viewCoords = mousePos;
     geometry::Vec2d worldCoords =
-        context.canvas()->camera().viewMatrix().inverted().transformPointAffine(
+        context.canvas()->camera().viewMatrix().inverse().transformPointAffine(
             viewCoords);
 
     // Compute the key face candidate for the current mouse position.

--- a/libs/vgc/tools/sculpt.cpp
+++ b/libs/vgc/tools/sculpt.cpp
@@ -121,7 +121,7 @@ public:
 
         cursorPosition_ = event->position();
 
-        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverted();
+        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
 
         float pixelSize = static_cast<float>(
             (inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 1))
@@ -286,7 +286,7 @@ public:
 
         cursorPosition_ = event->position();
 
-        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverted();
+        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
 
         float pixelSize = static_cast<float>(
             (inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 1))
@@ -457,7 +457,7 @@ public:
 
         cursorPosition_ = event->position();
 
-        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverted();
+        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
 
         float pixelSize = static_cast<float>(
             (inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 1))
@@ -675,7 +675,7 @@ void Sculpt::onMouseHover(ui::MouseHoverEvent* event) {
 
     geometry::Vec2d viewCursor(event->position());
     geometry::Vec2d worldCursor =
-        canvas->camera().viewMatrix().inverted().transformPointAffine(viewCursor);
+        canvas->camera().viewMatrix().inverse().transformPointAffine(viewCursor);
 
     double worldSculptRadius =
         options::sculptRadius()->value(); // / canvas->camera().zoom();
@@ -771,7 +771,7 @@ void Sculpt::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
     using geometry::Vec2d;
     using geometry::Vec2f;
 
-    geometry::Mat4d ivm = canvas->camera().viewMatrix().inverted();
+    geometry::Mat4d ivm = canvas->camera().viewMatrix().inverse();
 
     geometry::Mat4f translation = geometry::Mat4f::identity;
     if (isActionCircleEnabled_) {

--- a/libs/vgc/tools/select.cpp
+++ b/libs/vgc/tools/select.cpp
@@ -858,7 +858,7 @@ public:
 
         geometry::Vec2d position(event->position());
 
-        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverted();
+        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
         geometry::Vec2d cursorPositionInWorkspace =
             inverseViewMatrix.transformPointAffine(position);
 
@@ -1022,7 +1022,7 @@ bool Select::onMouseMove(ui::MouseMoveEvent* event) {
     }
 
     if (isDragging_) {
-        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverted();
+        geometry::Mat4d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
 
         geometry::Vec2d cursorPosition(cursorPosition_);
         geometry::Vec2d cursorPositionAtPress(cursorPositionAtPress_);
@@ -1450,7 +1450,7 @@ void Select::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
 
     if (isDragging_ && dragAction_ == DragAction::Select) {
         if (!selectionRectangleGeometry_) {
-            geometry::Mat4d invView = canvas->camera().viewMatrix().inverted();
+            geometry::Mat4d invView = canvas->camera().viewMatrix().inverse();
             Vec2f a(invView.transformPointAffine(Vec2d(cursorPositionAtPress_)));
             Vec2f b(invView.transformPointAffine(Vec2d(cursorPosition_)));
             geometry::Rect2f rect = geometry::Rect2f::empty;

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -675,7 +675,7 @@ void Sketch::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
         geometry::Vec2f pos(w->mapFromGlobal(ui::globalCursorPosition()));
         geometry::Vec2d posd(root()->mapTo(this, pos));
         pos = geometry::Vec2f(
-            canvas->camera().viewMatrix().inverted().transformPointAffine(posd));
+            canvas->camera().viewMatrix().inverse().transformPointAffine(posd));
         if (lastImmediateCursorPos_ != pos) {
             lastImmediateCursorPos_ = pos;
             cursorMoved = true;
@@ -1346,7 +1346,7 @@ void Sketch::startCurve_(ui::MouseEvent* event) {
     startTime_ = event->timestamp();
 
     // Transform: Save inverse view matrix
-    canvasToWorkspaceMatrix_ = canvas->camera().viewMatrix().inverted();
+    canvasToWorkspaceMatrix_ = canvas->camera().viewMatrix().inverse();
 
     // Snapping: Compute start vertex to snap to
     workspace::Element* snapVertex = nullptr;

--- a/libs/vgc/tools/transform.cpp
+++ b/libs/vgc/tools/transform.cpp
@@ -269,7 +269,7 @@ public:
         transformer_.setElements(workspace, box->elementIds_);
 
         const geometry::Mat4d& cameraMatrix = canvas->camera().viewMatrix();
-        geometry::Mat4d invCameraMatrix = cameraMatrix.inverted();
+        geometry::Mat4d invCameraMatrix = cameraMatrix.inverse();
 
         geometry::Vec2d cursorPositionInCanvas(event->position());
         geometry::Vec2d cursorPosition =
@@ -344,7 +344,7 @@ public:
         geometry::Mat3d transform = geometry::Mat3d::identity;
 
         const geometry::Mat4d& cameraMatrix = canvas->camera().viewMatrix();
-        geometry::Mat4d invCameraMatrix = cameraMatrix.inverted();
+        geometry::Mat4d invCameraMatrix = cameraMatrix.inverse();
         geometry::Vec2d cursorPositionInCanvas(event->position());
 
         switch (transformType_) {
@@ -1679,7 +1679,7 @@ void TransformBox::onTranslate_(detail::TranslateStepDirection direction, double
     }
 
     const geometry::Mat4d& cameraMatrix = canvas->camera().viewMatrix();
-    geometry::Mat4d invCameraMatrix = cameraMatrix.inverted();
+    geometry::Mat4d invCameraMatrix = cameraMatrix.inverse();
     geometry::Vec2d p0 = pivotPoint_; // or center
     geometry::Vec2d p0c = cameraMatrix.transformPoint(p0);
     geometry::Vec2d p1c = cameraMatrix.transformPoint(p0 + unitDelta);

--- a/libs/vgc/vacomplex/cell.cpp
+++ b/libs/vgc/vacomplex/cell.cpp
@@ -95,7 +95,7 @@ Transform Group::computeInverseTransformTo(Group* ancestor) const {
 void Group::setTransform_(const Transform& transform) {
     transform_ = transform;
     // todo: handle non-invertible case.
-    inverseTransform_ = transform_.inverted();
+    inverseTransform_ = transform_.inverse();
     updateTransformFromRoot_();
 }
 


### PR DESCRIPTION
#673

The reason I decided to call it `inverted()` instead of `inverse()` was to make it clear to the caller that it returns the inverse, as opposed to modifying the matrix in-place. See for example `Vec::normalized()` vs. `Vec::normalize()`. This is also how it is called in the Qt matrix classes (QMatrix4x4, QTranform, etc.).

However, given that:
1. The in-place version would be called `invert()` anyway, not `inverse()`.
2. The name "inverse" is more natural in maths. See for example Google for “inverse matrix” (2M results) vs. “inverted matrix” (50k results).
3. The method name `inverse()` seems preferred in many (most?) linear algebra or engine libraries:
  - Eigen: [`inverse()`](https://eigen.tuxfamily.org/dox/classEigen_1_1MatrixBase.html)
  - Unity: [`inverse`](https://docs.unity3d.com/ScriptReference/Matrix4x4-inverse.html)
  - Unreal Engine: [`Inverse()`](https://dev.epicgames.com/documentation/en-us/unreal-engine/API/Runtime/GeometryCore/TMatrix3/Inverse)
  - Maya: [`inverse()`](https://help.autodesk.com/view/MAYAUL/2022/ENU/?guid=Maya_SDK_cpp_ref_class_m_matrix_html)
  - OpenUSD: [`GetInverse()`](https://openusd.org/release/api/class_gf_matrix4d.html), despite having also both `Orthogonalize()` (in-place) and `GetOrthogonolized()` (returns the value)

I changed my mind and decided to also call it `inverse()` in VGC.