### PR TITLE
Remove operator< requirement for a type to be holdable in a dom::Value (#873)

### DIFF
--- a/libs/vgc/dom/tests/test_value.cpp
+++ b/libs/vgc/dom/tests/test_value.cpp
@@ -73,10 +73,6 @@ public:
         return false;
     }
 
-    bool operator<(const TestObject&) const {
-        return false;
-    }
-
     template<typename IStream>
     friend void readTo(TestObject&, IStream&) {
     }
@@ -131,10 +127,6 @@ public:
     }
 
     bool operator!=(const TestObject2&) const {
-        return false;
-    }
-
-    bool operator<(const TestObject2&) const {
         return false;
     }
 

--- a/libs/vgc/dom/value.h
+++ b/libs/vgc/dom/value.h
@@ -154,7 +154,6 @@ public:
     void (*move)(ValueData&, ValueData&);
     void (*destroy)(ValueData&);
     bool (*equal)(const ValueData&, const ValueData&);
-    bool (*less)(const ValueData&, const ValueData&);
     Value (*getArrayItemWrapped)(const ValueData&, Int);
     void (*write)(const ValueData&, core::StringWriter&);
     Value (*readAs)(core::StringReader&);
@@ -178,7 +177,6 @@ public:
         , move(&move_<T>)
         , destroy(&destroy_<T>)
         , equal(&equal_<T>)
-        , less(&less_<T>)
         , getArrayItemWrapped(&getArrayItemWrapped_<T>)
         , write(&write_<T>)
         , readAs(&readAs_<T>)
@@ -225,11 +223,6 @@ private:
     template<typename T>
     static bool equal_(const ValueData& d1, const ValueData& d2) {
         return d1.get<T>() == d2.get<T>();
-    }
-
-    template<typename T>
-    static bool less_(const ValueData& d1, const ValueData& d2) {
-        return d1.get<T>() < d2.get<T>();
     }
 
     // This function is defined further in this file due to cyclic dependency with Value
@@ -456,11 +449,6 @@ public:
 
     friend bool operator!=(const Value& lhs, const Value& rhs) {
         return !(lhs == rhs);
-    }
-
-    friend bool operator<(const Value& lhs, const Value& rhs) {
-        return lhs.typeInfo_ == rhs.typeInfo_ //
-               && lhs.info_().less(lhs.data_, rhs.data_);
     }
 
     template<typename OStream>

--- a/libs/vgc/dom/wraps/wrap_value.cpp
+++ b/libs/vgc/dom/wraps/wrap_value.cpp
@@ -86,10 +86,6 @@ void wrap_value(py::module& m) {
 
     c.def(py::self == py::self);
     c.def(py::self != py::self);
-    c.def(py::self < py::self);
-    //c.def(py::self > py::self);
-    //c.def(py::self <= py::self);
-    //c.def(py::self >= py::self);
 
     c.def("__str__", [](const This& self) -> std::string {
         fmt::memory_buffer mbuf;


### PR DESCRIPTION
#873

Indeed, we want matrices to be holdable in a Value, and while it is possible to define an `operator<` for matrices (e.g., lexicographical in some arbitrary order of its elements), it's not necessarily a good idea.