### PR TITLE
Rename transformPoint[Affine] to transform[Affine] in Mat types (#673)

### DIFF
--- a/libs/vgc/canvas/canvas.cpp
+++ b/libs/vgc/canvas/canvas.cpp
@@ -140,7 +140,7 @@ core::Array<SelectionCandidate> Canvas::computeSelectionCandidatesAboveOrAt(
     double worldTol = tolerance;
 
     if (coordinateSpace == CoordinateSpace::Widget) {
-        worldCoords = camera().viewMatrix().inverse().transformPointAffine(worldCoords);
+        worldCoords = camera().viewMatrix().inverse().transformAffine(worldCoords);
         worldTol /= camera().zoom();
     }
 
@@ -224,8 +224,8 @@ core::Array<core::Id> Canvas::computeRectangleSelectionCandidates(
     geometry::Vec2d b = b_;
     if (coordinateSpace == CoordinateSpace::Widget) {
         geometry::Mat3d invView = camera().viewMatrix().inverse();
-        a = invView.transformPointAffine(a);
-        b = invView.transformPointAffine(b);
+        a = invView.transformAffine(a);
+        b = invView.transformAffine(b);
     }
 
     core::Array<core::Id> result;
@@ -346,9 +346,9 @@ bool Canvas::onMouseMove(ui::MouseMoveEvent* event) {
         // Set new camera center so that rotation center = mouse pos at press
         geometry::Vec2d pivotViewCoords = mousePosAtPress;
         geometry::Vec2d pivotWorldCoords =
-            cameraAtPress_.viewMatrix().inverse().transformPointAffine(pivotViewCoords);
+            cameraAtPress_.viewMatrix().inverse().transformAffine(pivotViewCoords);
         geometry::Vec2d pivotViewCoordsNow =
-            camera.viewMatrix().transformPointAffine(pivotWorldCoords);
+            camera.viewMatrix().transformAffine(pivotWorldCoords);
         camera.setCenter(camera.center() - pivotViewCoords + pivotViewCoordsNow);
     }
     else if (isZooming_) {
@@ -363,9 +363,9 @@ bool Canvas::onMouseMove(ui::MouseMoveEvent* event) {
         // Set new camera center so that zoom center = mouse pos at press
         geometry::Vec2d pivotViewCoords = mousePosAtPress;
         geometry::Vec2d pivotWorldCoords =
-            cameraAtPress_.viewMatrix().inverse().transformPointAffine(pivotViewCoords);
+            cameraAtPress_.viewMatrix().inverse().transformAffine(pivotViewCoords);
         geometry::Vec2d pivotViewCoordsNow =
-            camera.viewMatrix().transformPointAffine(pivotWorldCoords);
+            camera.viewMatrix().transformAffine(pivotWorldCoords);
         camera.setCenter(camera.center() - pivotViewCoords + pivotViewCoordsNow);
     }
     else {
@@ -433,13 +433,13 @@ bool Canvas::onMouseRelease(ui::MouseReleaseEvent* event) {
 
         // Save mouse pos in world coords before modifying camera
         geometry::Vec2d mousePos(mousePosAtPress_);
-        geometry::Vec2d p1 = camera.viewMatrix().inverse().transformPointAffine(mousePos);
+        geometry::Vec2d p1 = camera.viewMatrix().inverse().transformAffine(mousePos);
 
         // Reset camera rotation
         camera.setRotation(0);
 
         // Set new camera center so that zoom center = mouse pos at scroll
-        geometry::Vec2d p2 = camera.viewMatrix().transformPointAffine(p1);
+        geometry::Vec2d p2 = camera.viewMatrix().transformAffine(p1);
         camera.setCenter(camera.center() - mousePos + p2);
 
         setCamera(camera);
@@ -530,12 +530,12 @@ bool Canvas::onMouseScroll(ui::ScrollEvent* event) {
 
         // Save mouse pos in world coords before applying zoom
         geometry::Vec2d mousePos = geometry::Vec2d(event->position());
-        geometry::Vec2d p1 = camera.viewMatrix().inverse().transformPointAffine(mousePos);
+        geometry::Vec2d p1 = camera.viewMatrix().inverse().transformAffine(mousePos);
 
         camera.setZoom(newZoom);
 
         // Set new camera center so that zoom center = mouse pos at scroll
-        geometry::Vec2d p2 = camera.viewMatrix().transformPointAffine(p1);
+        geometry::Vec2d p2 = camera.viewMatrix().transformAffine(p1);
         camera.setCenter(camera.center() - mousePos + p2);
 
         setCamera(camera);

--- a/libs/vgc/canvas/canvasmanager.cpp
+++ b/libs/vgc/canvas/canvasmanager.cpp
@@ -277,9 +277,9 @@ void fitViewToRect_(Canvas& canvas, const geometry::Rect2d& rect) {
     // Set rotation
     // TODO: improve Camera2d API to make this easier.
     geometry::Vec2d c0 = 0.5 * viewportSize;
-    geometry::Vec2d c1 = camera.viewMatrix().inverse().transformPointAffine(c0);
+    geometry::Vec2d c1 = camera.viewMatrix().inverse().transformAffine(c0);
     camera.setRotation(rotation);
-    geometry::Vec2d c2 = camera.viewMatrix().transformPointAffine(c1);
+    geometry::Vec2d c2 = camera.viewMatrix().transformAffine(c1);
     camera.setCenter(camera.center() - c0 + c2);
 
     canvas.setCamera(camera);

--- a/libs/vgc/geometry/camera2d.h
+++ b/libs/vgc/geometry/camera2d.h
@@ -99,13 +99,13 @@ namespace vgc::geometry {
 /// use the viewMatrix() associated with the 2D camera:
 ///
 /// ```cpp
-/// Vec2d viewCoords = camera.viewMatrix().transformPointAffine(worldCoords);
+/// Vec2d viewCoords = camera.viewMatrix().transformAffine(worldCoords);
 /// ```
 ///
 /// This view matrix is always invertible, therefore we also have:
 ///
 /// ```cpp
-/// Vec2d worldCoords = camera.viewMatrix().inverse().transformPointAffine(viewCoords);
+/// Vec2d worldCoords = camera.viewMatrix().inverse().transformAffine(viewCoords);
 /// ```
 ///
 /// The projectionMatrix() is provided for conveninence when using OpenGL. It

--- a/libs/vgc/geometry/interpolatingstroke.cpp
+++ b/libs/vgc/geometry/interpolatingstroke.cpp
@@ -234,7 +234,7 @@ void AbstractInterpolatingStroke2d::translate_(const Vec2d& delta) {
 
 void AbstractInterpolatingStroke2d::transform_(const Mat3d& transformation) {
     for (Vec2d& p : positions_) {
-        p = transformation.transformPoint(p);
+        p = transformation.transform(p);
     }
     onPositionsChanged_();
 }

--- a/libs/vgc/geometry/mat2d.h
+++ b/libs/vgc/geometry/mat2d.h
@@ -291,10 +291,10 @@ public:
     /// Mat2d m(a, b,
     ///         c, d);
     /// double x;
-    /// double y = m.transformPoint(x); // y = (ax + b) / (cx + d)
+    /// double y = m.transform(x); // y = (ax + b) / (cx + d)
     /// ```
     ///
-    double transformPoint(double x) const {
+    double transform(double x) const {
         double x_ = data_[0][0]*x + data_[1][0];
         double w_ = data_[0][1]*x + data_[1][1];
         return x_ / w_;
@@ -311,14 +311,14 @@ public:
     /// Mat2d m(a, b,
     ///         c, d);
     /// double x;
-    /// double y = m.transformPointAffine(x); // y = ax + b
+    /// double y = m.transformAffine(x); // y = ax + b
     /// ```
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 1]`.
     ///
-    double transformPointAffine(double x) const {
+    double transformAffine(double x) const {
         return data_[0][0]*x + data_[1][0];
     }
 

--- a/libs/vgc/geometry/mat2f.h
+++ b/libs/vgc/geometry/mat2f.h
@@ -291,10 +291,10 @@ public:
     /// Mat2f m(a, b,
     ///         c, d);
     /// float x;
-    /// float y = m.transformPoint(x); // y = (ax + b) / (cx + d)
+    /// float y = m.transform(x); // y = (ax + b) / (cx + d)
     /// ```
     ///
-    float transformPoint(float x) const {
+    float transform(float x) const {
         float x_ = data_[0][0]*x + data_[1][0];
         float w_ = data_[0][1]*x + data_[1][1];
         return x_ / w_;
@@ -311,14 +311,14 @@ public:
     /// Mat2f m(a, b,
     ///         c, d);
     /// float x;
-    /// float y = m.transformPointAffine(x); // y = ax + b
+    /// float y = m.transformAffine(x); // y = ax + b
     /// ```
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 1]`.
     ///
-    float transformPointAffine(float x) const {
+    float transformAffine(float x) const {
         return data_[0][0]*x + data_[1][0];
     }
 

--- a/libs/vgc/geometry/mat3d.h
+++ b/libs/vgc/geometry/mat3d.h
@@ -409,7 +409,7 @@ public:
     /// then returning the first two coordinates divided by the third
     /// coordinate.
     ///
-    Vec2d transformPoint(const Vec2d& v) const {
+    Vec2d transform(const Vec2d& v) const {
         double x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0];
         double y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1];
         double w = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2];
@@ -424,11 +424,11 @@ public:
     /// This is equivalent to multiplying the 2x3 submatrix of this `Mat3d` by
     /// `Vec3d(x, y, 1)`.
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 0, 1]`.
     ///
-    Vec2d transformPointAffine(const Vec2d& v) const {
+    Vec2d transformAffine(const Vec2d& v) const {
         double x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0];
         double y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1];
         return Vec2d(x, y);

--- a/libs/vgc/geometry/mat3f.h
+++ b/libs/vgc/geometry/mat3f.h
@@ -409,7 +409,7 @@ public:
     /// then returning the first two coordinates divided by the third
     /// coordinate.
     ///
-    Vec2f transformPoint(const Vec2f& v) const {
+    Vec2f transform(const Vec2f& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1];
         float w = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2];
@@ -424,11 +424,11 @@ public:
     /// This is equivalent to multiplying the 2x3 submatrix of this `Mat3f` by
     /// `Vec3f(x, y, 1)`.
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 0, 1]`.
     ///
-    Vec2f transformPointAffine(const Vec2f& v) const {
+    Vec2f transformAffine(const Vec2f& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1];
         return Vec2f(x, y);

--- a/libs/vgc/geometry/mat4d.h
+++ b/libs/vgc/geometry/mat4d.h
@@ -550,7 +550,7 @@ public:
     /// then returning the first three coordinates divided by the fourth
     /// coordinate.
     ///
-    Vec3d transformPoint(const Vec3d& v) const {
+    Vec3d transform(const Vec3d& v) const {
         double x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0]*v[2] + data_[3][0];
         double y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1]*v[2] + data_[3][1];
         double z = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2]*v[2] + data_[3][2];
@@ -563,9 +563,9 @@ public:
     /// `Vec3d` with `z = 0`) by this `Mat4d` (interpreted as a 3D projective
     /// transformation), and returns the first 2 coordinates.
     ///
-    /// See `transformPoint(const Vec3d& v)` for details.
+    /// See `transform(const Vec3d& v)` for details.
     ///
-    Vec2d transformPoint(const Vec2d& v) const {
+    Vec2d transform(const Vec2d& v) const {
         double x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[3][0];
         double y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[3][1];
         double w = data_[0][3]*v[0] + data_[1][3]*v[1] + data_[3][3];
@@ -580,11 +580,11 @@ public:
     /// This is equivalent to multiplying the 3x4 submatrix of this `Mat4d` by
     /// `Vec4d(x, y, z, 1)`.
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 0, 0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 0, 0, 1]`.
     ///
-    Vec3d transformPointAffine(const Vec3d& v) const {
+    Vec3d transformAffine(const Vec3d& v) const {
         double x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0]*v[2] + data_[3][0];
         double y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1]*v[2] + data_[3][1];
         double z = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2]*v[2] + data_[3][2];
@@ -596,9 +596,9 @@ public:
     /// transformation, that is, ignoring the projective component), and
     /// returns the first 2 coordinates.
     ///
-    /// See `transformPointAffine(const Vec3d& v)` for details.
+    /// See `transformAffine(const Vec3d& v)` for details.
     ///
-    Vec2d transformPointAffine(const Vec2d& v) const {
+    Vec2d transformAffine(const Vec2d& v) const {
         double x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[3][0];
         double y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[3][1];
         return Vec2d(x, y);

--- a/libs/vgc/geometry/mat4f.h
+++ b/libs/vgc/geometry/mat4f.h
@@ -550,7 +550,7 @@ public:
     /// then returning the first three coordinates divided by the fourth
     /// coordinate.
     ///
-    Vec3f transformPoint(const Vec3f& v) const {
+    Vec3f transform(const Vec3f& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0]*v[2] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1]*v[2] + data_[3][1];
         float z = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2]*v[2] + data_[3][2];
@@ -563,9 +563,9 @@ public:
     /// `Vec3f` with `z = 0`) by this `Mat4f` (interpreted as a 3D projective
     /// transformation), and returns the first 2 coordinates.
     ///
-    /// See `transformPoint(const Vec3f& v)` for details.
+    /// See `transform(const Vec3f& v)` for details.
     ///
-    Vec2f transformPoint(const Vec2f& v) const {
+    Vec2f transform(const Vec2f& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[3][1];
         float w = data_[0][3]*v[0] + data_[1][3]*v[1] + data_[3][3];
@@ -580,11 +580,11 @@ public:
     /// This is equivalent to multiplying the 3x4 submatrix of this `Mat4f` by
     /// `Vec4f(x, y, z, 1)`.
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 0, 0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 0, 0, 1]`.
     ///
-    Vec3f transformPointAffine(const Vec3f& v) const {
+    Vec3f transformAffine(const Vec3f& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0]*v[2] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1]*v[2] + data_[3][1];
         float z = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2]*v[2] + data_[3][2];
@@ -596,9 +596,9 @@ public:
     /// transformation, that is, ignoring the projective component), and
     /// returns the first 2 coordinates.
     ///
-    /// See `transformPointAffine(const Vec3f& v)` for details.
+    /// See `transformAffine(const Vec3f& v)` for details.
     ///
-    Vec2f transformPointAffine(const Vec2f& v) const {
+    Vec2f transformAffine(const Vec2f& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[3][1];
         return Vec2f(x, y);

--- a/libs/vgc/geometry/tests/test_mat.py
+++ b/libs/vgc/geometry/tests/test_mat.py
@@ -687,7 +687,7 @@ class TestMat(unittest.TestCase):
                      7, 8, 9)
             v1 = Vec2(10, 20)
             v2 = Vec2(53, 146)
-            v3 = m.transformPointAffine(v1)
+            v3 = m.transformAffine(v1)
             self.assertEqual(v3, v2)
 
         for (Mat4, Vec2) in Mat4Vec2Types:
@@ -697,7 +697,7 @@ class TestMat(unittest.TestCase):
                      13, 14, 15, 16)
             v1 = Vec2(10, 20)
             v2 = Vec2(54, 178)
-            v3 = m.transformPointAffine(v1)
+            v3 = m.transformAffine(v1)
             self.assertEqual(v3, v2)
 
     def testInvertedScale(self):
@@ -734,26 +734,26 @@ class TestMat(unittest.TestCase):
             m1 = Mat.identity.translate(10)
             m2 = Mat.identity
             m2.translate(10)
-            self.assertEqual(m1.transformPoint(v), Vec2(11, 2))
-            self.assertEqual(m2.transformPoint(v), Vec2(11, 2))
+            self.assertEqual(m1.transform(v), Vec2(11, 2))
+            self.assertEqual(m2.transform(v), Vec2(11, 2))
             m1 = Mat.identity.translate(10, 20)
             m2 = Mat.identity
             m2.translate(10, 20)
-            self.assertEqual(m1.transformPoint(v), Vec2(11, 22))
-            self.assertEqual(m2.transformPoint(v), Vec2(11, 22))
+            self.assertEqual(m1.transform(v), Vec2(11, 22))
+            self.assertEqual(m2.transform(v), Vec2(11, 22))
 
         for (Mat3, Vec2) in Mat3Vec2Types:
             v = Vec2(1, 2)
             m1 = Mat3.identity.translate(Vec2(10, 20))
-            self.assertEqual(m1.transformPoint(v), Vec2(11, 22))
+            self.assertEqual(m1.transform(v), Vec2(11, 22))
 
         for (Mat4, Vec2) in Mat4Vec2Types:
             v = Vec2(1, 2)
             m1 = Mat4.identity.translate(10, 20, 30)
             m2 = Mat4.identity
             m2.translate(10, 20, 30)
-            self.assertEqual(m1.transformPoint(v), Vec2(11, 22))
-            self.assertEqual(m2.transformPoint(v), Vec2(11, 22))
+            self.assertEqual(m1.transform(v), Vec2(11, 22))
+            self.assertEqual(m2.transform(v), Vec2(11, 22))
 
     def testRotate(self):
         for (Mat, Vec2) in Mat3Vec2Types + Mat4Vec2Types:
@@ -761,16 +761,16 @@ class TestMat(unittest.TestCase):
             m1 = Mat.identity.rotate(pi/2)
             m2 = Mat.identity
             m2.rotate(pi/2)
-            self.assertEqual(m1.transformPoint(v), Vec2(-2, 1))
-            self.assertEqual(m2.transformPoint(v), Vec2(-2, 1))
+            self.assertEqual(m1.transform(v), Vec2(-2, 1))
+            self.assertEqual(m2.transform(v), Vec2(-2, 1))
             v = Vec2(2, 0)
             m1 = Mat.identity.rotate(pi/3)
             m2 = Mat.identity
             m2.rotate(pi/3)
             v2 = Vec2(1, sqrt(3))
             absTol = 1.0e-6
-            self.assertTrue(v2.allNear(m1.transformPoint(v), absTol))
-            self.assertTrue(v2.allNear(m2.transformPoint(v), absTol))
+            self.assertTrue(v2.allNear(m1.transform(v), absTol))
+            self.assertTrue(v2.allNear(m2.transform(v), absTol))
 
     def testScale(self):
         for (Mat, Vec2) in Mat3Vec2Types + Mat4Vec2Types:
@@ -778,26 +778,26 @@ class TestMat(unittest.TestCase):
             m1 = Mat.identity.scale(20)
             m2 = Mat.identity
             m2.scale(20)
-            self.assertEqual(m1.transformPoint(v), Vec2(40, 60))
-            self.assertEqual(m2.transformPoint(v), Vec2(40, 60))
+            self.assertEqual(m1.transform(v), Vec2(40, 60))
+            self.assertEqual(m2.transform(v), Vec2(40, 60))
             m1 = Mat.identity.scale(20, 30)
             m2 = Mat.identity
             m2.scale(20, 30)
-            self.assertTrue(m1.transformPoint(v), Vec2(40, 90))
-            self.assertEqual(m2.transformPoint(v), Vec2(40, 90))
+            self.assertTrue(m1.transform(v), Vec2(40, 90))
+            self.assertEqual(m2.transform(v), Vec2(40, 90))
 
         for (Mat3, Vec2) in Mat3Vec2Types:
             v = Vec2(2, 3)
             m1 = Mat3.identity.scale(Vec2(20, 30))
-            self.assertTrue(m1.transformPoint(v), Vec2(40, 90))
+            self.assertTrue(m1.transform(v), Vec2(40, 90))
 
         for (Mat4, Vec2) in Mat4Vec2Types:
             v = Vec2(2, 3)
             m1 = Mat4.identity.scale(20, 30, 40)
             m2 = Mat4.identity
             m2.scale(20, 30, 40)
-            self.assertEqual(m1.transformPoint(v), Vec2(40, 90))
-            self.assertEqual(m2.transformPoint(v), Vec2(40, 90))
+            self.assertEqual(m1.transform(v), Vec2(40, 90))
+            self.assertEqual(m2.transform(v), Vec2(40, 90))
 
     def testComparisonOperators(self):
         for (Mat, dim) in MatTypes:

--- a/libs/vgc/geometry/tools/mat2x.h
+++ b/libs/vgc/geometry/tools/mat2x.h
@@ -291,10 +291,10 @@ public:
     /// Mat2x m(a, b,
     ///         c, d);
     /// float x;
-    /// float y = m.transformPoint(x); // y = (ax + b) / (cx + d)
+    /// float y = m.transform(x); // y = (ax + b) / (cx + d)
     /// ```
     ///
-    float transformPoint(float x) const {
+    float transform(float x) const {
         float x_ = data_[0][0]*x + data_[1][0];
         float w_ = data_[0][1]*x + data_[1][1];
         return x_ / w_;
@@ -311,14 +311,14 @@ public:
     /// Mat2x m(a, b,
     ///         c, d);
     /// float x;
-    /// float y = m.transformPointAffine(x); // y = ax + b
+    /// float y = m.transformAffine(x); // y = ax + b
     /// ```
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 1]`.
     ///
-    float transformPointAffine(float x) const {
+    float transformAffine(float x) const {
         return data_[0][0]*x + data_[1][0];
     }
 

--- a/libs/vgc/geometry/tools/mat3x.h
+++ b/libs/vgc/geometry/tools/mat3x.h
@@ -409,7 +409,7 @@ public:
     /// then returning the first two coordinates divided by the third
     /// coordinate.
     ///
-    Vec2x transformPoint(const Vec2x& v) const {
+    Vec2x transform(const Vec2x& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1];
         float w = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2];
@@ -424,11 +424,11 @@ public:
     /// This is equivalent to multiplying the 2x3 submatrix of this `Mat3x` by
     /// `Vec3x(x, y, 1)`.
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 0, 1]`.
     ///
-    Vec2x transformPointAffine(const Vec2x& v) const {
+    Vec2x transformAffine(const Vec2x& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1];
         return Vec2x(x, y);

--- a/libs/vgc/geometry/tools/mat4x.h
+++ b/libs/vgc/geometry/tools/mat4x.h
@@ -550,7 +550,7 @@ public:
     /// then returning the first three coordinates divided by the fourth
     /// coordinate.
     ///
-    Vec3x transformPoint(const Vec3x& v) const {
+    Vec3x transform(const Vec3x& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0]*v[2] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1]*v[2] + data_[3][1];
         float z = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2]*v[2] + data_[3][2];
@@ -563,9 +563,9 @@ public:
     /// `Vec3x` with `z = 0`) by this `Mat4x` (interpreted as a 3D projective
     /// transformation), and returns the first 2 coordinates.
     ///
-    /// See `transformPoint(const Vec3x& v)` for details.
+    /// See `transform(const Vec3x& v)` for details.
     ///
-    Vec2x transformPoint(const Vec2x& v) const {
+    Vec2x transform(const Vec2x& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[3][1];
         float w = data_[0][3]*v[0] + data_[1][3]*v[1] + data_[3][3];
@@ -580,11 +580,11 @@ public:
     /// This is equivalent to multiplying the 3x4 submatrix of this `Mat4x` by
     /// `Vec4x(x, y, z, 1)`.
     ///
-    /// This can be used as a faster version of `transformPoint()` whenever you
+    /// This can be used as a faster version of `transform()` whenever you
     /// know that the last row of the matrix is equal to `[0, 0, 0, 1]`, or
     /// whenever you prefer to behave as if the last row was `[0, 0, 0, 1]`.
     ///
-    Vec3x transformPointAffine(const Vec3x& v) const {
+    Vec3x transformAffine(const Vec3x& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[2][0]*v[2] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[2][1]*v[2] + data_[3][1];
         float z = data_[0][2]*v[0] + data_[1][2]*v[1] + data_[2][2]*v[2] + data_[3][2];
@@ -596,9 +596,9 @@ public:
     /// transformation, that is, ignoring the projective component), and
     /// returns the first 2 coordinates.
     ///
-    /// See `transformPointAffine(const Vec3x& v)` for details.
+    /// See `transformAffine(const Vec3x& v)` for details.
     ///
-    Vec2x transformPointAffine(const Vec2x& v) const {
+    Vec2x transformAffine(const Vec2x& v) const {
         float x = data_[0][0]*v[0] + data_[1][0]*v[1] + data_[3][0];
         float y = data_[0][1]*v[0] + data_[1][1]*v[1] + data_[3][1];
         return Vec2x(x, y);

--- a/libs/vgc/geometry/wraps/wrap_mat.cpp
+++ b/libs/vgc/geometry/wraps/wrap_mat.cpp
@@ -371,18 +371,18 @@ void wrap_mat(py::module& m, const std::string& name) {
 
     // Transform
     cmat.def(
-        "transformPoint",
-        py::overload_cast<TPointParam>(&TMat::transformPoint, py::const_));
+        "transform",
+        py::overload_cast<TPointParam>(&TMat::transform, py::const_));
     cmat.def(
-        "transformPointAffine",
-        py::overload_cast<TPointParam>(&TMat::transformPointAffine, py::const_));
+        "transformAffine",
+        py::overload_cast<TPointParam>(&TMat::transformAffine, py::const_));
     if constexpr (dimension == 4) {
         cmat.def(
-            "transformPoint",
-            py::overload_cast<const TVec2&>(&TMat::transformPoint, py::const_));
+            "transform",
+            py::overload_cast<const TVec2&>(&TMat::transform, py::const_));
         cmat.def(
-            "transformPointAffine",
-            py::overload_cast<const TVec2&>(&TMat::transformPointAffine, py::const_));
+            "transformAffine",
+            py::overload_cast<const TVec2&>(&TMat::transformAffine, py::const_));
     }
 
     // Identity

--- a/libs/vgc/geometry/wraps/wrap_mat.cpp
+++ b/libs/vgc/geometry/wraps/wrap_mat.cpp
@@ -370,16 +370,13 @@ void wrap_mat(py::module& m, const std::string& name) {
         .def(py::self * TVec());
 
     // Transform
-    cmat.def(
-        "transform",
-        py::overload_cast<TPointParam>(&TMat::transform, py::const_));
+    cmat.def("transform", py::overload_cast<TPointParam>(&TMat::transform, py::const_));
     cmat.def(
         "transformAffine",
         py::overload_cast<TPointParam>(&TMat::transformAffine, py::const_));
     if constexpr (dimension == 4) {
         cmat.def(
-            "transform",
-            py::overload_cast<const TVec2&>(&TMat::transform, py::const_));
+            "transform", py::overload_cast<const TVec2&>(&TMat::transform, py::const_));
         cmat.def(
             "transformAffine",
             py::overload_cast<const TVec2&>(&TMat::transformAffine, py::const_));

--- a/libs/vgc/graphics/font.cpp
+++ b/libs/vgc/graphics/font.cpp
@@ -749,7 +749,7 @@ void SizedGlyph::fill(core::FloatArray& data, const geometry::Mat3f& transform) 
     while (out != end) {
         float x = *in++;
         float y = *in++;
-        geometry::Vec2f v = transform.transformPoint({x, y});
+        geometry::Vec2f v = transform.transform({x, y});
         *out++ = v[0];
         *out++ = v[1];
     }

--- a/libs/vgc/graphics/icon.cpp
+++ b/libs/vgc/graphics/icon.cpp
@@ -143,7 +143,7 @@ void applyTransform(Batch& batch, const SvgSimplePath& path, Int oldLength) {
     for (Int i = oldLength; i + 1 < newLength; i += 2) {
         float& x = batch.vertices.getUnchecked(i);
         float& y = batch.vertices.getUnchecked(i + 1);
-        geometry::Vec2f p = tf.transformPoint(geometry::Vec2f(x, y));
+        geometry::Vec2f p = tf.transform(geometry::Vec2f(x, y));
         x = p.x();
         y = p.y();
     }

--- a/libs/vgc/tools/paintbucket.cpp
+++ b/libs/vgc/tools/paintbucket.cpp
@@ -61,8 +61,7 @@ void PaintBucket::onMouseHover(ui::MouseHoverEvent* event) {
     geometry::Vec2d mousePos = geometry::Vec2d(mousePosf.x(), mousePosf.y());
     geometry::Vec2d viewCoords = mousePos;
     geometry::Vec2d worldCoords =
-        context.canvas()->camera().viewMatrix().inverse().transformAffine(
-            viewCoords);
+        context.canvas()->camera().viewMatrix().inverse().transformAffine(viewCoords);
 
     // Compute the key face candidate for the current mouse position.
     //

--- a/libs/vgc/tools/paintbucket.cpp
+++ b/libs/vgc/tools/paintbucket.cpp
@@ -61,7 +61,7 @@ void PaintBucket::onMouseHover(ui::MouseHoverEvent* event) {
     geometry::Vec2d mousePos = geometry::Vec2d(mousePosf.x(), mousePosf.y());
     geometry::Vec2d viewCoords = mousePos;
     geometry::Vec2d worldCoords =
-        context.canvas()->camera().viewMatrix().inverse().transformPointAffine(
+        context.canvas()->camera().viewMatrix().inverse().transformAffine(
             viewCoords);
 
     // Compute the key face candidate for the current mouse position.

--- a/libs/vgc/tools/sculpt.cpp
+++ b/libs/vgc/tools/sculpt.cpp
@@ -124,14 +124,14 @@ public:
         geometry::Mat3d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
 
         float pixelSize = static_cast<float>(
-            (inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 1))
-             - inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 0)))
+            (inverseViewMatrix.transformAffine(geometry::Vec2d(0, 1))
+             - inverseViewMatrix.transformAffine(geometry::Vec2d(0, 0)))
                 .length());
 
         geometry::Vec2d cursorPositionInWorkspace =
-            inverseViewMatrix.transformPointAffine(geometry::Vec2d(cursorPosition_));
+            inverseViewMatrix.transformAffine(geometry::Vec2d(cursorPosition_));
         geometry::Vec2d cursorPositionInWorkspaceAtPress =
-            inverseViewMatrix.transformPointAffine(
+            inverseViewMatrix.transformAffine(
                 geometry::Vec2d(cursorPositionAtPress_));
 
         // Open history group
@@ -289,12 +289,12 @@ public:
         geometry::Mat3d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
 
         float pixelSize = static_cast<float>(
-            (inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 1))
-             - inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 0)))
+            (inverseViewMatrix.transformAffine(geometry::Vec2d(0, 1))
+             - inverseViewMatrix.transformAffine(geometry::Vec2d(0, 0)))
                 .length());
 
         geometry::Vec2d cursorPositionInWorkspaceAtPress =
-            inverseViewMatrix.transformPointAffine(
+            inverseViewMatrix.transformAffine(
                 geometry::Vec2d(cursorPositionAtPress_));
 
         geometry::Vec2f deltaCursor = cursorPosition_ - cursorPositionAtPress_;
@@ -460,12 +460,12 @@ public:
         geometry::Mat3d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
 
         float pixelSize = static_cast<float>(
-            (inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 1))
-             - inverseViewMatrix.transformPointAffine(geometry::Vec2d(0, 0)))
+            (inverseViewMatrix.transformAffine(geometry::Vec2d(0, 1))
+             - inverseViewMatrix.transformAffine(geometry::Vec2d(0, 0)))
                 .length());
 
         // for now, smooth once in the middle of the cursor displacement
-        geometry::Vec2d positionInWorkspace = inverseViewMatrix.transformPointAffine(
+        geometry::Vec2d positionInWorkspace = inverseViewMatrix.transformAffine(
             geometry::Vec2d(0.5 * (cursorPosition_ + cursorPositionAtLastSmooth_)));
         double disp = (cursorPosition_ - cursorPositionAtLastSmooth_).length()
                       / canvas->camera().zoom();
@@ -675,7 +675,7 @@ void Sculpt::onMouseHover(ui::MouseHoverEvent* event) {
 
     geometry::Vec2d viewCursor(event->position());
     geometry::Vec2d worldCursor =
-        canvas->camera().viewMatrix().inverse().transformPointAffine(viewCursor);
+        canvas->camera().viewMatrix().inverse().transformAffine(viewCursor);
 
     double worldSculptRadius =
         options::sculptRadius()->value(); // / canvas->camera().zoom();
@@ -785,7 +785,7 @@ void Sculpt::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
     }
     else {
         Vec2d pos(cursorPosition_);
-        translation.translate(canvasViewInverse.transformPointAffine(pos));
+        translation.translate(canvasViewInverse.transformAffine(pos));
     }
 
     Mat4f scaling = Mat4f::identity;

--- a/libs/vgc/tools/sculpt.cpp
+++ b/libs/vgc/tools/sculpt.cpp
@@ -131,8 +131,7 @@ public:
         geometry::Vec2d cursorPositionInWorkspace =
             inverseViewMatrix.transformAffine(geometry::Vec2d(cursorPosition_));
         geometry::Vec2d cursorPositionInWorkspaceAtPress =
-            inverseViewMatrix.transformAffine(
-                geometry::Vec2d(cursorPositionAtPress_));
+            inverseViewMatrix.transformAffine(geometry::Vec2d(cursorPositionAtPress_));
 
         // Open history group
         core::UndoGroup* undoGroup = nullptr;
@@ -294,8 +293,7 @@ public:
                 .length());
 
         geometry::Vec2d cursorPositionInWorkspaceAtPress =
-            inverseViewMatrix.transformAffine(
-                geometry::Vec2d(cursorPositionAtPress_));
+            inverseViewMatrix.transformAffine(geometry::Vec2d(cursorPositionAtPress_));
 
         geometry::Vec2f deltaCursor = cursorPosition_ - cursorPositionAtPress_;
         double sinAngle = deltaCursor.normalized().det(geometry::Vec2f(1, 0));

--- a/libs/vgc/tools/select.cpp
+++ b/libs/vgc/tools/select.cpp
@@ -860,7 +860,7 @@ public:
 
         geometry::Mat3d inverseViewMatrix = canvas->camera().viewMatrix().inverse();
         geometry::Vec2d cursorPositionInWorkspace =
-            inverseViewMatrix.transformPointAffine(position);
+            inverseViewMatrix.transformAffine(position);
 
         core::Array<canvas::SelectionCandidate> candidates =
             canvas->computeSelectionCandidates(position);
@@ -1028,9 +1028,9 @@ bool Select::onMouseMove(ui::MouseMoveEvent* event) {
         geometry::Vec2d cursorPositionAtPress(cursorPositionAtPress_);
 
         geometry::Vec2d cursorPositionInWorkspace =
-            inverseViewMatrix.transformPointAffine(cursorPosition);
+            inverseViewMatrix.transformAffine(cursorPosition);
         geometry::Vec2d cursorPositionInWorkspaceAtPress =
-            inverseViewMatrix.transformPointAffine(cursorPositionAtPress);
+            inverseViewMatrix.transformAffine(cursorPositionAtPress);
 
         switch (dragAction_) {
         case DragAction::Select: {
@@ -1451,8 +1451,8 @@ void Select::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
     if (isDragging_ && dragAction_ == DragAction::Select) {
         if (!selectionRectangleGeometry_) {
             geometry::Mat3d invView = canvas->camera().viewMatrix().inverse();
-            Vec2f a(invView.transformPointAffine(Vec2d(cursorPositionAtPress_)));
-            Vec2f b(invView.transformPointAffine(Vec2d(cursorPosition_)));
+            Vec2f a(invView.transformAffine(Vec2d(cursorPositionAtPress_)));
+            Vec2f b(invView.transformAffine(Vec2d(cursorPosition_)));
             geometry::Rect2f rect = geometry::Rect2f::empty;
             rect.uniteWith(a);
             rect.uniteWith(b);

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -675,7 +675,7 @@ void Sketch::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
         geometry::Vec2f pos(w->mapFromGlobal(ui::globalCursorPosition()));
         geometry::Vec2d posd(root()->mapTo(this, pos));
         pos = geometry::Vec2f(
-            canvas->camera().viewMatrix().inverse().transformPointAffine(posd));
+            canvas->camera().viewMatrix().inverse().transformAffine(posd));
         if (lastImmediateCursorPos_ != pos) {
             lastImmediateCursorPos_ = pos;
             cursorMoved = true;
@@ -772,8 +772,8 @@ void Sketch::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
 
     if (showInputPixels) { // TODO: only update on new points
         float hp = static_cast<float>(
-            (canvasToWorkspaceMatrix_.transformPointAffine(geometry::Vec2d(0, 0.5))
-             - canvasToWorkspaceMatrix_.transformPointAffine(geometry::Vec2d(0, 0)))
+            (canvasToWorkspaceMatrix_.transformAffine(geometry::Vec2d(0, 0.5))
+             - canvasToWorkspaceMatrix_.transformAffine(geometry::Vec2d(0, 0)))
                 .length());
         core::FloatArray pointVertices(
             {-hp, -hp, 0, 0, hp, -hp, 0, 0, -hp, hp, 0, 0, hp, hp, 0, 0});
@@ -783,7 +783,7 @@ void Sketch::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
         for (Int i = 0; i < numPoints; ++i) {
             geometry::Vec2d pd = inputPoints_[i].position();
             geometry::Vec2f p =
-                geometry::Vec2f(canvasToWorkspaceMatrix_.transformPointAffine(pd));
+                geometry::Vec2f(canvasToWorkspaceMatrix_.transformAffine(pd));
             pointInstData.extend({p.x(), p.y(), 0.f, 4.f, 0.f, 1.f, 0.f, 0.5f});
         }
 
@@ -955,7 +955,7 @@ void Sketch::updateTransformedPoints_() {
 
     for (auto it = inputPoints.begin() + n; it != inputPoints.end(); ++it) {
         SketchPoint& p = transformedPoints_.append(*it);
-        p.setPosition(canvasToWorkspaceMatrix_.transformPointAffine(p.position()));
+        p.setPosition(canvasToWorkspaceMatrix_.transformAffine(p.position()));
     }
 }
 
@@ -1350,8 +1350,7 @@ void Sketch::startCurve_(ui::MouseEvent* event) {
 
     // Snapping: Compute start vertex to snap to
     workspace::Element* snapVertex = nullptr;
-    geometry::Vec2d startPosition =
-        canvasToWorkspaceMatrix_.transformPointAffine(eventPos2d);
+    geometry::Vec2d startPosition = canvasToWorkspaceMatrix_.transformAffine(eventPos2d);
     if (isSnappingEnabled()) {
         snapVertex = computeSnapVertex_(startPosition, 0);
         if (snapVertex) {

--- a/libs/vgc/tools/transform.cpp
+++ b/libs/vgc/tools/transform.cpp
@@ -349,8 +349,8 @@ public:
 
         switch (transformType_) {
         case detail::TransformDragActionType::Scale: {
-            geometry::Vec2d cursorPosition = invCameraMatrix.transform(
-                cursorPositionInCanvas + cursorManipDelta_);
+            geometry::Vec2d cursorPosition =
+                invCameraMatrix.transform(cursorPositionInCanvas + cursorManipDelta_);
             transform.translate(oppositeManipPoint_);
             geometry::Vec2d d0 = (originalManipPoint_ - oppositeManipPoint_);
             geometry::Vec2d d1 = (cursorPosition - oppositeManipPoint_);
@@ -668,8 +668,7 @@ void TopologyAwareTransformer::transform(const geometry::Mat3d& transform) {
         vacomplex::KeyVertex* kv = findKeyVertex_(*workspace, td.elementId);
         if (kv) {
             mainOp.addComplex(kv->complex());
-            vacomplex::ops::setKeyVertexPosition(
-                kv, transform.transform(kv->position()));
+            vacomplex::ops::setKeyVertexPosition(kv, transform.transform(kv->position()));
         }
     }
 

--- a/libs/vgc/tools/transform.cpp
+++ b/libs/vgc/tools/transform.cpp
@@ -273,7 +273,7 @@ public:
 
         geometry::Vec2d cursorPositionInCanvas(event->position());
         geometry::Vec2d cursorPosition =
-            invCameraMatrix.transformPoint(cursorPositionInCanvas);
+            invCameraMatrix.transform(cursorPositionInCanvas);
 
         // Retrieve positions in workspace of:
         // - pivot point
@@ -308,10 +308,10 @@ public:
 
         // Compute delta in canvas space between cursor and manipulation point.
         cursorManipDelta_ =
-            cameraMatrix.transformPoint(originalManipPoint_) - cursorPositionInCanvas;
+            cameraMatrix.transform(originalManipPoint_) - cursorPositionInCanvas;
 
         geometry::Vec2d oppositeManipPointInCanvas =
-            cameraMatrix.transformPoint(oppositeManipPoint_);
+            cameraMatrix.transform(oppositeManipPoint_);
         cursorManipAngleStart_ =
             (cursorPositionInCanvas - oppositeManipPointInCanvas).angle();
     }
@@ -349,7 +349,7 @@ public:
 
         switch (transformType_) {
         case detail::TransformDragActionType::Scale: {
-            geometry::Vec2d cursorPosition = invCameraMatrix.transformPoint(
+            geometry::Vec2d cursorPosition = invCameraMatrix.transform(
                 cursorPositionInCanvas + cursorManipDelta_);
             transform.translate(oppositeManipPoint_);
             geometry::Vec2d d0 = (originalManipPoint_ - oppositeManipPoint_);
@@ -376,7 +376,7 @@ public:
             transform.translate(oppositeManipPoint_);
 
             geometry::Vec2d oppositeManipPointInCanvas =
-                cameraMatrix.transformPoint(oppositeManipPoint_);
+                cameraMatrix.transform(oppositeManipPoint_);
             double cursorManipAngleNow =
                 (cursorPositionInCanvas - oppositeManipPointInCanvas).angle();
 
@@ -669,7 +669,7 @@ void TopologyAwareTransformer::transform(const geometry::Mat3d& transform) {
         if (kv) {
             mainOp.addComplex(kv->complex());
             vacomplex::ops::setKeyVertexPosition(
-                kv, transform.transformPoint(kv->position()));
+                kv, transform.transform(kv->position()));
         }
     }
 
@@ -788,7 +788,7 @@ void TopologyAwareTransformer::updateDragTransform(const geometry::Mat3d& transf
         if (kv) {
             mainOp.addComplex(kv->complex());
             vacomplex::ops::setKeyVertexPosition(
-                kv, transform.transformPoint(td.originalPosition));
+                kv, transform.transform(td.originalPosition));
         }
     }
 
@@ -1217,19 +1217,19 @@ void TransformBox::onPaintDraw(graphics::Engine* engine, ui::PaintOptions option
     Vec2f pivot;
     if (isTransformActionOngoing_) {
         for (Int i = 0; i < 4; ++i) {
-            Vec2d p = transformActionMatrix_.transformPoint(boundingBox_.corner(i));
-            corners[i] = Vec2f(cameraMatrix.transformPoint(p));
+            Vec2d p = transformActionMatrix_.transform(boundingBox_.corner(i));
+            corners[i] = Vec2f(cameraMatrix.transform(p));
         }
         {
-            Vec2d p = transformActionMatrix_.transformPoint(pivotPoint_);
-            pivot = Vec2f(cameraMatrix.transformPoint(p));
+            Vec2d p = transformActionMatrix_.transform(pivotPoint_);
+            pivot = Vec2f(cameraMatrix.transform(p));
         }
         hasRotation |= (transformActionMatrix_ * Vec3d(0, 1, 0)).x() != 0
                        || (transformActionMatrix_ * Vec3d(1, 0, 0)).y() != 0;
     }
     else {
         corners = corners_;
-        pivot = Vec2f(cameraMatrix.transformPoint(pivotPoint_));
+        pivot = Vec2f(cameraMatrix.transform(pivotPoint_));
     }
 
     if (doHinting && !hasRotation) {
@@ -1366,7 +1366,7 @@ void TransformBox::computeHoverData_(const canvas::Canvas& canvas) {
 
     // Compute corners_
     for (Int i = 0; i < 4; ++i) {
-        Vec2f p(cameraMatrix.transformPoint(boundingBox_.corner(i)));
+        Vec2f p(cameraMatrix.transform(boundingBox_.corner(i)));
         corners_[i] = p;
     }
 
@@ -1681,10 +1681,10 @@ void TransformBox::onTranslate_(detail::TranslateStepDirection direction, double
     geometry::Mat3d cameraMatrix = canvas->camera().viewMatrix();
     geometry::Mat3d invCameraMatrix = cameraMatrix.inverse();
     geometry::Vec2d p0 = pivotPoint_; // or center
-    geometry::Vec2d p0c = cameraMatrix.transformPoint(p0);
-    geometry::Vec2d p1c = cameraMatrix.transformPoint(p0 + unitDelta);
+    geometry::Vec2d p0c = cameraMatrix.transform(p0);
+    geometry::Vec2d p1c = cameraMatrix.transform(p0 + unitDelta);
     geometry::Vec2d dir = (p1c - p0c).normalized();
-    geometry::Vec2d p1 = invCameraMatrix.transformPoint(p0c + dir * size);
+    geometry::Vec2d p1 = invCameraMatrix.transform(p0c + dir * size);
     geometry::Vec2d delta = p1 - p0;
 
     detail::TopologyAwareTransformer transformer;


### PR DESCRIPTION
#673

Rationale: the name was a bit too long, and it seems more consistent/clear to me to have:

- transform
- transformAffine
- transformLinear

rather than:

- transformPoint
- transformPointAffine
- transformVector (or transformDir)

Since at the end of the day, what matters most is which operation is performed, which is better conveyed with the top terminology. It's up to client code to use it for different purposes, for example, one may want to apply the linear part of a transform to a "point" as well. This is actually a use case I have now to draw a quad centered at a given location, but rotated and scaled according to another transform.