### PR TITLE
Implement VGC_UNUSED to declare unused variables; Update code accordingly (#748)

### DIFF
--- a/libs/vgc/app/nativemenubar.cpp
+++ b/libs/vgc/app/nativemenubar.cpp
@@ -87,7 +87,8 @@ void NativeMenuBar::convertToNativeMenuBar_() {
     populateMenuBar_(menu_, qMenuBar_);
 }
 
-void NativeMenuBar::registerMenuBar_(ui::Menu* menu, QMenuBar* /*qMenu*/) {
+void NativeMenuBar::registerMenuBar_(ui::Menu* menu, QMenuBar* qMenu) {
+    VGC_UNUSED(qMenu);
     menu->changed().connect(onMenuChangedSlot_());
     ui::userShortcuts()->changed().connect(onShortcutsChangedSlot_());
 }

--- a/libs/vgc/canvas/canvas.cpp
+++ b/libs/vgc/canvas/canvas.cpp
@@ -153,7 +153,8 @@ core::Array<SelectionCandidate> Canvas::computeSelectionCandidatesAboveOrAt(
         bool skip = itemId > 0;
         workspace->visitDepthFirst(
             [](workspace::Element*, Int) { return true; },
-            [=, &result, &skip](workspace::Element* e, Int /*depth*/) {
+            [=, &result, &skip](workspace::Element* e, Int depth) {
+                VGC_UNUSED(depth);
                 if (!e || (skip && e->id() != itemId)) {
                     return;
                 }
@@ -242,7 +243,8 @@ core::Array<core::Id> Canvas::computeRectangleSelectionCandidates(
 
         workspace->visitDepthFirst(
             [](workspace::Element*, Int) { return true; },
-            [&, rect, isMeshEnabled](workspace::Element* e, Int /*depth*/) {
+            [&, rect, isMeshEnabled](workspace::Element* e, Int depth) {
+                VGC_UNUSED(depth);
                 if (!e) {
                     return;
                 }
@@ -592,11 +594,14 @@ void drawSubpass(
 
     engine->setRasterizerState(rasterizerState);
     workspace.visitDepthFirst(
-        [](workspace::Element* /*e*/, Int /*depth*/) {
+        [](workspace::Element* e, Int depth) {
+            VGC_UNUSED(e);
+            VGC_UNUSED(depth);
             // we always visit children for now
             return true;
         },
-        [=](workspace::Element* e, Int /*depth*/) {
+        [=](workspace::Element* e, Int depth) {
+            VGC_UNUSED(depth);
             if (e) {
                 e->paint(engine, {}, paintOptions);
             }
@@ -828,7 +833,8 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
         if (showInputSketchPoints) {
             engine->setRasterizerState(fillRS_);
             workspace->visitDepthFirstPreOrder(
-                [=, &selectedElements](workspace::Element* e, Int /*depth*/) {
+                [=, &selectedElements](workspace::Element* e, Int depth) {
+                    VGC_UNUSED(depth);
                     if (e && !selectedElements.contains(e)) {
                         if (auto edge = dynamic_cast<workspace::VacKeyEdge*>(e)) {
                             doPaintInputSketchPoints(
@@ -865,11 +871,14 @@ void Canvas::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
             bool areNonSelectedVerticesVisible =
                 isOutlineEnabled || areControlPointsVisible_;
             workspace->visitDepthFirst(
-                [](workspace::Element* /*e*/, Int /*depth*/) {
+                [](workspace::Element* e, Int depth) {
+                    VGC_UNUSED(e);
+                    VGC_UNUSED(depth);
                     // we always visit children for now
                     return true;
                 },
-                [=, &selectedElements](workspace::Element* e, Int /*depth*/) {
+                [=, &selectedElements](workspace::Element* e, Int depth) {
+                    VGC_UNUSED(depth);
                     if (e && selectedElements.contains(e)) {
                         auto edge = dynamic_cast<workspace::VacKeyEdge*>(e);
 

--- a/libs/vgc/canvas/canvasmanager.cpp
+++ b/libs/vgc/canvas/canvasmanager.cpp
@@ -292,7 +292,8 @@ void fitViewToDocument_(Canvas& canvas, workspace::Workspace& workspace) {
     // TODO: implement Workspace::boundingBox().
     geometry::Rect2d rect = geometry::Rect2d::empty;
     workspace.visitDepthFirstPreOrder( //
-        [&rect](workspace::Element* e, Int /*depth*/) {
+        [&rect](workspace::Element* e, Int depth) {
+            VGC_UNUSED(depth);
             rect.uniteWith(e->boundingBox());
         });
     fitViewToRect_(canvas, rect);

--- a/libs/vgc/core/defs.h
+++ b/libs/vgc/core/defs.h
@@ -180,10 +180,10 @@
 /// intentionally discarded. This is equivalent to a cast to `void` but
 /// clarifies intent and improves searchability.
 ///
-/// For unused variable, prefer using `VGC_UNUSED`.
+/// For unused variables, prefer using `VGC_UNUSED`.
 ///
 /// ```cpp
-/// [[nodiscar]] int foo();
+/// [[nodiscard]] int foo();
 /// void bar() {
 ///     VGC_DISCARD(foo());
 /// }
@@ -220,8 +220,8 @@
 /// int getOrInsert(const std::map<int, int>& map, int key, int value) {
 ///     auto [it, inserted] = map.try_emplace(key, value);
 ///     VGC_UNUSED(inserted);
-///     int value = it->second;;
-///     return value;
+///     int valueInMap = it->second;
+///     return valueInMap;
 /// }
 ///
 /// // Conditionally used argument depending on template instantiation.

--- a/libs/vgc/core/defs.h
+++ b/libs/vgc/core/defs.h
@@ -174,6 +174,95 @@
 #    define VGC_NODISCARD(msg) [[nodiscard]]
 #endif
 
+/// \def VGC_DISCARD
+///
+/// Declares that the returned value of a ``[[nodiscard]]`` function is
+/// intentionally discarded. This is equivalent to a cast to `void` but
+/// clarifies intent and improves searchability.
+///
+/// For unused variable, prefer using `VGC_UNUSED`.
+///
+/// ```cpp
+/// [[nodiscar]] int foo();
+/// void bar() {
+///     VGC_DISCARD(foo());
+/// }
+/// ```
+///
+/// Related:
+/// - https://stackoverflow.com/questions/53581744/how-can-i-intentionally-discard-a-nodiscard-return-value
+///
+// Note: `do { (void)(x); } while(0)` generates extra assembly in MSVC debug builds.
+//
+#define VGC_DISCARD(x) (void)(x)
+
+/// \def VGC_UNUSED
+///
+/// Declares that the given variable is intentionally unused, therefore
+/// silencing potential compiler warnings. This is equivalent to a cast to
+/// `void` but clarifies intent and improves searchability.
+///
+/// For a variable/argument that is conditionally used in some template
+/// instantiations but not others, prefer using `[[maybe_unused]]`.
+///
+/// For intentionally discarding the result of a `[[nodiscard]]` function,
+/// prefer using `VGC_DISCARD`.
+///
+/// ```cpp
+/// // Unused function argument.
+/// //
+/// void foo(int arg) {
+///     VGC_UNUSED(arg);
+/// }
+///
+/// // Partially unused structured binding.
+/// //
+/// int getOrInsert(const std::map<int, int>& map, int key, int value) {
+///     auto [it, inserted] = map.try_emplace(key, value);
+///     VGC_UNUSED(inserted);
+///     int value = it->second;;
+///     return value;
+/// }
+///
+/// // Conditionally used argument depending on template instantiation.
+/// //
+/// template<class T>
+/// bool isPositive([[maybe_unused]] T x) {
+///     if constexpr (std::is_unsigned_v<T>) {
+///         return true;
+///     }
+///     else {
+///         return x >= 0;
+///     }
+/// }
+/// ```
+///
+/// Using `VGC_UNUSED` is preferred over commenting out function arguments
+/// (e.g., `void foo(int /* arg */)`), since it makes it easier to later
+/// comment out a block of code if necessary (C-style comments cannot be
+/// nested), and commented arguments are potentially confusing to external
+/// tools and IDE (e.g., autocompletion, tooltips, doxygen).
+///
+/// Using `VGC_UNUSED` is preferred over `std::ignore` (except if using
+/// `std::tie`), since `std::ignore` is only meant to be used with `std::tie`,
+/// requires including the `<tuple>` header, and may generate extra assembly
+/// code in debug builds. The situation might improve in C++26 (P2968), but
+/// `VGC_UNUSED` is still preferred for now, and might still be preferred then
+/// for searchability (distinguishes usages between std::tie and other cases).
+///
+/// Starting in C++26, prefer using the `_` placeholder for partially unused
+/// structured bindings.
+///
+/// Related:
+/// - [Stack Overflow: How to silence unused variables warnings](https://stackoverflow.com/questions/1486904)
+/// - [Stack Overflow: About C++26 underscore variables](https://stackoverflow.com/questions/1486904)
+/// - [P2968: Make std::ignore a first-class object](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2968r2.html)
+/// - [P2169: A nice placeholder with no name](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2169r3.pdf)
+///
+// Note: `do { (void)(x); } while(0)` generates extra assembly in MSVC debug builds.
+//
+#define VGC_UNUSED(x) (void)(x)
+
 /// \def VGC_PRETTY_FUNCTION
 /// Returns the name of the current function. This is a cross-platform
 /// way to use the non-standard `__PRETTY_FUNCTION__`, `__FUNCSIG__`,

--- a/libs/vgc/core/wraps/sharedconst.h
+++ b/libs/vgc/core/wraps/sharedconst.h
@@ -53,7 +53,8 @@ void wrapSharedConstImplicitCast() {
         }
     };
 
-    auto implicitCaster = [](PyObject* obj, PyTypeObject* /*type*/) -> PyObject* {
+    auto implicitCaster = [](PyObject* obj, PyTypeObject* type) -> PyObject* {
+        VGC_UNUSED(type);
         static bool currentlyUsed = false;
         if (currentlyUsed) { // non-reentrant
             return nullptr;

--- a/libs/vgc/core/wraps/wrap_parse.cpp
+++ b/libs/vgc/core/wraps/wrap_parse.cpp
@@ -18,5 +18,6 @@
 
 #include <vgc/core/wraps/common.h>
 
-void wrap_parse(py::module& /*m*/) {
+void wrap_parse(py::module& m) {
+    VGC_UNUSED(m);
 }

--- a/libs/vgc/dom/document.cpp
+++ b/libs/vgc/dom/document.cpp
@@ -556,13 +556,13 @@ void Document::onElementIdChanged_(Element* element, core::StringId oldId) {
     // iterating on all elements.
     if (!oldId.isEmpty()) {
         for (const auto& [eId, e] : elementByInternalIdMap_) {
-            std::ignore = eId;
+            VGC_UNUSED(eId);
             detail::prepareInternalPathsForUpdate(e);
         }
         detail::PathUpdateData pud;
         pud.addAbsolutePathChangedElement(element->internalId());
         for (const auto& [eId, e] : elementByInternalIdMap_) {
-            std::ignore = eId;
+            VGC_UNUSED(eId);
             detail::updateInternalPaths(e, pud);
         }
     }
@@ -740,7 +740,7 @@ Element* Document::resolveElementPartOfPath_(
         }
         // Break out of loop if there is an error or we reached the end of
         // the "element part" of the path.
-        if (!element /* <- error */) {
+        if (!element) {
             hasError = true;
             break;
         }
@@ -772,10 +772,12 @@ Element* Document::resolveElementPartOfPath_(
 
 // static
 Value Document::resolveAttributePartOfPath_(
-    const Path& /*path*/,
+    const Path& path,
     Path::ConstSegmentIterator& segIt,
     Path::ConstSegmentIterator segEnd,
     const Element* element) {
+
+    VGC_UNUSED(path);
 
     Value result = {};
     for (; segIt != segEnd; ++segIt) {

--- a/libs/vgc/geometry/bezier.h
+++ b/libs/vgc/geometry/bezier.h
@@ -313,7 +313,8 @@ public:
             controlPoints_[0], controlPoints_[1], controlPoints_[2], u);
     }
 
-    T evalSecondDerivative(Scalar /*u*/) const {
+    T evalSecondDerivative(Scalar u) const {
+        VGC_UNUSED(u);
         return quadraticBezierSecondDerivative(
             controlPoints_[0], controlPoints_[1], controlPoints_[2]);
     }

--- a/libs/vgc/geometry/curves2d.cpp
+++ b/libs/vgc/geometry/curves2d.cpp
@@ -283,8 +283,8 @@ public:
         segmentData_.append(data);
     }
 
-    void
-    addJoin_(const Vec2d& p1, const Vec2d& p2, const Vec2d& t1, const Vec2d& /*t2*/) {
+    void addJoin_(const Vec2d& p1, const Vec2d& p2, const Vec2d& t1, const Vec2d& t2) {
+        VGC_UNUSED(t2);
         if (p1 == p2) {
             return;
         }

--- a/libs/vgc/geometry/interpolatingstroke.cpp
+++ b/libs/vgc/geometry/interpolatingstroke.cpp
@@ -252,7 +252,8 @@ void AbstractInterpolatingStroke2d::close_(bool smoothJoin) {
     }
 }
 
-void AbstractInterpolatingStroke2d::open_(bool /*keepJoinAsBestAsPossible*/) {
+void AbstractInterpolatingStroke2d::open_(bool keepJoinAsBestAsPossible) {
+    VGC_UNUSED(keepJoinAsBestAsPossible);
     if (positions_.length() > 0) {
         positions_.append(positions_.first());
         if (!hasConstantWidth_) {
@@ -500,10 +501,13 @@ template<typename TPoint, typename PositionGetter, typename WidthGetter>
     core::Span<TPoint> points,
     core::IntArray& indices,
     Int intervalStart,
-    bool /*isClosed*/,
-    double /*tolerance*/,
+    bool isClosed,
+    double tolerance,
     PositionGetter positionGetter,
     WidthGetter widthGetter) {
+
+    VGC_UNUSED(isClosed);
+    VGC_UNUSED(tolerance);
 
     Int i = intervalStart;
     Int endIndex = indices[i + 1];
@@ -1819,7 +1823,9 @@ public:
     }
 
 private:
-    bool initStrokeSampling_(CurveSamplingQuality /*quality*/, double /*maxDs*/) {
+    bool initStrokeSampling_(CurveSamplingQuality quality, double maxDs) {
+        VGC_UNUSED(quality);
+        VGC_UNUSED(maxDs);
         if (numKnots_ < 2) {
             return false;
         }
@@ -2373,9 +2379,11 @@ Vec2d AbstractInterpolatingStroke2d::sculptGrab_(
     const Vec2d& startPosition,
     const Vec2d& endPosition,
     double radius,
-    double /*strength*/,
+    double strength,
     double tolerance,
     bool isClosed) {
+
+    VGC_UNUSED(strength);
 
     // Let's consider tolerance will be ~= pixelSize for now.
     //
@@ -2645,8 +2653,10 @@ Vec2d AbstractInterpolatingStroke2d::sculptWidth_(
     const Vec2d& position,
     double delta,
     double radius,
-    double /*tolerance*/,
+    double tolerance,
     bool isClosed) {
+
+    VGC_UNUSED(tolerance);
 
     Int numKnots = positions_.length();
     if (numKnots == 0) {

--- a/libs/vgc/geometry/wraps/wrap_curve.cpp
+++ b/libs/vgc/geometry/wraps/wrap_curve.cpp
@@ -20,7 +20,9 @@
 #include <vgc/core/wraps/class.h>
 #include <vgc/core/wraps/common.h>
 
-void wrap_curve(py::module& /*m*/) {
+void wrap_curve(py::module& m) {
+
+    VGC_UNUSED(m);
 
     //using This = vgc::geometry::StrokeView2d;
     ////using Vec2d = vgc::geometry::Vec2d;

--- a/libs/vgc/geometry/yuksel.cpp
+++ b/libs/vgc/geometry/yuksel.cpp
@@ -518,7 +518,10 @@ StrokeBoundaryInfo YukselSplineStroke2d::computeBoundaryInfo_() const {
 }
 
 void YukselSplineStroke2d::updateCache_(
-    const core::Array<SegmentComputeData>& /*baseComputeDataArray*/) const {
+    const core::Array<SegmentComputeData>& baseComputeDataArray) const {
+
+    VGC_UNUSED(baseComputeDataArray);
+
     // no custom cache data
 }
 

--- a/libs/vgc/graphics/d3d11/d3d11engine.cpp
+++ b/libs/vgc/graphics/d3d11/d3d11engine.cpp
@@ -1294,7 +1294,8 @@ void D3d11Engine::initBuiltinResources_() {
     // no-op
 }
 
-void D3d11Engine::initFramebuffer_(Framebuffer* /*framebuffer*/) {
+void D3d11Engine::initFramebuffer_(Framebuffer* framebuffer) {
+    VGC_UNUSED(framebuffer);
     // no-op
 }
 
@@ -1677,7 +1678,8 @@ void D3d11Engine::initSamplerState_(SamplerState* state) {
     device_->CreateSamplerState(&desc, d3dSamplerState->object_.releaseAndGetAddressOf());
 }
 
-void D3d11Engine::initGeometryView_(GeometryView* /*view*/) {
+void D3d11Engine::initGeometryView_(GeometryView* view) {
+    VGC_UNUSED(view);
     //D3d11GeometryView* d3dGeometryView = static_cast<D3d11GeometryView*>(view);
     // no-op ?
 }
@@ -2043,8 +2045,8 @@ void D3d11Engine::clear_(const core::Color& color) {
 }
 
 UInt64
-D3d11Engine::present_(SwapChain* swapChain, UInt32 syncInterval, PresentFlags /*flags*/) {
-
+D3d11Engine::present_(SwapChain* swapChain, UInt32 syncInterval, PresentFlags flags) {
+    VGC_UNUSED(flags);
     D3d11SwapChain* d3dSwapChain = static_cast<D3d11SwapChain*>(swapChain);
     IDXGISwapChain1* dxgiSwapChain1 = d3dSwapChain->dxgiSwapChain1();
     if (dxgiSwapChain1->Present(syncInterval, 0) != S_OK) {

--- a/libs/vgc/graphics/engine.cpp
+++ b/libs/vgc/graphics/engine.cpp
@@ -1307,7 +1307,8 @@ bool Engine::hasSubmittedCommandListPendingForTranslation_() {
     return lastExecutedCommandListId_ != lastSubmittedCommandListId_;
 }
 
-void Engine::sanitize_(SwapChainCreateInfo& /*createInfo*/) {
+void Engine::sanitize_(SwapChainCreateInfo& createInfo) {
+    VGC_UNUSED(createInfo);
     // XXX
 }
 
@@ -1486,7 +1487,8 @@ void Engine::sanitize_(ImageCreateInfo& createInfo) {
     //resourceMiscFlags
 }
 
-void Engine::sanitize_(ImageViewCreateInfo& /*createInfo*/) {
+void Engine::sanitize_(ImageViewCreateInfo& createInfo) {
+    VGC_UNUSED(createInfo);
     // XXX should check bind flags compatibility here
 }
 
@@ -1496,15 +1498,18 @@ void Engine::sanitize_(SamplerStateCreateInfo& createInfo) {
     }
 }
 
-void Engine::sanitize_(GeometryViewCreateInfo& /*createInfo*/) {
+void Engine::sanitize_(GeometryViewCreateInfo& createInfo) {
+    VGC_UNUSED(createInfo);
     // XXX
 }
 
-void Engine::sanitize_(BlendStateCreateInfo& /*createInfo*/) {
+void Engine::sanitize_(BlendStateCreateInfo& createInfo) {
+    VGC_UNUSED(createInfo);
     // XXX
 }
 
-void Engine::sanitize_(RasterizerStateCreateInfo& /*createInfo*/) {
+void Engine::sanitize_(RasterizerStateCreateInfo& createInfo) {
+    VGC_UNUSED(createInfo);
     // XXX
 }
 

--- a/libs/vgc/graphics/richtext.cpp
+++ b/libs/vgc/graphics/richtext.cpp
@@ -480,7 +480,9 @@ void RichText::fill(core::FloatArray& a) const {
 Int RichText::movedPosition(
     Int position,
     RichTextMoveOperation operation,
-    Int /* selectionIndex */) const {
+    Int selectionIndex) const {
+
+    VGC_UNUSED(selectionIndex);
 
     using Op = RichTextMoveOperation;
 

--- a/libs/vgc/style/sheet.cpp
+++ b/libs/vgc/style/sheet.cpp
@@ -67,7 +67,7 @@ private:
     // https://www.w3.org/TR/css-syntax-3/#consume-list-of-rules
     // Note: we use 'styleSheet != nullptr' as top-level flag
     core::Array<RuleSetPtr> consumeRuleList_(TokenIterator& it, TokenIterator end) {
-        std::ignore = topLevel_; // suppress warning
+        VGC_UNUSED(topLevel_);
         core::Array<RuleSetPtr> res;
         while (true) {
             if (it == end) {

--- a/libs/vgc/style/stylableobject.cpp
+++ b/libs/vgc/style/stylableobject.cpp
@@ -160,7 +160,7 @@ void StylableObject::populateStyleSpecTable(SpecTable*) {
 
 void StylableObject::debugPrintStyle(core::StringWriter& out) {
     for (auto [ruleSet, specificity] : styleCache_.ruleSetArray) {
-        std::ignore = specificity;
+        VGC_UNUSED(specificity);
         write(out, ruleSet->text());
         write(out, "\n\n");
     }

--- a/libs/vgc/style/wraps/wrap_style.cpp
+++ b/libs/vgc/style/wraps/wrap_style.cpp
@@ -16,10 +16,11 @@
 
 #include <vgc/core/wraps/common.h>
 
-void wrap_style(py::module& /*m*/) {
+void wrap_style(py::module& m) {
     // Necessary to define inheritance across modules. See:
     // http://pybind11.readthedocs.io/en/stable/advanced/misc.html#partitioning-code-over-multiple-extension-modules
     py::module::import("vgc.core");
 
+    VGC_UNUSED(m);
     // TODO
 }

--- a/libs/vgc/tools/colorpalette.cpp
+++ b/libs/vgc/tools/colorpalette.cpp
@@ -252,7 +252,7 @@ computeHighlightColor(const core::Color& c, HighlightStyle style = HighlightStyl
 
     // Convert to HSL
     auto [h, s, lightness] = c.toHsl();
-    std::ignore = s;
+    VGC_UNUSED(s);
 
     // Convert to Lab space, which is a perceptual color space. This means that
     // increasing the luminance by a fixed amount in this space looks like an
@@ -290,7 +290,7 @@ computeHighlightColor(const core::Color& c, HighlightStyle style = HighlightStyl
     // Apply back the original hue. Indeed, modifying the luminance in Lab
     // space alters the hue, which sometimes look weird for an highlight.
     auto [newH, newS, newL] = labSpaceContrasted.toHsl();
-    std::ignore = newH;
+    VGC_UNUSED(newH);
     core::Color res = core::Color::hsl(h, newS, newL);
 
     return res;
@@ -2083,7 +2083,9 @@ void ColorPaletteSelector::computeSlSubMetrics_(float width, Metrics& m) const {
     m.saturationLightnessRect = {x0, y0, x0 + w, y0 + h};
 }
 
-void ColorPaletteSelector::computeHueSubMetrics_(float /* width */, Metrics& m) const {
+void ColorPaletteSelector::computeHueSubMetrics_(float width, Metrics& m) const {
+
+    VGC_UNUSED(width);
 
     using namespace style::literals;
     const style::Length minCellWidth_ = 0.0_dp;
@@ -2229,7 +2231,8 @@ bool ColorPaletteSelector::onMousePress(ui::MousePressEvent* event) {
     }
 }
 
-bool ColorPaletteSelector::onMouseRelease(ui::MouseReleaseEvent* /*event*/) {
+bool ColorPaletteSelector::onMouseRelease(ui::MouseReleaseEvent* event) {
+    VGC_UNUSED(event);
     scrubbedSelector_ = SelectorType::None;
     return true;
 }
@@ -2865,8 +2868,9 @@ void ColorListView::onMouseLeave() {
     }
 }
 
-float ColorListView::preferredWidthForHeight(float /* height */) const {
+float ColorListView::preferredWidthForHeight(float height) const {
     // TODO
+    VGC_UNUSED(height);
     return preferredSize()[0];
 }
 

--- a/libs/vgc/tools/paintbucket.cpp
+++ b/libs/vgc/tools/paintbucket.cpp
@@ -153,7 +153,8 @@ bool PaintBucket::onMousePress(ui::MousePressEvent* event) {
     return false;
 }
 
-bool PaintBucket::onMouseRelease(ui::MouseReleaseEvent* /*event*/) {
+bool PaintBucket::onMouseRelease(ui::MouseReleaseEvent* event) {
+    VGC_UNUSED(event);
     // TODO
     return false;
 }

--- a/libs/vgc/tools/sculpt.cpp
+++ b/libs/vgc/tools/sculpt.cpp
@@ -176,7 +176,8 @@ public:
         }
     }
 
-    void onMouseDragConfirm(ui::MouseEvent* /*event*/) override {
+    void onMouseDragConfirm(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
         if (edgeId_ == -1) {
             return;
         }
@@ -186,7 +187,8 @@ public:
         reset_();
     }
 
-    void onMouseDragCancel(ui::MouseEvent* /*event*/) override {
+    void onMouseDragCancel(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
         if (edgeId_ == -1) {
             return;
         }
@@ -343,7 +345,8 @@ public:
         }
     }
 
-    void onMouseDragConfirm(ui::MouseEvent* /*event*/) override {
+    void onMouseDragConfirm(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
         if (edgeId_ == -1) {
             return;
         }
@@ -355,7 +358,8 @@ public:
         reset_();
     }
 
-    void onMouseDragCancel(ui::MouseEvent* /*event*/) override {
+    void onMouseDragCancel(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
         if (edgeId_ == -1) {
             return;
         }
@@ -509,7 +513,8 @@ public:
         }
     }
 
-    void onMouseDragConfirm(ui::MouseEvent* /*event*/) override {
+    void onMouseDragConfirm(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
         if (edgeId_ == -1) {
             return;
         }
@@ -520,7 +525,8 @@ public:
         reset_();
     }
 
-    void onMouseDragCancel(ui::MouseEvent* /*event*/) override {
+    void onMouseDragCancel(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
         if (edgeId_ == -1) {
             return;
         }
@@ -613,10 +619,12 @@ public:
         tool->dirtyActionCircle();
     }
 
-    void onMouseDragConfirm(ui::MouseEvent* /*event*/) override {
+    void onMouseDragConfirm(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
     }
 
-    void onMouseDragCancel(ui::MouseEvent* /*event*/) override {
+    void onMouseDragCancel(ui::MouseEvent* event) override {
+        VGC_UNUSED(event);
         options::sculptRadius()->setValue(oldRadius_);
         if (auto tool = tool_.lock()) {
             tool->dirtyActionCircle();
@@ -681,7 +689,8 @@ void Sculpt::onMouseHover(ui::MouseHoverEvent* event) {
 
     workspace->visitDepthFirst(
         [](workspace::Element*, Int) { return true; },
-        [&, worldCursor](workspace::Element* e, Int /*depth*/) {
+        [&, worldCursor](workspace::Element* e, Int depth) {
+            VGC_UNUSED(depth);
             if (!e) {
                 return;
             }

--- a/libs/vgc/tools/select.cpp
+++ b/libs/vgc/tools/select.cpp
@@ -1672,7 +1672,7 @@ void Select::finalizeDragMovedElements_(workspace::Workspace* workspace) {
             vacomplex::KeyEdge* ke = element->vacNode()->toCellUnchecked()->toKeyEdge();
             if (ke && ked.isEditStarted) {
                 const vacomplex::KeyEdgeData& data = ke->data();
-                std::ignore = data;
+                VGC_UNUSED(data);
                 //data.finishEdit();
             }
         }

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -162,7 +162,9 @@ void SketchPointsProcessingPass::updateCumulativeChordalDistances() {
 
 namespace detail {
 
-Int EmptyPass::update_(const SketchPointBuffer& input, Int /*lastNumStableInputPoints*/) {
+Int EmptyPass::update_(const SketchPointBuffer& input, Int lastNumStableInputPoints) {
+
+    VGC_UNUSED(lastNumStableInputPoints);
 
     const SketchPointArray& inputPoints = input.data();
     Int numStablePoints = this->numStablePoints();
@@ -362,9 +364,9 @@ void applyWidthRoughnessLimitor(
 
 } // namespace
 
-Int SmoothingPass::update_(
-    const SketchPointBuffer& input,
-    Int /*lastNumStableInputPoints*/) {
+Int SmoothingPass::update_(const SketchPointBuffer& input, Int lastNumStableInputPoints) {
+
+    VGC_UNUSED(lastNumStableInputPoints);
 
     const SketchPointArray& inputPoints = input.data();
     Int numPoints = inputPoints.length();
@@ -594,7 +596,9 @@ Int reconstructInputStep(
 
 Int DouglasPeuckerPass::update_(
     const SketchPointBuffer& input,
-    Int /*lastNumStableInputPoints*/) {
+    Int lastNumStableInputPoints) {
+
+    VGC_UNUSED(lastNumStableInputPoints);
 
     // A copy required to make a mutable span, which the Douglas-Peuckert
     // algorithm needs (it modifies the points slightly).
@@ -694,7 +698,8 @@ ui::WidgetPtr Sketch::doCreateOptionsWidget() const {
     return res;
 }
 
-bool Sketch::onKeyPress(ui::KeyPressEvent* /*event*/) {
+bool Sketch::onKeyPress(ui::KeyPressEvent* event) {
+    VGC_UNUSED(event);
     return false;
 }
 
@@ -1630,7 +1635,9 @@ void autoFill(vacomplex::Node* keNode) {
 
 } // namespace
 
-void Sketch::finishCurve_(ui::MouseEvent* /*event*/) {
+void Sketch::finishCurve_(ui::MouseEvent* event) {
+
+    VGC_UNUSED(event);
 
     namespace ds = dom::strings;
 

--- a/libs/vgc/tools/transform.cpp
+++ b/libs/vgc/tools/transform.cpp
@@ -400,7 +400,9 @@ public:
         draggedOnce_ = true;
     }
 
-    void onMouseDragConfirm(ui::MouseEvent* /*event*/) override {
+    void onMouseDragConfirm(ui::MouseEvent* event) override {
+
+        VGC_UNUSED(event);
 
         auto box = box_.lock();
         if (!box) {
@@ -428,7 +430,9 @@ public:
         reset_();
     }
 
-    void onMouseDragCancel(ui::MouseEvent* /*event*/) override {
+    void onMouseDragCancel(ui::MouseEvent* event) override {
+
+        VGC_UNUSED(event);
 
         auto box = box_.lock();
         if (!box) {
@@ -869,7 +873,7 @@ void TopologyAwareTransformer::finalizeDragTransform() {
         vacomplex::KeyEdge* ke = findKeyEdge_(*workspace, td.elementId);
         if (ke) {
             const vacomplex::KeyEdgeData& data = ke->data();
-            std::ignore = data;
+            VGC_UNUSED(data);
             //data->finishEdit();
         }
     }
@@ -879,7 +883,7 @@ void TopologyAwareTransformer::finalizeDragTransform() {
         vacomplex::KeyEdge* ke = findKeyEdge_(*workspace, td.elementId);
         if (ke) {
             const vacomplex::KeyEdgeData& data = ke->data();
-            std::ignore = data;
+            VGC_UNUSED(data);
             //data->finishEdit();
         }
     }

--- a/libs/vgc/ui/application.cpp
+++ b/libs/vgc/ui/application.cpp
@@ -69,8 +69,11 @@ Application* application() {
     return globalApplication_;
 }
 
-Application::Application(CreateKey key, int /*argc*/, char* /*argv*/[])
+Application::Application(CreateKey key, int argc, char* argv[])
     : Object(key) {
+
+    VGC_UNUSED(argc);
+    VGC_UNUSED(argv);
 
     if (globalApplication_) {
         throw core::LogicError(

--- a/libs/vgc/ui/detail/qopenglengine.cpp
+++ b/libs/vgc/ui/detail/qopenglengine.cpp
@@ -1059,7 +1059,9 @@ QglEngine::constructRasterizerState_(const RasterizerStateCreateInfo& createInfo
     return RasterizerStatePtr(state.release());
 }
 
-void QglEngine::onWindowResize_(SwapChain* aSwapChain, UInt32 /*width*/, UInt32 height) {
+void QglEngine::onWindowResize_(SwapChain* aSwapChain, UInt32 width, UInt32 height) {
+
+    VGC_UNUSED(width);
 
     // Store the height in order to be able to convert from OpenGL coordinates
     // (origin is bottom-left) to Engine coordinate (origin is top-left).
@@ -1450,15 +1452,18 @@ void QglEngine::initSamplerState_(SamplerState* aState) {
     api_->glSamplerParameterf(object, GL_TEXTURE_MAX_LOD, state->maxLOD());
 }
 
-void QglEngine::initGeometryView_(GeometryView* /*view*/) {
+void QglEngine::initGeometryView_(GeometryView* view) {
+    VGC_UNUSED(view);
     // no-op, vaos are built per program
 }
 
-void QglEngine::initBlendState_(BlendState* /*state*/) {
+void QglEngine::initBlendState_(BlendState* state) {
+    VGC_UNUSED(state);
     // no-op
 }
 
-void QglEngine::initRasterizerState_(RasterizerState* /*state*/) {
+void QglEngine::initRasterizerState_(RasterizerState* state) {
+    VGC_UNUSED(state);
     // no-op
 }
 
@@ -1866,10 +1871,11 @@ void QglEngine::clear_(const core::Color& color) {
     api_->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
-UInt64 QglEngine::present_(
-    SwapChain* aSwapChain,
-    UInt32 /*syncInterval*/,
-    PresentFlags /*flags*/) {
+UInt64
+QglEngine::present_(SwapChain* aSwapChain, UInt32 syncInterval, PresentFlags flags) {
+
+    VGC_UNUSED(syncInterval);
+    VGC_UNUSED(flags);
 
     QglSwapChain* swapChain = static_cast<QglSwapChain*>(aSwapChain);
     if (surface_ != swapChain->surface_) {

--- a/libs/vgc/ui/overlayarea.cpp
+++ b/libs/vgc/ui/overlayarea.cpp
@@ -73,7 +73,10 @@ void OverlayArea::onResize() {
     SuperClass::onResize();
 }
 
-void OverlayArea::onWidgetAdded(Widget* w, bool /*wasOnlyReordered*/) {
+void OverlayArea::onWidgetAdded(Widget* w, bool wasOnlyReordered) {
+
+    VGC_UNUSED(wasOnlyReordered);
+
     // If area is no longer first, move to first.
     if (areaWidget_ && areaWidget_->previousSibling()) {
         insertChild(firstChild(), areaWidget_);

--- a/libs/vgc/ui/panelarea.cpp
+++ b/libs/vgc/ui/panelarea.cpp
@@ -1004,7 +1004,7 @@ void destroyAreaAndToBeEmptyAncestorAreas(PanelArea* area) {
 } // namespace
 
 void PanelArea::onTabClosed_(Int tabIndex) {
-    std::ignore = tabIndex;
+    VGC_UNUSED(tabIndex);
     TabBar* tabBar = this->tabBar();
     Int numRemainingTabs = tabBar ? tabBar->numTabs() : 0;
     if (numRemainingTabs == 0) {

--- a/libs/vgc/ui/panelmanager.cpp
+++ b/libs/vgc/ui/panelmanager.cpp
@@ -38,7 +38,7 @@ PanelManagerPtr PanelManager::create(const ui::ModuleContext& context) {
 core::Array<PanelTypeId> PanelManager::registeredPanelTypeIds() const {
     core::Array<PanelTypeId> res;
     for (auto& [id, info] : infos_) {
-        std::ignore = info;
+        VGC_UNUSED(info);
         res.append(id);
     }
     return res;

--- a/libs/vgc/ui/plot2d.cpp
+++ b/libs/vgc/ui/plot2d.cpp
@@ -394,11 +394,13 @@ bool Plot2d::onMouseMove(MouseMoveEvent* event) {
     return true;
 }
 
-bool Plot2d::onMousePress(MousePressEvent* /*event*/) {
+bool Plot2d::onMousePress(MousePressEvent* event) {
+    VGC_UNUSED(event);
     return true;
 }
 
-bool Plot2d::onMouseRelease(MouseReleaseEvent* /*event*/) {
+bool Plot2d::onMouseRelease(MouseReleaseEvent* event) {
+    VGC_UNUSED(event);
     return true;
 }
 

--- a/libs/vgc/ui/popuplayer.cpp
+++ b/libs/vgc/ui/popuplayer.cpp
@@ -39,7 +39,8 @@ PopupLayerPtr PopupLayer::create(Widget* underlyingWidget) {
     return core::createObject<PopupLayer>(underlyingWidget);
 }
 
-void PopupLayer::onWidgetAdded(Widget* child, bool /*wasOnlyReordered*/) {
+void PopupLayer::onWidgetAdded(Widget* child, bool wasOnlyReordered) {
+    VGC_UNUSED(wasOnlyReordered);
     child->updateGeometry(0, 0, 0, 0);
 }
 

--- a/libs/vgc/ui/tabbody.cpp
+++ b/libs/vgc/ui/tabbody.cpp
@@ -55,7 +55,8 @@ void TabBody::updateChildrenGeometry() {
     }
 }
 
-void TabBody::onWidgetAdded(Widget* /*child*/, bool) {
+void TabBody::onWidgetAdded(Widget* child, bool) {
+    VGC_UNUSED(child);
     // TODO: auto-hide if not active
 }
 

--- a/libs/vgc/ui/widget.cpp
+++ b/libs/vgc/ui/widget.cpp
@@ -538,7 +538,9 @@ void Widget::onPaintCreate(graphics::Engine* engine) {
     triangles_ = engine->createDynamicTriangleListView(layout);
 }
 
-void Widget::onPaintPrepare(graphics::Engine* /*engine*/, PaintOptions /*options*/) {
+void Widget::onPaintPrepare(graphics::Engine* engine, PaintOptions options) {
+    VGC_UNUSED(engine);
+    VGC_UNUSED(options);
 }
 
 void Widget::onPaintDraw(graphics::Engine* engine, PaintOptions options) {
@@ -546,11 +548,13 @@ void Widget::onPaintDraw(graphics::Engine* engine, PaintOptions options) {
     paintChildren(engine, options);
 }
 
-void Widget::onPaintDestroy(graphics::Engine* /*engine*/) {
+void Widget::onPaintDestroy(graphics::Engine* engine) {
+    VGC_UNUSED(engine);
     triangles_.reset();
 }
 
-void Widget::paintBackground(graphics::Engine* engine, PaintOptions /*options*/) {
+void Widget::paintBackground(graphics::Engine* engine, PaintOptions options) {
+    VGC_UNUSED(options);
     if (backgroundColor_.a() > 0) {
         if (backgroundChanged_) {
             backgroundChanged_ = false;
@@ -769,31 +773,38 @@ bool Widget::mouseScroll(ScrollEvent* event) {
     // updated as a result of that change.
 }
 
-void Widget::preMouseMove(MouseMoveEvent* /*event*/) {
+void Widget::preMouseMove(MouseMoveEvent* event) {
+    VGC_UNUSED(event);
     // no-op
 }
 
-void Widget::preMousePress(MousePressEvent* /*event*/) {
+void Widget::preMousePress(MousePressEvent* event) {
+    VGC_UNUSED(event);
     // no-op
 }
 
-void Widget::preMouseRelease(MouseReleaseEvent* /*event*/) {
+void Widget::preMouseRelease(MouseReleaseEvent* event) {
+    VGC_UNUSED(event);
     // no-op
 }
 
-bool Widget::onMouseMove(MouseMoveEvent* /*event*/) {
+bool Widget::onMouseMove(MouseMoveEvent* event) {
+    VGC_UNUSED(event);
     return false;
 }
 
-bool Widget::onMousePress(MousePressEvent* /*event*/) {
+bool Widget::onMousePress(MousePressEvent* event) {
+    VGC_UNUSED(event);
     return false;
 }
 
-bool Widget::onMouseRelease(MouseReleaseEvent* /*event*/) {
+bool Widget::onMouseRelease(MouseReleaseEvent* event) {
+    VGC_UNUSED(event);
     return false;
 }
 
-bool Widget::onMouseScroll(ScrollEvent* /*event*/) {
+bool Widget::onMouseScroll(ScrollEvent* event) {
+    VGC_UNUSED(event);
     return false;
 }
 

--- a/libs/vgc/vacomplex/cell.h
+++ b/libs/vgc/vacomplex/cell.h
@@ -1173,7 +1173,7 @@ public:
     //       if we want to share the data. The straight forward implementation
     //       is to not cache this result in the cell, otherwise we'd have to manage
     //       a cache array in inbetween cells.
-    //virtual EdgeGeometry computeSamplingAt(core::AnimTime /*t*/) = 0;
+    //virtual EdgeGeometry computeSamplingAt(core::AnimTime t) = 0;
 };
 
 class VGC_VACOMPLEX_API FaceCell : public Cell {

--- a/libs/vgc/vacomplex/cellproperty.cpp
+++ b/libs/vgc/vacomplex/cellproperty.cpp
@@ -23,32 +23,37 @@
 
 namespace vgc::vacomplex {
 
-CellProperty::OpResult
-CellProperty::onTranslateGeometry_(const geometry::Vec2d& /*delta*/) {
+CellProperty::OpResult CellProperty::onTranslateGeometry_(const geometry::Vec2d& delta) {
+    VGC_UNUSED(delta);
     return OpResult::Unchanged;
 }
 
 CellProperty::OpResult
-CellProperty::onTransformGeometry_(const geometry::Mat3d& /*transformation*/) {
+CellProperty::onTransformGeometry_(const geometry::Mat3d& transformation) {
+    VGC_UNUSED(transformation);
     return OpResult::Unchanged;
 }
 
 CellProperty::OpResult
-CellProperty::onUpdateGeometry_(const geometry::AbstractStroke2d* /*newStroke*/) {
+CellProperty::onUpdateGeometry_(const geometry::AbstractStroke2d* newStroke) {
+    VGC_UNUSED(newStroke);
     return OpResult::Unchanged;
 }
 
 std::unique_ptr<CellProperty> CellProperty::fromConcatStep_(
-    const KeyHalfedgeData& /*khd1*/,
-    const KeyHalfedgeData& /*khd2*/) const {
+    const KeyHalfedgeData& khd1,
+    const KeyHalfedgeData& khd2) const {
 
+    VGC_UNUSED(khd1);
+    VGC_UNUSED(khd2);
     return nullptr;
 }
 
-std::unique_ptr<CellProperty> CellProperty::fromConcatStep_(
-    const KeyFaceData& /*kfd1*/,
-    const KeyFaceData& /*kfd2*/) const {
+std::unique_ptr<CellProperty>
+CellProperty::fromConcatStep_(const KeyFaceData& kfd1, const KeyFaceData& kfd2) const {
 
+    VGC_UNUSED(kfd1);
+    VGC_UNUSED(kfd2);
     return nullptr;
 }
 
@@ -57,19 +62,26 @@ CellProperty::OpResult CellProperty::finalizeConcat_() {
 }
 
 std::unique_ptr<CellProperty> CellProperty::fromGlue_(
-    core::ConstSpan<KeyHalfedgeData> /*khds*/,
-    const geometry::AbstractStroke2d* /*gluedStroke*/) const {
+    core::ConstSpan<KeyHalfedgeData> khds,
+    const geometry::AbstractStroke2d* gluedStroke) const {
 
+    VGC_UNUSED(khds);
+    VGC_UNUSED(gluedStroke);
     return nullptr;
 }
 
 std::unique_ptr<CellProperty> CellProperty::fromSlice_(
-    const KeyEdgeData& /*ked*/,
-    const geometry::CurveParameter& /*start*/,
-    const geometry::CurveParameter& /*end*/,
-    Int /*numWraps*/,
-    const geometry::AbstractStroke2d* /*subStroke*/) const {
+    const KeyEdgeData& ked,
+    const geometry::CurveParameter& start,
+    const geometry::CurveParameter& end,
+    Int numWraps,
+    const geometry::AbstractStroke2d* subStroke) const {
 
+    VGC_UNUSED(ked);
+    VGC_UNUSED(start);
+    VGC_UNUSED(end);
+    VGC_UNUSED(numWraps);
+    VGC_UNUSED(subStroke);
     return nullptr;
 }
 

--- a/libs/vgc/vacomplex/detail/operationsimpl.cpp
+++ b/libs/vgc/vacomplex/detail/operationsimpl.cpp
@@ -441,9 +441,9 @@ private:
 } // namespace
 
 // deleteIsolatedVertices is not supported yet
-void Operations::softDelete(
-    core::ConstSpan<Node*> nodes,
-    bool /*deleteIsolatedVertices*/) {
+void Operations::softDelete(core::ConstSpan<Node*> nodes, bool deleteIsolatedVertices) {
+
+    VGC_UNUSED(deleteIsolatedVertices);
 
     if (nodes.isEmpty()) {
         return;

--- a/libs/vgc/vacomplex/inbetweenedge.cpp
+++ b/libs/vgc/vacomplex/inbetweenedge.cpp
@@ -18,12 +18,14 @@
 
 namespace vgc::vacomplex {
 
-bool InbetweenEdge::isStartVertex(const VertexCell* /*v*/) const {
+bool InbetweenEdge::isStartVertex(const VertexCell* v) const {
+    VGC_UNUSED(v);
     // TODO: check whether v is one of the start vertices of this inbetween edge.
     return false;
 }
 
-bool InbetweenEdge::isEndVertex(const VertexCell* /*v*/) const {
+bool InbetweenEdge::isEndVertex(const VertexCell* v) const {
+    VGC_UNUSED(v);
     // TODO: check whether v is one of the end vertices of this inbetween edge.
     return false;
 }
@@ -33,8 +35,9 @@ bool InbetweenEdge::isClosed() const {
     return false;
 }
 
-geometry::Rect2d InbetweenEdge::boundingBoxAt(core::AnimTime /*t*/) const {
+geometry::Rect2d InbetweenEdge::boundingBoxAt(core::AnimTime t) const {
     // TODO
+    VGC_UNUSED(t);
     return geometry::Rect2d::empty;
 }
 

--- a/libs/vgc/vacomplex/inbetweenedge.h
+++ b/libs/vgc/vacomplex/inbetweenedge.h
@@ -42,11 +42,12 @@ public:
     bool isClosed() const override;
 
     std::shared_ptr<const geometry::StrokeSampling2d>
-    strokeSamplingShared(core::AnimTime /*t*/) const override {
+    strokeSamplingShared(core::AnimTime t) const override {
+        VGC_UNUSED(t);
         return nullptr;
     }
 
-    geometry::Rect2d boundingBoxAt(core::AnimTime /*t*/) const override;
+    geometry::Rect2d boundingBoxAt(core::AnimTime t) const override;
 
 private:
     void substituteKeyVertex_(KeyVertex* oldVertex, KeyVertex* newVertex) override;

--- a/libs/vgc/vacomplex/inbetweenface.cpp
+++ b/libs/vgc/vacomplex/inbetweenface.cpp
@@ -18,8 +18,9 @@
 
 namespace vgc::vacomplex {
 
-geometry::Rect2d InbetweenFace::boundingBoxAt(core::AnimTime /*t*/) const {
+geometry::Rect2d InbetweenFace::boundingBoxAt(core::AnimTime t) const {
     // TODO
+    VGC_UNUSED(t);
     return geometry::Rect2d::empty;
 }
 

--- a/libs/vgc/vacomplex/inbetweenface.h
+++ b/libs/vgc/vacomplex/inbetweenface.h
@@ -37,7 +37,7 @@ private:
 public:
     VGC_VACOMPLEX_DEFINE_SPATIOTEMPORAL_CELL_CAST_METHODS(Inbetween, Face)
 
-    geometry::Rect2d boundingBoxAt(core::AnimTime /*t*/) const override;
+    geometry::Rect2d boundingBoxAt(core::AnimTime t) const override;
 
 private:
     void substituteKeyVertex_(KeyVertex* oldVertex, KeyVertex* newVertex) override;

--- a/libs/vgc/vacomplex/inbetweenvertex.cpp
+++ b/libs/vgc/vacomplex/inbetweenvertex.cpp
@@ -18,8 +18,9 @@
 
 namespace vgc::vacomplex {
 
-geometry::Rect2d InbetweenVertex::boundingBoxAt(core::AnimTime /*t*/) const {
+geometry::Rect2d InbetweenVertex::boundingBoxAt(core::AnimTime t) const {
     // TODO
+    VGC_UNUSED(t);
     return geometry::Rect2d::empty;
 }
 

--- a/libs/vgc/vacomplex/inbetweenvertex.h
+++ b/libs/vgc/vacomplex/inbetweenvertex.h
@@ -39,7 +39,7 @@ public:
 
     geometry::Vec2d position(core::AnimTime t) const override;
 
-    geometry::Rect2d boundingBoxAt(core::AnimTime /*t*/) const override;
+    geometry::Rect2d boundingBoxAt(core::AnimTime t) const override;
 
 private:
     void substituteKeyVertex_(KeyVertex* oldVertex, KeyVertex* newVertex) override;

--- a/libs/vgc/vacomplex/keyedge.cpp
+++ b/libs/vgc/vacomplex/keyedge.cpp
@@ -232,8 +232,11 @@ void KeyEdge::substituteKeyVertex_(KeyVertex* oldVertex, KeyVertex* newVertex) {
 }
 
 void KeyEdge::substituteKeyEdge_(
-    const class KeyHalfedge& /*oldHalfedge*/,
-    const class KeyHalfedge& /*newHalfedge*/) {
+    const class KeyHalfedge& oldHalfedge,
+    const class KeyHalfedge& newHalfedge) {
+
+    VGC_UNUSED(oldHalfedge);
+    VGC_UNUSED(newHalfedge);
     // no-op
 }
 

--- a/libs/vgc/vacomplex/keyedge.h
+++ b/libs/vgc/vacomplex/keyedge.h
@@ -74,7 +74,8 @@ public:
     }
 
     std::shared_ptr<const geometry::StrokeSampling2d>
-    strokeSamplingShared(core::AnimTime /*t*/) const override {
+    strokeSamplingShared(core::AnimTime t) const override {
+        VGC_UNUSED(t);
         return data_.strokeSamplingShared();
     }
 

--- a/libs/vgc/vacomplex/keyvertex.h
+++ b/libs/vgc/vacomplex/keyvertex.h
@@ -102,7 +102,8 @@ public:
         return position_;
     }
 
-    geometry::Vec2d position(core::AnimTime /*t*/) const override {
+    geometry::Vec2d position(core::AnimTime t) const override {
+        VGC_UNUSED(t);
         return position_;
     }
 

--- a/libs/vgc/workspace/edge.cpp
+++ b/libs/vgc/workspace/edge.cpp
@@ -224,8 +224,10 @@ bool VacEdgeCellFrameData::isSelectableInRect(const geometry::Rect2d& rect) cons
 namespace detail {
 
 graphics::GeometryViewPtr
-loadMeshGraphics(graphics::Engine* /*engine*/, const StuvMesh2d& /*mesh*/) {
+loadMeshGraphics(graphics::Engine* engine, const StuvMesh2d& mesh) {
     // TODO
+    VGC_UNUSED(engine);
+    VGC_UNUSED(mesh);
     return {};
 }
 
@@ -302,8 +304,10 @@ VacKeyEdge::computeFrameDataAt(core::AnimTime t, VacEdgeComputationStage stage) 
     return nullptr;
 }
 
-void VacKeyEdge::onPaintPrepare(core::AnimTime /*t*/, PaintOptions /*flags*/) {
+void VacKeyEdge::onPaintPrepare(core::AnimTime t, PaintOptions flags) {
     // todo, use paint options to not compute everything or with lower quality
+    VGC_UNUSED(t);
+    VGC_UNUSED(flags);
     computeStrokeMesh_();
     computeStrokeStyle_();
 }
@@ -672,8 +676,8 @@ void VacKeyEdge::onPaintDraw(
     }
 }
 
-ElementStatus
-VacKeyEdge::onDependencyChanged_(Element* /*dependency*/, ChangeFlags changes) {
+ElementStatus VacKeyEdge::onDependencyChanged_(Element* dependency, ChangeFlags changes) {
+    VGC_UNUSED(dependency);
     ElementStatus status = this->status();
     if (status == ElementStatus::Ok) {
         if (changes.has(ChangeFlag::VertexPosition)) {

--- a/libs/vgc/workspace/element.cpp
+++ b/libs/vgc/workspace/element.cpp
@@ -31,23 +31,29 @@ std::optional<core::StringId> Element::domTagName() const {
     return {};
 }
 
-geometry::Rect2d Element::boundingBox(core::AnimTime /*t*/) const {
+geometry::Rect2d Element::boundingBox(core::AnimTime t) const {
+    VGC_UNUSED(t);
     return geometry::Rect2d::empty;
 }
 
 bool Element::isSelectableAt(
-    const geometry::Vec2d& /*pos*/,
-    bool /*outlineOnly*/,
-    double /*tol*/,
-    double* /*outDistance*/,
-    core::AnimTime /*t*/) const {
+    const geometry::Vec2d& pos,
+    bool outlineOnly,
+    double tol,
+    double* outDistance,
+    core::AnimTime t) const {
 
+    VGC_UNUSED(pos);
+    VGC_UNUSED(outlineOnly);
+    VGC_UNUSED(tol);
+    VGC_UNUSED(outDistance);
+    VGC_UNUSED(t);
     return false;
 }
 
-bool Element::isSelectableInRect(const geometry::Rect2d& /*rect*/, core::AnimTime /*t*/)
-    const {
-
+bool Element::isSelectableInRect(const geometry::Rect2d& rect, core::AnimTime t) const {
+    VGC_UNUSED(rect);
+    VGC_UNUSED(t);
     return false;
 }
 
@@ -91,14 +97,17 @@ void Element::notifyChangesToDependents(ChangeFlags changes) {
     }
 }
 
-void Element::onPaintPrepare(core::AnimTime /*t*/, PaintOptions /*flags*/) {
+void Element::onPaintPrepare(core::AnimTime t, PaintOptions flags) {
+    VGC_UNUSED(t);
+    VGC_UNUSED(flags);
 }
 
-void Element::onPaintDraw(
-    graphics::Engine* /*engine*/,
-    core::AnimTime /*t*/,
-    PaintOptions /*flags*/) const {
+void Element::onPaintDraw(graphics::Engine* engine, core::AnimTime t, PaintOptions flags)
+    const {
 
+    VGC_UNUSED(engine);
+    VGC_UNUSED(t);
+    VGC_UNUSED(flags);
     // XXX make it pure virtual once the factory is in.
 }
 
@@ -118,17 +127,20 @@ VacElement* Element::findFirstSiblingVacElementReverse_(Element* start) {
     return static_cast<VacElement*>(e);
 }
 
-ElementStatus Element::updateFromDom_(Workspace* /*workspace*/) {
+ElementStatus Element::updateFromDom_(Workspace* workspace) {
+    VGC_UNUSED(workspace);
     return ElementStatus::Ok;
 }
 
-ElementStatus
-Element::onDependencyChanged_(Element* /*dependency*/, ChangeFlags /*changes*/) {
+ElementStatus Element::onDependencyChanged_(Element* dependency, ChangeFlags changes) {
+    VGC_UNUSED(dependency);
+    VGC_UNUSED(changes);
     return status_;
 }
 
-ElementStatus Element::onDependencyRemoved_(Element* /*dependency*/) {
+ElementStatus Element::onDependencyRemoved_(Element* dependency) {
     // child classes typically have to invalidate data when a dependency is removed
+    VGC_UNUSED(dependency);
     ElementStatus status = this->status();
     if (status == ElementStatus::Ok) {
         status = ElementStatus::UnresolvedDependency;
@@ -136,14 +148,17 @@ ElementStatus Element::onDependencyRemoved_(Element* /*dependency*/) {
     return status;
 }
 
-void Element::onDependencyMoved_(Element* /*dependency*/) {
+void Element::onDependencyMoved_(Element* dependency) {
     // child classes typically have to update paths when a dependency moves
+    VGC_UNUSED(dependency);
 }
 
-void Element::onDependentElementRemoved_(Element* /*dependent*/) {
+void Element::onDependentElementRemoved_(Element* dependent) {
+    VGC_UNUSED(dependent);
 }
 
-void Element::onDependentElementAdded_(Element* /*dependent*/) {
+void Element::onDependentElementAdded_(Element* dependent) {
+    VGC_UNUSED(dependent);
 }
 
 VacElement::~VacElement() {

--- a/libs/vgc/workspace/face.cpp
+++ b/libs/vgc/workspace/face.cpp
@@ -67,9 +67,11 @@ geometry::Rect2d VacKeyFace::boundingBox(core::AnimTime t) const {
 bool VacKeyFace::isSelectableAt(
     const geometry::Vec2d& position,
     bool outlineOnly,
-    double /*tol*/,
+    double tol,
     double* outDistance,
     core::AnimTime t) const {
+
+    VGC_UNUSED(tol);
 
     if (frameData_.time() == t) {
         if (outlineOnly) {
@@ -141,8 +143,10 @@ const VacFaceCellFrameData* VacKeyFace::computeFrameDataAt(core::AnimTime t) {
     return nullptr;
 }
 
-void VacKeyFace::onPaintPrepare(core::AnimTime /*t*/, PaintOptions /*flags*/) {
+void VacKeyFace::onPaintPrepare(core::AnimTime t, PaintOptions flags) {
     // todo, use paint options to not compute everything or with lower quality
+    VGC_UNUSED(t);
+    VGC_UNUSED(flags);
     computeFillMesh_();
     computeStrokeStyle_();
 }
@@ -217,8 +221,8 @@ void VacKeyFace::onPaintDraw(
     // draws nothing if non-selected and in outline mode
 }
 
-ElementStatus
-VacKeyFace::onDependencyChanged_(Element* /*dependency*/, ChangeFlags changes) {
+ElementStatus VacKeyFace::onDependencyChanged_(Element* dependency, ChangeFlags changes) {
+    VGC_UNUSED(dependency);
     ElementStatus status = this->status();
     if (status == ElementStatus::Ok) {
         if (changes.has(ChangeFlag::EdgePreJoinGeometry)) {
@@ -228,7 +232,8 @@ VacKeyFace::onDependencyChanged_(Element* /*dependency*/, ChangeFlags changes) {
     return status;
 }
 
-ElementStatus VacKeyFace::onDependencyRemoved_(Element* /*dependency*/) {
+ElementStatus VacKeyFace::onDependencyRemoved_(Element* dependency) {
+    VGC_UNUSED(dependency);
     ElementStatus status = this->status();
     if (status == ElementStatus::Ok) {
         status = ElementStatus::UnresolvedDependency;
@@ -636,12 +641,13 @@ bool VacKeyFace::computeStrokeStyle_() {
     return true;
 }
 
-void VacKeyFace::dirtyStrokeStyle_(bool /*notifyDependentsImmediately*/) {
+void VacKeyFace::dirtyStrokeStyle_(bool notifyDependentsImmediately) {
     VacKeyFaceFrameData& frameData = frameData_;
     if (!frameData.isStyleDirty_) {
         frameData.isStyleDirty_ = true;
         frameData.graphics_.clearStyle();
         notifyChangesToDependents(ChangeFlag::Style);
+        VGC_UNUSED(notifyDependentsImmediately);
         //notifyChanges_({ ChangeFlag::Style }, notifyDependentsImmediately);
     }
 }

--- a/libs/vgc/workspace/layer.cpp
+++ b/libs/vgc/workspace/layer.cpp
@@ -24,19 +24,24 @@ std::optional<core::StringId> Layer::domTagName() const {
     return dom::strings::layer;
 }
 
-geometry::Rect2d Layer::boundingBox(core::AnimTime /*t*/) const {
+geometry::Rect2d Layer::boundingBox(core::AnimTime t) const {
     // todo, union of children
+    VGC_UNUSED(t);
     return geometry::Rect2d::empty;
 }
 
-void Layer::onPaintDraw(
-    graphics::Engine* /*engine*/,
-    core::AnimTime /*t*/,
-    PaintOptions /*flags*/) const {
+void Layer::onPaintDraw(graphics::Engine* engine, core::AnimTime t, PaintOptions flags)
+    const {
+
+    VGC_UNUSED(engine);
+    VGC_UNUSED(t);
+    VGC_UNUSED(flags);
 }
 
-ElementStatus Layer::updateFromDom_(Workspace* /*workspace*/) {
+ElementStatus Layer::updateFromDom_(Workspace* workspace) {
     //dom::Element* const domElement = this->domElement();
+
+    VGC_UNUSED(workspace);
 
     vacomplex::Node* node = vacNode();
     vacomplex::Group* group =
@@ -60,8 +65,9 @@ ElementStatus Layer::updateFromDom_(Workspace* /*workspace*/) {
     return ElementStatus::Ok;
 }
 
-void Layer::updateFromVac_(vacomplex::NodeModificationFlags /*flags*/) {
+void Layer::updateFromVac_(vacomplex::NodeModificationFlags flags) {
     // TODO
+    VGC_UNUSED(flags);
 }
 
 } // namespace vgc::workspace

--- a/libs/vgc/workspace/style.cpp
+++ b/libs/vgc/workspace/style.cpp
@@ -24,20 +24,23 @@
 
 namespace vgc::workspace {
 
-CellStyle::OpResult CellStyle::onTranslateGeometry_(const geometry::Vec2d& /*delta*/) {
+CellStyle::OpResult CellStyle::onTranslateGeometry_(const geometry::Vec2d& delta) {
     // XXX: gradient ?
+    VGC_UNUSED(delta);
     return OpResult::Unchanged;
 }
 
 CellStyle::OpResult
-CellStyle::onTransformGeometry_(const geometry::Mat3d& /*transformation*/) {
+CellStyle::onTransformGeometry_(const geometry::Mat3d& transformation) {
     // XXX: gradient ?
+    VGC_UNUSED(transformation);
     return OpResult::Unchanged;
 }
 
 CellStyle::OpResult
-CellStyle::onUpdateGeometry_(const geometry::AbstractStroke2d* /*newStroke*/) {
+CellStyle::onUpdateGeometry_(const geometry::AbstractStroke2d* newStroke) {
     // XXX: something to do ?
+    VGC_UNUSED(newStroke);
     return OpResult::Unchanged;
 }
 
@@ -220,7 +223,9 @@ CellStyle::OpResult CellStyle::finalizeConcat_() {
 
 std::unique_ptr<vacomplex::CellProperty> CellStyle::fromGlue_(
     core::ConstSpan<vacomplex::KeyHalfedgeData> khds,
-    const geometry::AbstractStroke2d* /*gluedStroke*/) const {
+    const geometry::AbstractStroke2d* gluedStroke) const {
+
+    VGC_UNUSED(gluedStroke);
 
     // use color used the most arclength-wise
 
@@ -256,10 +261,15 @@ std::unique_ptr<vacomplex::CellProperty> CellStyle::fromGlue_(
 
 std::unique_ptr<vacomplex::CellProperty> CellStyle::fromSlice_(
     const vacomplex::KeyEdgeData& ked,
-    const geometry::CurveParameter& /*start*/,
-    const geometry::CurveParameter& /*end*/,
-    Int /*numWraps*/,
-    const geometry::AbstractStroke2d* /*subStroke*/) const {
+    const geometry::CurveParameter& start,
+    const geometry::CurveParameter& end,
+    Int numWraps,
+    const geometry::AbstractStroke2d* subStroke) const {
+
+    VGC_UNUSED(start);
+    VGC_UNUSED(end);
+    VGC_UNUSED(numWraps);
+    VGC_UNUSED(subStroke);
 
     auto styleProp = static_cast<const CellStyle*>(ked.findProperty(strings::style));
     if (styleProp) {

--- a/libs/vgc/workspace/vertex.cpp
+++ b/libs/vgc/workspace/vertex.cpp
@@ -44,10 +44,8 @@ void setMultiJoinEnabled(bool enabled) {
 
 } // namespace detail
 
-void VacVertexCellFrameData::debugPaint_(graphics::Engine* /*engine*/) {
-
-    using namespace graphics;
-    using detail::VacJoinHalfedgeFrameData;
+void VacVertexCellFrameData::debugPaint_(graphics::Engine* engine) {
+    VGC_UNUSED(engine);
 }
 
 void VacVertexCell::rebuildJoinHalfedgesArray() const {
@@ -115,10 +113,12 @@ geometry::Rect2d VacKeyVertex::boundingBox(core::AnimTime t) const {
 
 bool VacKeyVertex::isSelectableAt(
     const geometry::Vec2d& p,
-    bool /*outlineOnly*/,
+    bool outlineOnly,
     double tol,
     double* outDistance,
     core::AnimTime t) const {
+
+    VGC_UNUSED(outlineOnly);
 
     vacomplex::KeyVertex* kv = vacKeyVertexNode();
     if (kv && frameData_.time() == t) {
@@ -213,7 +213,8 @@ void VacKeyVertex::onPaintDraw(
     }
 }
 
-ElementStatus VacKeyVertex::updateFromDom_(Workspace* /*workspace*/) {
+ElementStatus VacKeyVertex::updateFromDom_(Workspace* workspace) {
+    VGC_UNUSED(workspace);
     namespace ds = dom::strings;
     dom::Element* const domElement = this->domElement();
     if (!domElement) {

--- a/libs/vgc/workspace/workspace.cpp
+++ b/libs/vgc/workspace/workspace.cpp
@@ -1452,7 +1452,7 @@ void Workspace::onVacNodesChanged_(const vacomplex::ComplexDiff& diff) {
     // Note: transient vac nodes are included.
     //
     for (auto [id, vacElement] : workspaceItemsToDestroy) {
-        std::ignore = id;
+        VGC_UNUSED(id);
 
         // Delete the corresponding DOM element if any.
         //
@@ -1927,7 +1927,10 @@ void Workspace::updateVacFromDom_(const dom::Diff& diff) {
     changed().emit();
 }
 
-//void Workspace::updateTreeAndDomFromVac_(const vacomplex::Diff& /*diff*/) {
+//void Workspace::updateTreeAndDomFromVac_(const vacomplex::Diff& diff) {
+//
+//    VGC_UNUSED(diff);
+//
 //    if (!document_) {
 //        VGC_ERROR(LogVgcWorkspace, "DOM is null.")
 //        return;


### PR DESCRIPTION
#748

This also implements `VGC_DISCARD` for clarifying that `VGC_UNUSED` shouldn't be used for discarding the return value of `[[nodiscard]]` function, which should be extremely rare (we currently never do it).