### PR TITLE
Implement recomputation of edge geometry when fit method changes (#1191)

### DIFF
--- a/libs/vgc/dom/element.cpp
+++ b/libs/vgc/dom/element.cpp
@@ -196,8 +196,6 @@ const Value& Element::getAttribute(core::StringId name) const {
             return attributeSpec->defaultValue();
         }
         else {
-            VGC_WARNING(
-                LogVgcDom, "Attribute is neither authored nor have a default value.");
             return Value::invalid();
         }
     }

--- a/libs/vgc/dom/element.h
+++ b/libs/vgc/dom/element.h
@@ -298,10 +298,22 @@ public:
     ///
     const Value& getAuthoredAttribute(core::StringId name) const;
 
-    /// Gets the value of the attribute named `name`. Emits a warning and returns an
-    /// invalid value if the attribute neither is authored nor has a default value.
+    /// Gets the value of the attribute named `name`. Returns an invalid value
+    /// if the attribute neither is authored nor has a default value.
     ///
     const Value& getAttribute(core::StringId name) const;
+
+    /// Gets the value of the attribute named `name` as a `const T*`. Returns
+    /// `nullptr` if the attribute neither is authored nor has a default value,
+    /// or if the held value is not of the requested type.
+    ///
+    // XXX Use smart pointers instead?
+    //
+    template<typename T>
+    const T* getAttributeIf(core::StringId name) const {
+        const Value& value = getAttribute(name);
+        return value.getIf<T>();
+    }
 
     /// Gets the element referred to by the path attribute named `name`.
     ///


### PR DESCRIPTION
#1191

With this PR, when switching fit methods (Ctrl+Alt+Shift+F), then any edge whose input sketch points are saved (as per option in Experimental panel) will be modified by recomputing its geometry from the input points using the new fit method. this makes it easier to compare the results of different fit methods.