### PR TITLE
Remove commented static keywords in cpp files (#1466)

### DIFF
--- a/libs/vgc/core/performancelog.cpp
+++ b/libs/vgc/core/performancelog.cpp
@@ -35,7 +35,6 @@ PerformanceLog::PerformanceLog(
     }
 }
 
-/* static */
 PerformanceLogPtr PerformanceLog::create(const std::string& name) {
     return createObject<PerformanceLog>(nullptr, name);
 }
@@ -72,7 +71,6 @@ PerformanceLogParams::PerformanceLogParams(CreateKey key)
     : Object(key) {
 }
 
-/* static */
 PerformanceLogParamsPtr PerformanceLogParams::create() {
     return createObject<PerformanceLogParams>();
 }

--- a/libs/vgc/core/python.cpp
+++ b/libs/vgc/core/python.cpp
@@ -193,7 +193,6 @@ PythonInterpreter::PythonInterpreter(
         pythonPath());
 }
 
-/* static */
 PythonInterpreterPtr
 PythonInterpreter::create(const std::string& programName, const std::string& pythonHome) {
     return createObject<PythonInterpreter>(programName, pythonHome);

--- a/libs/vgc/dom/document.cpp
+++ b/libs/vgc/dom/document.cpp
@@ -46,7 +46,6 @@ Document::Document(CreateKey key)
     generateXmlDeclaration_();
 }
 
-/* static */
 DocumentPtr Document::create() {
     return core::createObject<Document>();
 }
@@ -203,7 +202,6 @@ private:
 
 } // namespace
 
-/* static */
 DocumentPtr Document::open(std::string_view filePath) {
     // Note: in the future, we want to be able to detect formatting style of
     // input XML files, and preserve this style, as well as existing
@@ -329,7 +327,6 @@ void Document::save(const std::string& filePath, const XmlFormattingStyle& style
     writeChildren(out, style, 0, this);
 }
 
-/* static */
 DocumentPtr Document::copy(core::ConstSpan<Node*> nodes) {
 
     static_assert(core::isRange<core::Span<Node*>>);
@@ -406,7 +403,6 @@ DocumentPtr Document::copy(core::ConstSpan<Node*> nodes) {
     return result;
 }
 
-/* static */
 core::Array<Node*> Document::paste(DocumentPtr document, Node* parent) {
 
     core::Array<Node*> res;

--- a/libs/vgc/dom/element.cpp
+++ b/libs/vgc/dom/element.cpp
@@ -40,7 +40,6 @@ void Element::onDestroyed() {
     SuperClass::onDestroyed();
 }
 
-/* static */
 Element* Element::create_(Node* parent, core::StringId tagName, Element* nextSibling) {
     Document* doc = parent->document();
 
@@ -52,7 +51,6 @@ Element* Element::create_(Node* parent, core::StringId tagName, Element* nextSib
     return e.get();
 }
 
-/* static */
 Element* Element::createCopy_(Node* parent, const Element* source, Element* nextSibling) {
 
     Document* srcDoc = source->document();
@@ -72,7 +70,6 @@ Element* Element::createCopy_(Node* parent, const Element* source, Element* next
     return result;
 }
 
-/* static */
 Element* Element::createCopy_(
     Node* parent,
     const Element* source,
@@ -87,7 +84,6 @@ Element* Element::createCopy_(
     return e;
 }
 
-/* static */
 Element* Element::createCopyRec_(
     Node* parent,
     const Element* source,
@@ -126,7 +122,6 @@ Element* Element::createCopyRec_(
     return e.get();
 }
 
-/* static */
 Element* Element::create(Document* parent, core::StringId tagName) {
     if (parent->rootElement()) {
         throw SecondRootElementError(parent);
@@ -135,12 +130,10 @@ Element* Element::create(Document* parent, core::StringId tagName) {
     return create_(parent, tagName, nullptr);
 }
 
-/* static */
 Element* Element::create(Element* parent, core::StringId tagName, Element* nextSibling) {
     return create_(parent, tagName, nextSibling);
 }
 
-/* static */
 Element* Element::createCopy(Document* parent, const Element* source) {
     if (parent->rootElement()) {
         throw SecondRootElementError(parent);
@@ -149,7 +142,6 @@ Element* Element::createCopy(Document* parent, const Element* source) {
     return createCopy_(parent, source, nullptr);
 }
 
-/* static */
 Element*
 Element::createCopy(Element* parent, const Element* source, Element* nextSibling) {
     return createCopy_(parent, source, nextSibling);

--- a/libs/vgc/graphics/d3d11/d3d11engine.cpp
+++ b/libs/vgc/graphics/d3d11/d3d11engine.cpp
@@ -853,7 +853,6 @@ void D3d11Engine::onDestroyed() {
     Engine::onDestroyed();
 }
 
-/* static */
 D3d11EnginePtr D3d11Engine::create(const EngineCreateInfo& createInfo) {
     D3d11EnginePtr engine = core::createObject<D3d11Engine>(createInfo);
     engine->init_();

--- a/libs/vgc/tools/colorpalette.cpp
+++ b/libs/vgc/tools/colorpalette.cpp
@@ -864,7 +864,6 @@ ColorPaletteSelector::ColorPaletteSelector(CreateKey key)
     addStyleClass(strings::ColorPaletteSelector);
 }
 
-/* static */
 ColorPaletteSelectorPtr ColorPaletteSelector::create() {
     return core::createObject<ColorPaletteSelector>();
 }

--- a/libs/vgc/ui/detail/qopenglengine.cpp
+++ b/libs/vgc/ui/detail/qopenglengine.cpp
@@ -871,14 +871,12 @@ void QglEngine::onDestroyed() {
     surface_ = nullptr;
 }
 
-/* static */
 QglEnginePtr QglEngine::create(const EngineCreateInfo& createInfo) {
     QglEnginePtr engine = core::createObject<QglEngine>(createInfo, nullptr);
     engine->init_();
     return engine;
 }
 
-/* static */
 QglEnginePtr
 QglEngine::create(const EngineCreateInfo& createInfo, QOpenGLContext* externalCtx) {
     // Multithreading not supported atm, Qt does thread affinity

--- a/libs/vgc/ui/event.cpp
+++ b/libs/vgc/ui/event.cpp
@@ -24,7 +24,6 @@ Event::Event(CreateKey key, double timestamp, ModifierKeys modifiers)
     , modifierKeys_(modifiers) {
 }
 
-/* static */
 EventPtr Event::create(double timestamp, ModifierKeys modifiers) {
     return core::createObject<Event>(timestamp, modifiers);
 }

--- a/libs/vgc/ui/scrollevent.cpp
+++ b/libs/vgc/ui/scrollevent.cpp
@@ -48,7 +48,6 @@ ScrollEvent::ScrollEvent(
     , verticalSteps_(verticalSteps) {
 }
 
-/* static */
 ScrollEventPtr ScrollEvent::create(
     double timestamp,
     ModifierKeys modifiers,

--- a/libs/vgc/vacomplex/cellproperty.cpp
+++ b/libs/vgc/vacomplex/cellproperty.cpp
@@ -283,7 +283,6 @@ void CellProperties::assignFromSlice(
     }
 }
 
-/* static */
 void CellProperties::emitPropertyChanged_(core::StringId name) {
     if (cell_) {
         Complex* complex = cell_->complex();

--- a/libs/vgc/vacomplex/detail/operationsimpl.cpp
+++ b/libs/vgc/vacomplex/detail/operationsimpl.cpp
@@ -2378,7 +2378,6 @@ void Operations::insertNodeAsLastChild_(Node* node, Group* parent) {
     }
 }
 
-/* static */
 Node* Operations::findTopMost(core::ConstSpan<Node*> nodes) {
     // currently only looking under a single parent
     // TODO: tree-wide top most.
@@ -2397,7 +2396,6 @@ Node* Operations::findTopMost(core::ConstSpan<Node*> nodes) {
     return topMostNode;
 }
 
-/* static */
 Node* Operations::findBottomMost(core::ConstSpan<Node*> nodes) {
     // currently only looking under a single parent
     // TODO: tree-wide bottom most.

--- a/libs/vgc/vacomplex/keyedgedata.cpp
+++ b/libs/vgc/vacomplex/keyedgedata.cpp
@@ -209,7 +209,6 @@ void KeyEdgeData::closeStroke(bool smoothJoin) {
 // IDEA: do conversion to common best stroke geometry to merge
 //       then match cell properties by pairs (use null if not present)
 
-/* static */
 KeyEdgeData KeyEdgeData::fromConcatStep(
     const KeyHalfedgeData& khd1,
     const KeyHalfedgeData& khd2,
@@ -249,7 +248,6 @@ void KeyEdgeData::finalizeConcat() {
     properties_.finalizeConcat();
 }
 
-/* static */
 KeyEdgeData KeyEdgeData::fromGlueOpen(core::ConstSpan<KeyHalfedgeData> khds) {
 
     struct ConvertedStroke {
@@ -292,7 +290,6 @@ KeyEdgeData KeyEdgeData::fromGlueOpen(core::ConstSpan<KeyHalfedgeData> khds) {
     return fromGlue(khds, std::move(gluedStroke));
 }
 
-/* static */
 KeyEdgeData KeyEdgeData::fromGlueClosed(
     core::ConstSpan<KeyHalfedgeData> khds,
     core::ConstSpan<double> uOffsets) {
@@ -337,7 +334,6 @@ KeyEdgeData KeyEdgeData::fromGlueClosed(
     return fromGlue(khds, std::move(gluedStroke));
 }
 
-/* static */
 KeyEdgeData KeyEdgeData::fromGlue(
     core::ConstSpan<KeyHalfedgeData> khds,
     std::unique_ptr<geometry::AbstractStroke2d>&& gluedStroke) {

--- a/libs/vgc/vacomplex/keyfacedata.cpp
+++ b/libs/vgc/vacomplex/keyfacedata.cpp
@@ -60,7 +60,6 @@ void KeyFaceData::transform(const geometry::Mat3d& transformation) {
     properties_.onTransformGeometry(transformation);
 }
 
-/* static */
 void KeyFaceData::assignFromConcatStep(
     KeyFaceData& result,
     const KeyFaceData& kfd1,

--- a/libs/vgc/workspace/edge.cpp
+++ b/libs/vgc/workspace/edge.cpp
@@ -700,7 +700,6 @@ ElementStatus VacKeyEdge::onDependencyRemoved_(Element* dependency) {
     return status;
 }
 
-/* static */
 bool VacKeyEdge::updateStrokeFromDom_(
     vacomplex::KeyEdgeData& data,
     const dom::Element* domElement) {
@@ -736,7 +735,6 @@ bool VacKeyEdge::updateStrokeFromDom_(
     return true;
 }
 
-/* static */
 void VacKeyEdge::writeStrokeToDom_(
     dom::Element* domElement,
     const vacomplex::KeyEdgeData& data) {
@@ -753,7 +751,6 @@ void VacKeyEdge::writeStrokeToDom_(
     }
 }
 
-/* static */
 void VacKeyEdge::clearStrokeFromDom_(dom::Element* domElement) {
     namespace ds = dom::strings;
     domElement->clearAttribute(ds::positions);


### PR DESCRIPTION
#1466

Rationale: we had no tool to enforce it so it was not consistently used, and wasn't so useful anyway. So the new guideline is to not use such comments.