### PR TITLE
Move arrow from Button to DropdownButton; Set icon based on DropDirection; Show arrow for submenus (#900)

### DIFF
--- a/libs/vgc/ui/CMakeLists.txt
+++ b/libs/vgc/ui/CMakeLists.txt
@@ -152,6 +152,7 @@ vgc_add_library(ui
 
     RESOURCE_FILES
         icons/button-down-arrow.svg
+        icons/button-right-arrow.svg
         icons/checkmark.svg
         icons/close.svg
         stylesheets/default.vgcss

--- a/libs/vgc/ui/button.cpp
+++ b/libs/vgc/ui/button.cpp
@@ -106,21 +106,6 @@ void Button::setShortcutVisible(bool visible) {
     }
 }
 
-bool Button::isArrowVisible() const {
-    return arrowIcon_ ? arrowIcon_->visibility() == Visibility::Inherit : false;
-}
-
-void Button::setArrowVisible(bool visible) {
-    if (visible && !arrowIcon_) {
-        std::string arrowIconPath = core::resourcePath("ui/icons/button-down-arrow.svg");
-        arrowIcon_ = createChild<IconWidget>(arrowIconPath);
-        arrowIcon_->addStyleClass(strings::arrow);
-    }
-    if (arrowIcon_) {
-        arrowIcon_->setVisibility(visible ? Visibility::Inherit : Visibility::Invisible);
-    }
-}
-
 bool Button::isTextVisible() const {
     return textLabel_ ? textLabel_->visibility() == Visibility::Inherit : false;
 }

--- a/libs/vgc/ui/button.h
+++ b/libs/vgc/ui/button.h
@@ -130,14 +130,6 @@ public:
     ///
     void setShortcutVisible(bool visible);
 
-    /// Returns whether the arrow is visible.
-    ///
-    bool isArrowVisible() const;
-
-    /// Sets whether the arrow is visible. By default, it is hidden.
-    ///
-    void setArrowVisible(bool visible);
-
     /// Returns whether a tooltip appears when hovering the button.
     ///
     /// The default is `true`.
@@ -281,10 +273,6 @@ protected:
         return shortcutLabel_;
     }
 
-    IconWidget* arrowIcon() const {
-        return arrowIcon_;
-    }
-
     void setActive(bool isActive);
 
 private:
@@ -293,7 +281,6 @@ private:
     IconWidget* iconWidget_ = nullptr;
     Label* textLabel_ = nullptr;
     Label* shortcutLabel_ = nullptr;
-    IconWidget* arrowIcon_ = nullptr;
 
     // Style
     bool isPressed_ = false;

--- a/libs/vgc/ui/dropdownbutton.cpp
+++ b/libs/vgc/ui/dropdownbutton.cpp
@@ -16,6 +16,7 @@
 
 #include <vgc/ui/dropdownbutton.h>
 
+#include <vgc/core/paths.h>
 #include <vgc/ui/menu.h>
 #include <vgc/ui/strings.h>
 
@@ -29,16 +30,64 @@ DropdownButton::DropdownButton(
     : Button(key, action, layoutDirection) {
 
     addStyleClass(strings::DropdownButton);
-    setShortcutVisible(true);
+    updateArrowIcon_();
 }
 
 DropdownButtonPtr DropdownButton::create(Action* action, FlexDirection layoutDirection) {
     return core::createObject<DropdownButton>(action, layoutDirection);
 }
 
+void DropdownButton::setDropDirection(DropDirection direction) {
+    if (dropDirection_ != direction) {
+        dropDirection_ = direction;
+        updateArrowIcon_();
+    }
+}
+
+bool DropdownButton::isArrowVisible() const {
+    if (auto arrowIcon = arrowIcon_.lock()) {
+        return arrowIcon_->visibility() == Visibility::Inherit;
+    }
+    else {
+        return false;
+    }
+}
+
+void DropdownButton::setArrowVisible(bool visible) {
+    if (auto arrowIcon = arrowIcon_.lock()) {
+        arrowIcon->setVisibility(visible ? Visibility::Inherit : Visibility::Invisible);
+    }
+}
+
 void DropdownButton::closePopupMenu() {
     if (Menu* menu = popupMenu()) {
         menu->close();
+    }
+}
+
+namespace {
+
+std::string getArrowIconPath(DropDirection direction) {
+    switch (direction) {
+    case DropDirection::Horizontal:
+        return core::resourcePath("ui/icons/button-right-arrow.svg");
+    case DropDirection::Vertical:
+        return core::resourcePath("ui/icons/button-down-arrow.svg");
+    }
+    return core::resourcePath("");
+}
+
+} // namespace
+
+void DropdownButton::updateArrowIcon_() {
+    if (auto arrowIcon = arrowIcon_.lock()) {
+        arrowIcon->reparent(nullptr);
+        arrowIcon_ = nullptr;
+    }
+    std::string iconPath = getArrowIconPath(dropDirection());
+    if (!iconPath.empty()) {
+        arrowIcon_ = createChild<IconWidget>(iconPath);
+        arrowIcon_->addStyleClass(strings::arrow);
     }
 }
 

--- a/libs/vgc/ui/dropdownbutton.cpp
+++ b/libs/vgc/ui/dropdownbutton.cpp
@@ -46,7 +46,7 @@ void DropdownButton::setDropDirection(DropDirection direction) {
 
 bool DropdownButton::isArrowVisible() const {
     if (auto arrowIcon = arrowIcon_.lock()) {
-        return arrowIcon_->visibility() == Visibility::Inherit;
+        return arrowIcon->visibility() == Visibility::Inherit;
     }
     else {
         return false;
@@ -74,7 +74,7 @@ std::string getArrowIconPath(DropDirection direction) {
     case DropDirection::Vertical:
         return core::resourcePath("ui/icons/button-down-arrow.svg");
     }
-    return core::resourcePath("");
+    return "";
 }
 
 } // namespace
@@ -87,7 +87,9 @@ void DropdownButton::updateArrowIcon_() {
     std::string iconPath = getArrowIconPath(dropDirection());
     if (!iconPath.empty()) {
         arrowIcon_ = createChild<IconWidget>(iconPath);
-        arrowIcon_->addStyleClass(strings::arrow);
+        if (auto arrowIcon = arrowIcon_.lock()) {
+            arrowIcon->addStyleClass(strings::arrow);
+        }
     }
 }
 

--- a/libs/vgc/ui/dropdownbutton.h
+++ b/libs/vgc/ui/dropdownbutton.h
@@ -81,7 +81,7 @@ private:
     DropDirection dropDirection_ = DropDirection::Vertical;
     Menu* popupMenu_ = nullptr;
 
-    IconWidgetSharedPtr arrowIcon_;
+    IconWidgetWeakPtr arrowIcon_;
     void updateArrowIcon_();
 
     // The menu calls this when it opens as a popup.

--- a/libs/vgc/ui/dropdownbutton.h
+++ b/libs/vgc/ui/dropdownbutton.h
@@ -17,20 +17,8 @@
 #ifndef VGC_UI_DROPDOWNBUTTON_H
 #define VGC_UI_DROPDOWNBUTTON_H
 
-#include <string>
-#include <string_view>
-
-#include <vgc/core/innercore.h>
-#include <vgc/geometry/vec2f.h>
-#include <vgc/graphics/richtext.h>
-#include <vgc/ui/action.h>
-#include <vgc/ui/api.h>
 #include <vgc/ui/button.h>
-#include <vgc/ui/flex.h>
 #include <vgc/ui/iconwidget.h>
-#include <vgc/ui/label.h>
-#include <vgc/ui/margins.h>
-#include <vgc/ui/widget.h>
 
 namespace vgc::ui {
 
@@ -41,8 +29,8 @@ VGC_DECLARE_OBJECT(DropdownButton);
 /// \brief The direction in which a dropdown overlay should appear.
 ///
 enum class DropDirection {
-    Horizontal,
     Vertical,
+    Horizontal,
 };
 
 /// \class vgc::ui::DropdownButton
@@ -62,13 +50,23 @@ public:
     static DropdownButtonPtr
     create(Action* action, FlexDirection layoutDirection = FlexDirection::Column);
 
-    void setDropDirection(DropDirection direction) {
-        dropDirection_ = direction;
-    }
-
+    /// Returns the `DropDirection` of this dropdown button.
+    ///
     DropDirection dropDirection() const {
         return dropDirection_;
     }
+
+    /// Sets the `DropDirection` of this dropdown button.
+    ///
+    void setDropDirection(DropDirection direction);
+
+    /// Returns whether the arrow is visible.
+    ///
+    bool isArrowVisible() const;
+
+    /// Sets whether the arrow is visible. By default, it is visible.
+    ///
+    void setArrowVisible(bool visible);
 
     Menu* popupMenu() const {
         return popupMenu_;
@@ -80,8 +78,11 @@ public:
     VGC_SIGNAL(menuPopupClosed, (bool, recursive));
 
 private:
-    DropDirection dropDirection_ = DropDirection::Horizontal;
+    DropDirection dropDirection_ = DropDirection::Vertical;
     Menu* popupMenu_ = nullptr;
+
+    IconWidgetSharedPtr arrowIcon_;
+    void updateArrowIcon_();
 
     // The menu calls this when it opens as a popup.
     void onMenuPopupOpened_(Menu* menu);

--- a/libs/vgc/ui/icons/button-right-arrow.svg
+++ b/libs/vgc/ui/icons/button-right-arrow.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <style
+       id="style1"><![CDATA[.background { fill:#404244; }
+.fill-foreground-color { fill:#f5f5f5; }
+.fill-accent-color { fill:#0b52ac; }
+.stroke-foreground-color { stroke:#f5f5f5; }
+.stroke-accent-color { stroke:#0b52ac; }
+.stop-foreground-color { stop-color:#f5f5f5; }
+.stop-accent-color { stop-color: #0b52ac; }
+]]></style>
+  </defs>
+  <rect
+     class="background"
+     x="0"
+     y="0"
+     width="32"
+     height="32"
+     id="rect1" />
+  <path
+     class="stroke-foreground-color"
+     style="fill:none;stroke-width:5;stroke-linecap:round;stroke-linejoin:round"
+     d="m 12,8 8,8 -8,8"
+     id="path13397" />
+</svg>

--- a/libs/vgc/ui/menu.cpp
+++ b/libs/vgc/ui/menu.cpp
@@ -123,6 +123,14 @@ void Menu::addItemAt(Int index, Menu* menu) {
     DropdownButton* button = createChildAt<DropdownButton>(index, action);
     button->addStyleClass(strings::button);
     button->setTooltipEnabled(false);
+    if (direction() == FlexDirection::Column) {
+        button->setArrowVisible(true);
+        button->setDropDirection(DropDirection::Horizontal);
+    }
+    else {
+        button->setArrowVisible(false);
+        button->setDropDirection(DropDirection::Vertical);
+    }
     items_.insert(index, MenuItem(action, button, menu));
     onItemAdded_(items_[index]);
     notifyChanged(true);
@@ -289,20 +297,12 @@ void placeMenuFit(
     menuRect.setPosition(resultPos);
 }
 
-DropDirection getDropDirection(Menu* parentMenu, DropdownButton* button) {
-    if (parentMenu) {
-        if (parentMenu->isRow()) {
-            return DropDirection::Vertical;
-        }
-        else {
-            return DropDirection::Horizontal;
-        }
-    }
-    else if (button) {
+DropDirection getDropDirection(Widget* opener) {
+    if (DropdownButton* button = dynamic_cast<DropdownButton*>(opener)) {
         return button->dropDirection();
     }
     else {
-        return DropDirection::Horizontal;
+        return DropDirection::Vertical;
     }
 }
 
@@ -314,10 +314,7 @@ Menu* getMenuFromItem(Widget* item) {
 
 geometry::Vec2f Menu::computePopupPosition(Widget* opener, Widget* area) {
 
-    DropdownButton* button = dynamic_cast<DropdownButton*>(opener);
-    Menu* parentMenu = getMenuFromItem(opener);
-
-    DropDirection dropDir = getDropDirection(parentMenu, button);
+    DropDirection dropDir = getDropDirection(opener);
     int dropDirIndex = (dropDir == DropDirection::Horizontal) ? 0 : 1;
 
     geometry::Rect2f areaRect = area->rect();


### PR DESCRIPTION
#900

There are no submenus in VGC Illustrations yet, but when there will be, they will finally have a right-arrow icon!

![image](https://github.com/vgc/vgc/assets/4809739/0fd9a1ce-8024-4e34-8a59-b38569315e67)
