### PR TITLE
Restrict allowed types for core::contains<Container, T> to compatible types (#748)

### DIFF
--- a/libs/vgc/core/algorithms.h
+++ b/libs/vgc/core/algorithms.h
@@ -37,6 +37,8 @@
 //
 #include <vgc/core/arithmetic.h>
 
+#include <vgc/core/detail/containerutil.h> // IsCompatibleRange
+
 namespace vgc::core {
 
 /// Returns the sum of all values in the given vector.
@@ -126,7 +128,10 @@ bool contains(const std::vector<T>& v, const T& x) {
 
 /// Returns whether the given container `c` contains the given value `x`.
 ///
-template<typename Container, typename T>
+template<
+    typename Container,
+    typename T,
+    VGC_REQUIRES(detail::isCompatibleRange<Container, T>)>
 bool contains(const Container& c, const T& x) {
     return std::find(c.begin(), c.end(), x) != c.end();
 }

--- a/libs/vgc/graphics/svg.cpp
+++ b/libs/vgc/graphics/svg.cpp
@@ -973,7 +973,7 @@ std::optional<core::Color> parseColor(std::string_view s) {
         // Return result
         return core::Color(colors[0], colors[1], colors[2]);
     }
-    else if (startsWith(s, "hsla") && endsWith(s, ")") && contains(s, "(")) {
+    else if (startsWith(s, "hsla") && endsWith(s, ")") && contains(s, '(')) {
 
         // Remove hsla()
         s.remove_prefix(4);
@@ -1010,7 +1010,7 @@ std::optional<core::Color> parseColor(std::string_view s) {
         // Return result
         return core::Color::hsla(hue, saturation, lightness, alpha);
     }
-    else if (startsWith(s, "hsl") && endsWith(s, ")") && contains(s, "(")) {
+    else if (startsWith(s, "hsl") && endsWith(s, ")") && contains(s, '(')) {
 
         // Remove hsl()
         s.remove_prefix(3);
@@ -1048,7 +1048,7 @@ std::optional<core::Color> parseColor(std::string_view s) {
         s = trimmed(s);
         return core::Color::fromHex(s);
     }
-    else if (startsWith(s, "url") && endsWith(s, ")") && contains(s, "(")) {
+    else if (startsWith(s, "url") && endsWith(s, ")") && contains(s, '(')) {
         VGC_WARNING(LogVgcGraphicsSvg, "Unsupported color type: {}", s);
         return std::nullopt;
     }


### PR DESCRIPTION
#748

Related: #1658

This fixes a compile error I got after adding `#include <vgc/core/algorithms.h>` in an unrelated header. This made a conflict between the `contains` method defined in algorithms.h and the one defined in stringutil.h: the compiler preferred the one in algorithms.h (due to an implicit conversion to string_view needed for the one in stringutil.h), resulting in a compile error.

The changes to svg.cpp fixed the error in this specific case (only one character), but the real more general fix are the changes to algorithms.h.