### PR TITLE
Implement non-templated versions of Enum methods (#1751)

### DIFF
--- a/libs/vgc/core/enum.cpp
+++ b/libs/vgc/core/enum.cpp
@@ -151,6 +151,7 @@ void EnumDataBase::addItemBase(
     valueToIndex[value] = index;
     shortNameToIndex[data.shortName] = index;
 
+    enumValues.append(EnumValue(typeId, value));
     fullNames.append(data.fullName);
     shortNames.append(data.shortName);
     prettyNames.append(data.prettyName);


### PR DESCRIPTION
#1751

Note: the only change to `EnumDataBase` is adding the `Array<EnumValue> values` data member. But since this means that  `EnumDataBase` now depends on `EnumValue`, the whole class is moved further down the file, creating an artificially large change while the actual change is not so big.

Note 2: a lot of the change is also simply improving the documentation.

Important: using the non-templated versions have the potential issue that the the enum data might not yet have been initialized at the moment of the call, due to lazy initialization. The initialization can only take place when one of the templated version is called. One way to fix this problem would be to introduce a new class `EnumTypeId` (or simply `EnumType`), similar to `TypeId` but specifically for enum types. By requiring users to instanciate an `EnumType` rather than the more generic `TypeId` (by changing the signature of all methods in `Enum` to use `EnumType` instead of `TypeId`), this would provide an opportunity to perform the initialization before it is needed.

It would also naturally remove the need to do the initialization in `EnumValue`, since it would be transitively done by the `EnumValue` storing its `EnumType`.