### PR TITLE
Implement EnumType and use it instead of Enum (#1751)

### DIFF
--- a/apps/uitest/main.cpp
+++ b/apps/uitest/main.cpp
@@ -314,11 +314,11 @@ private:
         return comboBox_;
     }
 
-    template<typename EnumType>
+    template<typename TEnum>
     ui::ComboBoxWeakPtr createComboBoxFromEnum_(ui::Widget* parent) {
         ui::Column* col = parent->createChild<ui::Column>();
         ui::LabelWeakPtr label_ = col->createChild<ui::Label>();
-        auto comboBoxShared_ = ui::ComboBox::createFromEnum<EnumType>();
+        auto comboBoxShared_ = ui::ComboBox::createFromEnum<TEnum>();
         ui::ComboBoxWeakPtr comboBox_ = comboBoxShared_;
         setComboBoxLabelText_(label_, comboBox_, -1);
         if (auto comboBox = comboBox_.lock()) {

--- a/libs/vgc/canvas/canvasmanager.cpp
+++ b/libs/vgc/canvas/canvasmanager.cpp
@@ -362,7 +362,7 @@ void setSamplingQuality_(
     VGC_INFO(
         LogVgcCanvas,
         "Switched sampling quality to: {}",
-        core::Enum::prettyName(quality));
+        core::EnumValue(quality).prettyName());
 
     complex.setSamplingQuality(quality);
     canvas.requestRepaint();

--- a/libs/vgc/core/enum.h
+++ b/libs/vgc/core/enum.h
@@ -20,6 +20,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 
 #include <vgc/core/algorithms.h> // hashCombine
@@ -33,233 +34,288 @@
 
 namespace vgc::core {
 
+class EnumValue;
+
 namespace detail {
 
-struct EnumValueData {
-    TypeId typeId;          //  core::typeId<vgc::ui::Key>()
+// Note: We have chosen to store type-erased enum values by casting them to a
+// 64bit integer, which means that we do not support enum types whose
+// underlying type is larger than 64bit. This is unlikely to ever be an issue,
+// since as of this writing (e.g., up to C++23), such enum types are not
+// portably supported anyway. Example with Clang:
+//
+//   enum Foo { _65bitValue = 0x1ffff'ffff'ffff'ffff };
+//
+//   error: integer literal is too large to be represented in any integer type.
+
+struct EnumValueInfo {
     UInt64 value;           //  static_cast<UInt64>(vgc::ui::Key::Digit0)
     std::string fullName;   //  "vgc::ui::Key::Digit0"
     std::string shortName;  //  "Digit0"
     std::string prettyName; //  "0"
-
-    // Note: Not supporting enum types larger than 64bit is unlikely to ever be
-    // an issue, since (at least up to C++23), such enum types are not portably
-    // supported anyway. Example with Clang:
-    //
-    //   enum Foo { _65bitValue = 0x1ffff'ffff'ffff'ffff };
-    //
-    //   error: integer literal is too large to be represented in any integer type.
 };
 
-struct EnumDataBase;
+// Base class storing most of the meta-info of a given EnumType.
+//
+class VGC_CORE_API EnumTypeInfo_ {
+public:
+    core::TypeId typeId;
+    bool isRegistered = false;
 
-VGC_CORE_API
-void registerEnumDataBase(const EnumDataBase& data);
+    std::string unknownItemFullName;   // "vgc::ui::Key::Unknown_Key"
+    std::string unknownItemShortName;  // "Unknown_Key"
+    std::string unknownItemPrettyName; // "Unknown Key"
 
-VGC_CORE_API
-const EnumDataBase* getEnumDataBase(TypeId typeId);
+    // This is where the actual per-enumerator data is stored. We allocate each
+    // EnumValueInfo separately on the heap to ensure that it has a stable
+    // address, and therefore that string_views to the stored strings stay
+    // valid when valueInfo grows (or if this EnumTypeInfo_ is moved).
+    //
+    Array<std::unique_ptr<EnumValueInfo>> valueInfo;
 
-VGC_CORE_API
-const EnumValueData* getEnumValueData(TypeId typeId, UInt64 value);
+    // These maps make it possible to quickly find the appropriate
+    // EnumValueInfo from the enum value or the enum short name.
+    //
+    std::unordered_map<UInt64, Int> valueToIndex;
+    std::unordered_map<std::string_view, Int> shortNameToIndex;
+
+    // These are convenient arrays (redundant with valueInfo) facilitating
+    // iteration without the need for proxy iterators. This approach increases
+    // debuggability and works better with parallelization libs (sometimes not
+    // supporting proxy iterators).
+    //
+    Array<EnumValue> enumValues;
+    Array<std::string_view> fullNames;
+    Array<std::string_view> shortNames;
+    Array<std::string_view> prettyNames;
+
+    EnumTypeInfo_(TypeId id);
+    virtual ~EnumTypeInfo_() = 0;
+
+    // EnumTypeInfo_ is non-copyable (because it stores unique_ptrs).
+    // We need to explicitly mark it non-copyable otherwise it doesn't compile on MSVC.
+    EnumTypeInfo_(const EnumTypeInfo_&) = delete;
+    EnumTypeInfo_& operator=(const EnumTypeInfo_&) = delete;
+
+    // Returns the index corresponding to the given enum value, if any.
+    //
+    std::optional<Int> getIndex(UInt64 value) const;
+
+    // Returns the index corresponding to the given enum short name, if any.
+    //
+    std::optional<Int> getIndexFromShortName(std::string_view shortName) const;
+
+protected:
+    void addValue_(UInt64 value, std::string_view shortName, std::string_view prettyName);
+};
+
+// Derived template class providing a non-type-erased API.
+//
+// For example, this allows iteration over all enum values stored as their
+// original types instead of casted as a 64bit integer.
+//
+template<typename TEnum, VGC_REQUIRES(std::is_enum_v<TEnum>)>
+class EnumTypeInfo : public EnumTypeInfo_ {
+public:
+    Array<TEnum> values;
+
+    EnumTypeInfo(TypeId id)
+        : EnumTypeInfo_(id) {
+    }
+
+    void addValue(TEnum value, std::string_view shortName, std::string_view prettyName) {
+        addValue_(static_cast<UInt64>(value), shortName, prettyName);
+        values.append(value);
+    }
+
+    std::optional<Int> getIndex(TEnum value) const {
+        return getIndex(static_cast<UInt64>(value));
+    }
+};
 
 } // namespace detail
 
 /// Type trait for `isRegisteredEnum`.
 ///
-template<typename EnumType, typename SFINAE = void>
+template<typename TEnum, typename SFINAE = void>
 struct IsRegisteredEnum : std::false_type {};
 
-template<typename EnumType>
-struct IsRegisteredEnum<EnumType, RequiresValid<decltype(enumData_(EnumType()))>>
+template<typename TEnum>
+struct IsRegisteredEnum<
+    TEnum,
+    RequiresValid<decltype(initEnumTypeInfo_((detail::EnumTypeInfo<TEnum>*)(0)))>>
     : std::true_type {};
 
-/// Checks whether `EnumType` is an enumeration type that has been registered
+/// Checks whether `TEnum` is an enumeration type that has been registered
 /// via `VGC_DECLARE_ENUM` and `VGC_DEFINE_ENUM`.
 ///
-template<typename EnumType>
-inline constexpr bool isRegisteredEnum = IsRegisteredEnum<EnumType>::value;
+template<typename TEnum>
+inline constexpr bool isRegisteredEnum = IsRegisteredEnum<TEnum>::value;
 
-class Enum;
+namespace detail {
+
+using EnumTypeInfoFactory = std::function<const EnumTypeInfo_*()>;
+
+// Creates and returns an `EnumTypeInfo_` with the given `factory`, unless an
+// `EnumTypeInfo_` with the given `typeId` has already been created, in which
+// case the pre-existing `EnumTypeInfo_` is returned instead. This ensures
+// uniqueness of the `EnumTypeInfo_*` even across shared library boundary.
+//
+VGC_CORE_API const EnumTypeInfo_*
+getOrCreateEnumTypeInfo(TypeId typeId, EnumTypeInfoFactory factory);
+
+template<typename TEnum>
+const EnumTypeInfo<TEnum>* getOrCreateEnumTypeInfo() {
+    TypeId typeId = core::typeId<TEnum>();
+    const EnumTypeInfo_* info_ = getOrCreateEnumTypeInfo(typeId, [typeId]() {
+        auto info = new EnumTypeInfo<TEnum>(typeId); // leaks intentionally
+        if constexpr (isRegisteredEnum<TEnum>) {
+            info->isRegistered = true;
+            initEnumTypeInfo_(info); // found via ADL
+        }
+        return info;
+    });
+    return static_cast<const EnumTypeInfo<TEnum>*>(info_);
+}
+
+} // namespace detail
+
+/// \class vgc::core::EnumType
+/// \brief Represents the type of an enum value.
+///
+/// ```cpp
+/// EnumType type = enumType<vgc::ui::Key>();
+/// ```
+///
+class VGC_CORE_API EnumType {
+public:
+    template<typename T>
+    using ArrayView = const Array<T>&;
+
+    /// Returns the unqualified type name of this `EnumType`.
+    ///
+    /// ```cpp
+    /// enumType<vgc::ui::Key>().shortName()`; // => "Key"
+    /// ```
+    ///
+    std::string_view shortName() const {
+        return info_->typeId.name();
+    }
+
+    /// Returns the fully-qualified type name of this `EnumType`.
+    ///
+    /// ```cpp
+    /// enumType<vgc::ui::Key>().shortName()`; // => "vgc::ui::Key"
+    /// ```
+    ///
+    std::string_view fullName() const {
+        return info_->typeId.fullName();
+    }
+
+    /// Iterates over all the registered `EnumValue` of this `EnumType`,
+    /// in the same order as defined by `VGC_DEFINE_ENUM`.
+    ///
+    /// Returns an empty sequence if this is not a registered enum.
+    ///
+    /// \sa `values<EnumType>()`.
+    ///
+    ArrayView<EnumValue> values() const {
+        return info_->enumValues;
+    }
+
+    /// Converts the given enumerator's `shortName` (e.g., "Digit0")
+    /// to its corresponding value, if any.
+    ///
+    /// Return `std::nullopt` if there is no registered value with the given
+    /// `shortName` for this `EnumType`.
+    ///
+    std::optional<EnumValue> fromShortName(std::string_view shortName) const;
+
+    /// Returns whether this `EnumType` is equal to `other`.
+    ///
+    bool operator==(const EnumType& other) const {
+        return info_ == other.info_;
+    }
+
+    /// Returns whether this `EnumType` is different from `other`.
+    ///
+    bool operator!=(const EnumType& other) const {
+        return info_ != other.info_;
+    }
+
+    /// Returns whether this `EnumType` is less than `other`.
+    ///
+    bool operator<(const EnumType& other) const {
+        return info_ < other.info_;
+    }
+
+private:
+    const detail::EnumTypeInfo_* info_;
+
+    template<typename T>
+    friend EnumType enumType();
+
+    friend struct std::hash<EnumType>;
+
+    friend detail::EnumTypeInfo_;
+    friend EnumValue;
+
+    EnumType(const detail::EnumTypeInfo_* info)
+        : info_(info) {
+    }
+};
+
+/// Returns the `EnumType` of the given enum type.
+///
+/// ```
+/// enum class Animal { Cat, Dog };
+/// EnumType type = enumType<Animal>();
+/// ```
+///
+template<typename TEnum>
+EnumType enumType() {
+    static const detail::EnumTypeInfo_* info = detail::getOrCreateEnumTypeInfo<TEnum>();
+    return EnumType(info);
+}
+
+} // namespace vgc::core
+
+namespace std {
+
+template<>
+struct hash<vgc::core::EnumType> {
+    std::size_t operator()(const vgc::core::EnumType& t) const {
+        return std::hash<const vgc::core::detail::EnumTypeInfo_*>()(t.info_);
+    }
+};
+
+} // namespace std
+
+template<>
+struct fmt::formatter<vgc::core::EnumType> : fmt::formatter<std::string_view> {
+    template<typename FormatContext>
+    auto format(vgc::core::EnumType t, FormatContext& ctx) {
+        return fmt::formatter<std::string_view>::format(t.fullName(), ctx);
+    }
+};
+
+namespace vgc::core {
 
 /// \class vgc::core::EnumValue
 /// \brief Stores any Enum value in a type-safe way.
 ///
-class EnumValue {
+class VGC_CORE_API EnumValue {
 public:
+    /*
     /// Creates an empty `EnumValue`.
     ///
     EnumValue()
         : typeId_(core::typeId<void>()) {
     }
+    */
 
-    /// Creates an `EnumValue` from the given enumerator value.
-    ///
-    // Note: This constructor intentionally allows implicit conversions.
-    //
-    template<typename EnumType, VGC_REQUIRES(std::is_enum_v<EnumType>)>
-    EnumValue(EnumType value)
-        : typeId_(core::typeId<EnumType>())
-        , value_(static_cast<UInt64>(value)) {
-
-        if constexpr (isRegisteredEnum<EnumType>) {
-
-            // Ensures that the global EnumData<EnumType> is initialized by
-            // making a call to `enumData_()` now. This is important since the
-            // data is lazy-initialized, and this constructor might be our only
-            // opportunity to call `enumData_()` before other methods such as
-            // `EnumValue::shortName()` are called, which require the data to
-            // have already been initialized (we cannot initialize it there
-            // because we do not have access to `EnumType` anymore).
-            //
-            const auto& init = enumData_(value);
-            VGC_UNUSED(init);
-        }
-
-        // Note: alternatively, we could call getEnumValueData() here and only
-        // store the returned pointer as data member. This would make
-        // `EnumValue` 64bit instead of 128bit, but would only work for
-        // registered enums, and would not support enum values outside of the
-        // registered values (so wouldn't work for flags). Therefore, for more
-        // genericity, we have chosen the current approach.
-    }
-
-    /// Returns whether the `EnumValue` is empty.
-    ///
-    bool isEmpty() const {
-        return typeId_ == core::typeId<void>();
-    }
-
-    /// Returns the `TypeId` of the type of the stored enumerator value.
-    ///
-    /// Returns `typeId<void>()` if `isEmpty()` is true.
-    ///
-    TypeId typeId() const {
-        return typeId_;
-    }
-
-    /// Returns whether the `EnumValue` stores an enumerator value
-    /// of the given `EnumType`.
-    ///
-    template<typename EnumType>
-    bool has() const {
-        return typeId_ == core::typeId<EnumType>();
-    }
-
-    /// Returns the stored value as an `EnumType`.
-    ///
-    /// Throws an exception if the `EnumType` is empty or if the stored
-    /// enumerator value is not of type `EnumType`.
-    ///
-    template<typename EnumType>
-    EnumType get() {
-        if (isEmpty()) {
-            throw core::LogicError(
-                "Attempting to get the stored value of an empty EnumValue.");
-        }
-        TypeId requestedType = core::typeId<EnumType>();
-        if (typeId_ != requestedType) {
-            throw core::LogicError(core::format(
-                "Mismatch between stored EnumValue type ({}) and requested type ({}).",
-                typeId_.name(),
-                requestedType.name()));
-        }
-        return static_cast<EnumType>(value_);
-    }
-
-    /// Returns the stored value as an `EnumType`.
-    ///
-    /// The behavior is undefined if the `EnumType` is empty or if the stored
-    /// enumerator value is not of type `EnumType`.
-    ///
-    template<typename EnumType>
-    EnumType getUnchecked() {
-        return static_cast<EnumType>(value_);
-    }
-
-    /// Returns the unqualified name (e.g., "Digit0") of the stored enumerator
-    /// value, if any.
-    ///
-    /// Otherwise, returns "NoValue".
-    ///
-    std::string_view shortName() const {
-        if (auto data = getEnumValueData_()) {
-            return data->shortName;
-        }
-        else {
-            return "NoValue";
-        }
-    }
-
-    /// Returns the fully-qualified name (e.g., "vgc::ui::Key::Digit0") of the
-    /// stored enumerator value, if any.
-    ///
-    /// Otherwise, returns "NoType::NoValue".
-    ///
-    std::string_view fullName() const {
-        if (auto data = getEnumValueData_()) {
-            return data->fullName;
-        }
-        else {
-            return "NoType::NoValue";
-        }
-    }
-
-    /// Returns the pretty name (e.g., "0") of the stored enumerator value, if
-    /// any.
-    ///
-    /// Otherwise, returns "No Value".
-    ///
-    std::string_view prettyName() const {
-        if (auto data = getEnumValueData_()) {
-            return data->prettyName;
-        }
-        else {
-            return "No Value";
-        }
-    }
-
-    /// Returns whether the two `EnumValue` are equal, that is, if
-    /// they have both same type and value.
-    ///
-    bool operator==(const EnumValue& other) const {
-        return typeId_ == other.typeId_ && value_ == other.value_;
-    }
-
-    /// Returns whether the two `EnumValue` are different.
-    ///
-    bool operator!=(const EnumValue& other) const {
-        return !(*this == other);
-    }
-
-    /// Compares the two `EnumValue`.
-    ///
-    bool operator<(const EnumValue& other) const {
-        if (typeId_ == other.typeId_) {
-            return value_ < other.value_;
-        }
-        else {
-            return typeId_ < other.typeId_;
-        }
-    }
-
-private:
-    TypeId typeId_;
-    UInt64 value_ = 0;
-
-    friend std::hash<EnumValue>;
-    friend fmt::formatter<EnumValue>;
-
-    const detail::EnumValueData* getEnumValueData_() const {
-        return detail::getEnumValueData(typeId_, value_);
-    }
-
-    // For access to the EnumValue(TypeId, UInt64) constructor.
-    // Will not be needed anymore if/when we publicize it (see comment below)
-    friend Enum;
-    friend detail::EnumDataBase;
-
-    // Creates an `EnumValue` given the `typeId` of the enum type and the
-    // `underlyingValue` of the enumerator as an `UInt64`.
+    // Creates an `EnumValue` given its `type` and underlying `value` as an
+    // `UInt64`.
     //
     // This constructor is only meant for advanced use cases and should rarely
     // be needed: whenever possible, prefer using the constructor from an
@@ -273,7 +329,7 @@ private:
     // };
     //
     // // Using this constructor
-    // EnumValue v1 = EnumValue(typeId<MyEnum>(), 0);
+    // EnumValue v1 = EnumValue(enumType<MyEnum>(), 0);
     //
     // // Using the type-safe constructor
     // EnumValue v2 = EnumValue(MyEnum::Foo);
@@ -281,37 +337,149 @@ private:
     // assert(v1 == v2);
     // ```
     //
-    // Also, note that when using this constructor, then the `shortName()`,
-    // `fullName()`, and `prettyName()` may not return correct values as they
-    // may not be properly initialized yet, especially at program startup.
-    // Using the type-safe constructor instead ensures proper initialization.
+    EnumValue(EnumType type, UInt64 value)
+        : type_(type)
+        , value_(value) {
+    }
+
+    /// Creates an `EnumValue` from the given enumerator value.
+    ///
+    // Note: This constructor intentionally allows implicit conversions.
     //
-    // XXX Publicize, or is it too dangerous?
-    //
-    // XXX Is it possible/desirable to modify the EnumData implementation to
-    // enforce at-least-partial initialization from this constructor? Indeed,
-    // while it is impossible to initialize `EnumData<EnumType>::values` here,
-    // it might be possible to at least initialize the `EnumDataBase` instance
-    // (including shortName, etc.), for example by actually storing it in the
-    // global registry separately from the EnumData<EnumType> instance.
-    // Instead, we currently have EnumData<EnumType> inherit EnumDataBase, and
-    // instanciated as a function static variable discovered via ADL (reason
-    // why we need the actual type to be able to call this function), the
-    // registry only pointing to this instance. But maybe even partial
-    // initialization is impossible, e.g.: how can we find the init function to
-    // call without being able to rely on ADL, while keeping the
-    // VGC_DECLARE/DEFINE_ENUM macros in the same namespace as the enum type?
-    // Should we instead use an actual global variable rather than a function
-    // static variable, which would enforce initialization when the dynamic
-    // library is loaded rather than at first use? Possibly using a Schwarz
-    // counter for more initialization order safety?
-    //
-    // => The points above might be solvable with a new EnumTypeId class (or
-    //    just `EnumType`), see comment [1] in Enum class.
-    //
-    EnumValue(core::TypeId typeId, UInt64 underlyingValue)
-        : typeId_(typeId)
-        , value_(underlyingValue) {
+    template<typename TEnum, VGC_REQUIRES(std::is_enum_v<TEnum>)>
+    EnumValue(TEnum value)
+        : type_(enumType<TEnum>())
+        , value_(static_cast<UInt64>(value)) {
+    }
+
+    /// Returns the `EnumType` of this `EnumValue`.
+    ///
+    EnumType type() const {
+        return type_;
+    }
+
+    /// Returns whether the `EnumValue` stores an enumerator value
+    /// of the given `TEnum` type.
+    ///
+    template<typename TEnum>
+    bool has() const {
+        return type_ == enumType<TEnum>();
+    }
+
+    /// Returns the stored value as a `TEnum`.
+    ///
+    /// Throws an exception if the `EnumValue` is empty or if the stored
+    /// enumerator value is not of type `TEnum`.
+    ///
+    template<typename TEnum>
+    TEnum get() const {
+        // if (isEmpty()) {
+        //     throw core::LogicError(
+        //         "Attempting to get the stored value of an empty EnumValue.");
+        // }
+        EnumType requestedType = enumType<TEnum>();
+        if (type_ != requestedType) {
+            throw core::LogicError(core::format(
+                "Mismatch between stored EnumValue type ({}) and requested type ({}).",
+                type_.fullName(),
+                requestedType.fullName()));
+        }
+        return static_cast<TEnum>(value_);
+    }
+
+    /// Returns the stored value as a `TEnum`.
+    ///
+    /// The behavior is undefined if the `EnumValue` is empty or if the stored
+    /// enumerator value is not of type `TEnum`.
+    ///
+    template<typename TEnum>
+    TEnum getUnchecked() const {
+        return static_cast<TEnum>(value_);
+    }
+
+    /// Returns the unqualified name (e.g., "Digit0") of the stored enumerator
+    /// value, if any.
+    ///
+    /// Otherwise, returns "NoValue".
+    ///
+    std::string_view shortName() const {
+        if (auto info = getEnumValueInfo_()) {
+            return info->shortName;
+        }
+        else {
+            return "NoValue";
+        }
+    }
+
+    /// Returns the fully-qualified name (e.g., "vgc::ui::Key::Digit0") of the
+    /// stored enumerator value, if any.
+    ///
+    /// Otherwise, returns "NoType::NoValue".
+    ///
+    std::string_view fullName() const {
+        if (auto info = getEnumValueInfo_()) {
+            return info->fullName;
+        }
+        else {
+            return "NoType::NoValue";
+        }
+    }
+
+    /// Returns the pretty name (e.g., "0") of the stored enumerator value, if
+    /// any.
+    ///
+    /// Otherwise, returns "No Value".
+    ///
+    std::string_view prettyName() const {
+        if (auto info = getEnumValueInfo_()) {
+            return info->prettyName;
+        }
+        else {
+            return "No Value";
+        }
+    }
+
+    /// Returns whether the two `EnumValue` are equal, that is, if
+    /// they have both same type and value.
+    ///
+    bool operator==(const EnumValue& other) const {
+        return type_ == other.type_ && value_ == other.value_;
+    }
+
+    /// Returns whether the two `EnumValue` are different.
+    ///
+    bool operator!=(const EnumValue& other) const {
+        return !(*this == other);
+    }
+
+    /// Compares the two `EnumValue`.
+    ///
+    bool operator<(const EnumValue& other) const {
+        if (type_ == other.type_) {
+            return value_ < other.value_;
+        }
+        else {
+            return type_ < other.type_;
+        }
+    }
+
+private:
+    EnumType type_;
+    UInt64 value_ = 0;
+
+    // Note: alternatively, we could just store an EnumValueInfo*. This
+    // would make `EnumValue` 64bit instead of 128bit, but would only work for
+    // registered enums, and would not support enum values outside of the
+    // registered values (so wouldn't work for flags). Therefore, for more
+    // genericity, we have chosen the current approach.
+
+    friend std::hash<EnumValue>;
+
+    const detail::EnumValueInfo* getEnumValueInfo_() const {
+        if (auto index = type_.info_->getIndex(value_)) {
+            return type_.info_->valueInfo[*index].get();
+        }
+        return nullptr;
     }
 };
 
@@ -323,7 +491,7 @@ template<>
 struct hash<vgc::core::EnumValue> {
     std::size_t operator()(const vgc::core::EnumValue& v) const {
         size_t res = 123456;
-        vgc::core::hashCombine(res, v.typeId_, v.value_);
+        vgc::core::hashCombine(res, v.type_, v.value_);
         return res;
     }
 };
@@ -334,105 +502,27 @@ template<>
 struct fmt::formatter<vgc::core::EnumValue> : fmt::formatter<std::string_view> {
     template<typename FormatContext>
     auto format(const vgc::core::EnumValue& v, FormatContext& ctx) {
-
         return fmt::formatter<std::string_view>::format(v.fullName(), ctx);
+    }
+};
+
+template<typename TEnum>
+struct fmt::formatter< //
+    TEnum,
+    char,
+    vgc::core::Requires<vgc::core::isRegisteredEnum<TEnum>>>
+
+    : fmt::formatter<vgc::core::EnumValue> {
+
+    template<typename FormatContext>
+    auto format(TEnum value, FormatContext& ctx) {
+        return fmt::formatter<vgc::core::EnumValue>::format(value, ctx);
     }
 };
 
 namespace vgc::core {
 
-namespace detail {
-
-// We use this base class for everything that does not need to be templated and
-// can therefore be moved to the .cpp file.
-//
-struct VGC_CORE_API EnumDataBase {
-
-    // EnumDataBase is non-copyable (because it stores unique_ptrs).
-    // We need to explicitly mark it non-copyable otherwise it doesn't compile on MSVC.
-    EnumDataBase(const EnumDataBase&) = delete;
-    EnumDataBase& operator=(const EnumDataBase&) = delete;
-
-    TypeId typeId;
-
-    std::string fullTypeName;  // "vgc::ui::Key"
-    std::string shortTypeName; // "Key"
-
-    std::string unknownItemFullName;   // "vgc::ui::Key::Unknown_Key"
-    std::string unknownItemShortName;  // "Unknown_Key"
-    std::string unknownItemPrettyName; // "Unknown Key"
-
-    // This is where the actual per-enumerator data is stored. We use pointers
-    // to ensure that any string_view to the stored strings stay valid when
-    // valueData grows, or when this EnumDataBase is moved.
-    //
-    Array<std::unique_ptr<EnumValueData>> valueData;
-
-    // These maps make it possible to quickly find the appropriate
-    // EnumValueData from the enum value or the enum short name.
-    //
-    std::unordered_map<UInt64, Int> valueToIndex;
-    std::unordered_map<std::string_view, Int> shortNameToIndex;
-
-    // These are convenient arrays (redundant with valueData) facilitating
-    // iteration without the need for proxy iterators. This approach increases
-    // debuggability and works better with parallelization libs (sometimes not
-    // supporting proxy iterators).
-    //
-    Array<EnumValue> enumValues;
-    Array<std::string_view> fullNames;
-    Array<std::string_view> shortNames;
-    Array<std::string_view> prettyNames;
-
-    EnumDataBase(TypeId id, std::string_view prettyFunction);
-    virtual ~EnumDataBase() = 0;
-
-    void
-    addItemBase(UInt64 value, std::string_view shortName, std::string_view prettyName);
-
-    std::optional<Int> getIndexBase(UInt64 value) const {
-        auto search = valueToIndex.find(value);
-        if (search != valueToIndex.end()) {
-            return search->second;
-        }
-        else {
-            return std::nullopt;
-        }
-    }
-
-    std::optional<Int> getIndexFromShortName(std::string_view shortName) const {
-        auto search = shortNameToIndex.find(shortName);
-        if (search != shortNameToIndex.end()) {
-            return search->second;
-        }
-        else {
-            return std::nullopt;
-        }
-    }
-};
-
-template<typename EnumType>
-struct EnumData : EnumDataBase {
-
-    Array<EnumType> values;
-
-    EnumData(TypeId id, std::string_view prettyFunction)
-        : EnumDataBase(id, prettyFunction) {
-    }
-
-    void
-    addItem(EnumType value, std::string_view shortName, std::string_view prettyName) {
-        addItemBase(static_cast<UInt64>(value), shortName, prettyName);
-        values.append(value);
-    }
-
-    std::optional<Int> getIndex(EnumType value) const {
-        return getIndexBase(static_cast<UInt64>(value));
-    }
-};
-
-} // namespace detail
-
+/*
 /// \class vgc::core::Enum
 /// \brief Provides runtime introspection for registered enum types
 ///
@@ -763,7 +853,7 @@ public:
                 // Note: Using the generally unsafe EnumValue(TypeId, UInt64)
                 // constructor is safe in this case, because we know that the
                 // enumerator data is already initialized, since we found it.
-                return EnumValue(enumTypeId, data->valueData[*index]->value);
+                return EnumValue(enumTypeId, data->valueInfo[*index]->value);
             }
             else {
                 return std::nullopt;
@@ -774,58 +864,31 @@ public:
         }
     }
 };
+*/
 
 } // namespace vgc::core
 
 // clang-format off
 
-// Partial specialization of fmt::formatter for registered enum types. This
-// relies on SFINAE and ADL: we SFINAE-test whether enumData_(item) is valid
-// code, which is true for registered enum types since the function enumData_()
-// is found via Argument-Dependent Lookup. Note that for this reason, we cannot
-// move the function enumData_() to a separate namespace, e.g., `detail`.
-//
-template<typename EnumType>
-struct fmt::formatter<
-        EnumType, char,
-        vgc::core::RequiresValid<decltype(enumData_(EnumType()))>>
-    : fmt::formatter<std::string_view> {
-
-    template<typename FormatContext>
-    auto format(EnumType item, FormatContext& ctx) {
-        return fmt::formatter<std::string_view>::format(
-            vgc::core::Enum::fullName(item), ctx);
-    }
-};
-
 /// Declares a scoped enum. See `Enum` for more details.
 ///
-#define VGC_DECLARE_ENUM(Enum)                                                           \
-    const ::vgc::core::detail::EnumData<Enum>& enumData_(Enum value);
+#define VGC_DECLARE_ENUM(TEnum)                                                          \
+    void initEnumTypeInfo_(::vgc::core::detail::EnumTypeInfo<TEnum>* info);
 
 /// Starts the definition of a scoped enum. See `Enum` for more details.
 ///
-#define VGC_DEFINE_ENUM_BEGIN(Enum)                                                      \
-    const ::vgc::core::detail::EnumData<Enum>& enumData_(Enum) {                         \
-        using EnumType = Enum;                                                           \
-        static ::std::string pf = VGC_PRETTY_FUNCTION;                                   \
-        static auto createData = []() {                                                  \
-            auto data = new ::vgc::core::detail::EnumData<Enum>(                         \
-                ::vgc::core::typeId<EnumType>(), pf);                                    \
-            registerEnumDataBase(*data);
+#define VGC_DEFINE_ENUM_BEGIN(TEnum)                                                     \
+    void initEnumTypeInfo_(::vgc::core::detail::EnumTypeInfo<TEnum>* info) {             \
+        using TEnum_ = TEnum;
 
 /// Defines an enumerator of a scoped enum. See `Enum` for more details.
 ///
 #define VGC_ENUM_ITEM(name, prettyName)                                                  \
-            data->addItem(EnumType::name, VGC_PP_STR(name), prettyName);
+        info->addValue(TEnum_::name, VGC_PP_STR(name), prettyName);
 
 /// Ends the definition of a scoped enum. See `Enum` for more details.
 ///
 #define VGC_DEFINE_ENUM_END()                                                            \
-            return data;                                                                 \
-        };                                                                               \
-        static auto data = createData();                                                 \
-        return *data;                                                                    \
     }
 
 #define VGC_ENUM_ITEM_(x, t)                                                             \

--- a/libs/vgc/core/enum.h
+++ b/libs/vgc/core/enum.h
@@ -27,6 +27,7 @@
 #include <vgc/core/api.h>
 #include <vgc/core/arithmetic.h>
 #include <vgc/core/array.h>
+#include <vgc/core/exceptions.h>
 #include <vgc/core/format.h>
 #include <vgc/core/preprocessor.h>
 #include <vgc/core/templateutil.h>
@@ -338,14 +339,6 @@ namespace vgc::core {
 ///
 class VGC_CORE_API EnumValue {
 public:
-    /*
-    /// Creates an empty `EnumValue`.
-    ///
-    EnumValue()
-        : typeId_(core::typeId<void>()) {
-    }
-    */
-
     // Creates an `EnumValue` given its `type` and underlying `value` as an
     // `UInt64`.
     //
@@ -405,10 +398,6 @@ public:
     ///
     template<typename TEnum>
     TEnum get() const {
-        // if (isEmpty()) {
-        //     throw core::LogicError(
-        //         "Attempting to get the stored value of an empty EnumValue.");
-        // }
         EnumType requestedType = enumType<TEnum>();
         if (type_ != requestedType) {
             throw core::LogicError(core::format(

--- a/libs/vgc/core/tests/test_enum.cpp
+++ b/libs/vgc/core/tests/test_enum.cpp
@@ -75,13 +75,6 @@ VGC_DEFINE_ENUM(
 
 } // namespace foo
 
-/*
-TEST(TestEnumValue, Empty) {
-    vgc::core::EnumValue v;
-    EXPECT_TRUE(v.isEmpty());
-}
-*/
-
 TEST(TestEnumType, Name) {
     EXPECT_EQ(vgc::core::enumType<UnscopedFoo>().shortName(), "UnscopedFoo");
     //EXPECT_EQ(vgc::core::enumType<UnscopedFoo>().fullName(), "(anonymous namespace)::UnscopedFoo");
@@ -92,8 +85,8 @@ TEST(TestEnumType, Name) {
     EXPECT_EQ(vgc::core::enumType<GlobalUnscopedFoo>().shortName(), "GlobalUnscopedFoo");
     EXPECT_EQ(vgc::core::enumType<GlobalUnscopedFoo>().fullName(), "GlobalUnscopedFoo");
 
-    EXPECT_EQ(vgc::core::enumType<ScopedFoo>().shortName(), "ScopedFoo");
-    //EXPECT_EQ(vgc::core::enumType<ScopedFoo>().fullName(), "(anonymous namespace)::ScopedFoo");
+    EXPECT_EQ(vgc::core::enumType<GlobalScopedFoo>().shortName(), "GlobalScopedFoo");
+    EXPECT_EQ(vgc::core::enumType<GlobalScopedFoo>().fullName(), "GlobalScopedFoo");
 
     EXPECT_EQ(vgc::core::enumType<foo::UnscopedFoo>().shortName(), "UnscopedFoo");
     EXPECT_EQ(vgc::core::enumType<foo::UnscopedFoo>().fullName(), "foo::UnscopedFoo");
@@ -109,7 +102,6 @@ TEST(TestEnumValue, UnscopedEnum) {
 
     {
         vgc::core::EnumValue v(A);
-        //EXPECT_FALSE(v.isEmpty());
         EXPECT_TRUE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_FALSE(v.has<ScopedFoo>());
@@ -120,7 +112,6 @@ TEST(TestEnumValue, UnscopedEnum) {
 
     {
         vgc::core::EnumValue v(A);
-        //EXPECT_FALSE(v.isEmpty());
         EXPECT_TRUE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_FALSE(v.has<ScopedFoo>());
@@ -131,7 +122,6 @@ TEST(TestEnumValue, UnscopedEnum) {
 
     {
         vgc::core::EnumValue v{A};
-        //EXPECT_FALSE(v.isEmpty());
         EXPECT_TRUE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_FALSE(v.has<ScopedFoo>());
@@ -145,7 +135,6 @@ TEST(TestEnumValue, ScopedEnum) {
 
     {
         vgc::core::EnumValue v(ScopedFoo::E);
-        //EXPECT_FALSE(v.isEmpty());
         EXPECT_FALSE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_TRUE(v.has<ScopedFoo>());
@@ -156,7 +145,6 @@ TEST(TestEnumValue, ScopedEnum) {
 
     {
         vgc::core::EnumValue v(ScopedFoo::E);
-        //EXPECT_FALSE(v.isEmpty());
         EXPECT_FALSE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_TRUE(v.has<ScopedFoo>());
@@ -167,7 +155,6 @@ TEST(TestEnumValue, ScopedEnum) {
 
     {
         vgc::core::EnumValue v{ScopedFoo::E};
-        //EXPECT_FALSE(v.isEmpty());
         EXPECT_FALSE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_TRUE(v.has<ScopedFoo>());

--- a/libs/vgc/core/tests/test_enum.cpp
+++ b/libs/vgc/core/tests/test_enum.cpp
@@ -41,9 +41,29 @@ enum class ScopedBar {
 
 } // namespace
 
+// Note: for testing purposes, we intentionally do not place the classes below in an unnamed namespace.
+
+enum GlobalUnscopedFoo {
+    GA,
+    GB
+};
+
+enum class GlobalScopedFoo {
+    E,
+    F
+};
+
 namespace foo {
 
-// Note: for testing purposes, we intentionally do not place this in an unnamed namespace.
+enum UnscopedFoo {
+    A,
+    B
+};
+
+enum class ScopedFoo {
+    E,
+    F
+};
 
 enum class RegisteredFoo {
     HelloWorld
@@ -55,16 +75,41 @@ VGC_DEFINE_ENUM(
 
 } // namespace foo
 
+/*
 TEST(TestEnumValue, Empty) {
     vgc::core::EnumValue v;
     EXPECT_TRUE(v.isEmpty());
+}
+*/
+
+TEST(TestEnumType, Name) {
+    EXPECT_EQ(vgc::core::enumType<UnscopedFoo>().shortName(), "UnscopedFoo");
+    //EXPECT_EQ(vgc::core::enumType<UnscopedFoo>().fullName(), "(anonymous namespace)::UnscopedFoo");
+
+    EXPECT_EQ(vgc::core::enumType<ScopedFoo>().shortName(), "ScopedFoo");
+    //EXPECT_EQ(vgc::core::enumType<ScopedFoo>().fullName(), "(anonymous namespace)::ScopedFoo");
+
+    EXPECT_EQ(vgc::core::enumType<GlobalUnscopedFoo>().shortName(), "GlobalUnscopedFoo");
+    EXPECT_EQ(vgc::core::enumType<GlobalUnscopedFoo>().fullName(), "GlobalUnscopedFoo");
+
+    EXPECT_EQ(vgc::core::enumType<ScopedFoo>().shortName(), "ScopedFoo");
+    //EXPECT_EQ(vgc::core::enumType<ScopedFoo>().fullName(), "(anonymous namespace)::ScopedFoo");
+
+    EXPECT_EQ(vgc::core::enumType<foo::UnscopedFoo>().shortName(), "UnscopedFoo");
+    EXPECT_EQ(vgc::core::enumType<foo::UnscopedFoo>().fullName(), "foo::UnscopedFoo");
+
+    EXPECT_EQ(vgc::core::enumType<foo::ScopedFoo>().shortName(), "ScopedFoo");
+    EXPECT_EQ(vgc::core::enumType<foo::ScopedFoo>().fullName(), "foo::ScopedFoo");
+
+    EXPECT_EQ(vgc::core::enumType<foo::RegisteredFoo>().shortName(), "RegisteredFoo");
+    EXPECT_EQ(vgc::core::enumType<foo::RegisteredFoo>().fullName(), "foo::RegisteredFoo");
 }
 
 TEST(TestEnumValue, UnscopedEnum) {
 
     {
         vgc::core::EnumValue v(A);
-        EXPECT_FALSE(v.isEmpty());
+        //EXPECT_FALSE(v.isEmpty());
         EXPECT_TRUE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_FALSE(v.has<ScopedFoo>());
@@ -75,7 +120,7 @@ TEST(TestEnumValue, UnscopedEnum) {
 
     {
         vgc::core::EnumValue v(A);
-        EXPECT_FALSE(v.isEmpty());
+        //EXPECT_FALSE(v.isEmpty());
         EXPECT_TRUE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_FALSE(v.has<ScopedFoo>());
@@ -86,7 +131,7 @@ TEST(TestEnumValue, UnscopedEnum) {
 
     {
         vgc::core::EnumValue v{A};
-        EXPECT_FALSE(v.isEmpty());
+        //EXPECT_FALSE(v.isEmpty());
         EXPECT_TRUE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_FALSE(v.has<ScopedFoo>());
@@ -100,7 +145,7 @@ TEST(TestEnumValue, ScopedEnum) {
 
     {
         vgc::core::EnumValue v(ScopedFoo::E);
-        EXPECT_FALSE(v.isEmpty());
+        //EXPECT_FALSE(v.isEmpty());
         EXPECT_FALSE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_TRUE(v.has<ScopedFoo>());
@@ -111,7 +156,7 @@ TEST(TestEnumValue, ScopedEnum) {
 
     {
         vgc::core::EnumValue v(ScopedFoo::E);
-        EXPECT_FALSE(v.isEmpty());
+        //EXPECT_FALSE(v.isEmpty());
         EXPECT_FALSE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_TRUE(v.has<ScopedFoo>());
@@ -122,7 +167,7 @@ TEST(TestEnumValue, ScopedEnum) {
 
     {
         vgc::core::EnumValue v{ScopedFoo::E};
-        EXPECT_FALSE(v.isEmpty());
+        //EXPECT_FALSE(v.isEmpty());
         EXPECT_FALSE(v.has<UnscopedFoo>());
         EXPECT_FALSE(v.has<UnscopedBar>());
         EXPECT_TRUE(v.has<ScopedFoo>());

--- a/libs/vgc/core/tests/test_format.cpp
+++ b/libs/vgc/core/tests/test_format.cpp
@@ -652,39 +652,41 @@ VGC_DEFINE_ENUM_END()
 } // namespace vgc::foo
 
 TEST(TestFormat, Enum) {
-    using vgc::core::Enum;
+    using vgc::core::enumType;
+    using vgc::core::EnumValue;
     using vgc::core::format;
     using vgc::foo::LongEnum;
     using vgc::foo::MyEnum;
     using vgc::foo::VeryLongEnum;
 
-    EXPECT_EQ(Enum::fullTypeName<MyEnum>(), "vgc::foo::MyEnum");
-    EXPECT_EQ(Enum::shortTypeName<MyEnum>(), "MyEnum");
+    EXPECT_EQ(enumType<MyEnum>().fullName(), "vgc::foo::MyEnum");
+    EXPECT_EQ(enumType<MyEnum>().shortName(), "MyEnum");
 
-    EXPECT_EQ(Enum::shortName(MyEnum::MyValue), "MyValue");
-    EXPECT_EQ(Enum::fullName(MyEnum::MyValue), "vgc::foo::MyEnum::MyValue");
-    EXPECT_EQ(Enum::prettyName(MyEnum::MyValue), "My Value");
+    EXPECT_EQ(EnumValue(MyEnum::MyValue).shortName(), "MyValue");
+    EXPECT_EQ(EnumValue(MyEnum::MyValue).fullName(), "vgc::foo::MyEnum::MyValue");
+    EXPECT_EQ(EnumValue(MyEnum::MyValue).prettyName(), "My Value");
 
     std::string s1 = format("{:-^29}", MyEnum::MyValue);
-    std::string_view s2 = Enum::prettyName(MyEnum::MyOtherValue);
-    std::string_view s3 = Enum::prettyName(LongEnum::V1);
-    std::string_view s4 = Enum::prettyName(LongEnum::V122);
-    std::string_view s5 = Enum::prettyName(VeryLongEnum::V1);
-    std::string_view s6 = Enum::prettyName(VeryLongEnum::V200);
+    std::string_view s2 = EnumValue(MyEnum::MyOtherValue).prettyName();
+    std::string_view s3 = EnumValue(LongEnum::V1).prettyName();
+    std::string_view s4 = EnumValue(LongEnum::V122).prettyName();
+    std::string_view s5 = EnumValue(VeryLongEnum::V1).prettyName();
+    std::string_view s6 = EnumValue(VeryLongEnum::V200).prettyName();
     EXPECT_EQ(s1, "--vgc::foo::MyEnum::MyValue--");
     EXPECT_EQ(s2, "My Other Value");
     EXPECT_EQ(s3, "v1");
     EXPECT_EQ(s4, "v122");
     for (int i = 1; i <= 122; ++i) {
         std::string v = "v";
-        std::string_view prettyName = Enum::prettyName(static_cast<LongEnum>(i));
+        std::string_view prettyName = EnumValue(static_cast<LongEnum>(i)).prettyName();
         EXPECT_EQ(prettyName, format("v{}", i));
     }
     EXPECT_EQ(s5, "v1");
     EXPECT_EQ(s6, "v200");
     for (int i = 1; i <= 200; ++i) {
         std::string v = "v";
-        std::string_view prettyName = Enum::prettyName(static_cast<VeryLongEnum>(i));
+        std::string_view prettyName =
+            EnumValue(static_cast<VeryLongEnum>(i)).prettyName();
         EXPECT_EQ(prettyName, format("v{}", i));
     }
 }

--- a/libs/vgc/geometry/curvecommand.h
+++ b/libs/vgc/geometry/curvecommand.h
@@ -44,7 +44,7 @@ VGC_DECLARE_ENUM(CurveCommandType)
 template<typename OStream>
 void write(OStream& out, CurveCommandType c) {
     using core::write;
-    write(out, core::Enum::shortName(c));
+    write(out, core::EnumValue(c).shortName());
 }
 
 namespace detail {

--- a/libs/vgc/geometry/curves2d.h
+++ b/libs/vgc/geometry/curves2d.h
@@ -622,12 +622,11 @@ struct fmt::formatter<vgc::geometry::Curves2dCommandRef> : fmt::formatter<double
         -> decltype(ctx.out()) {
 
         using vgc::core::copyStringTo;
-        using vgc::core::Enum;
         using vgc::geometry::CurveCommandType;
         using DoubleFormatter = fmt::formatter<double>;
 
         auto out = ctx.out();
-        out = copyStringTo(out, Enum::shortName(c.type()));
+        out = copyStringTo(out, vgc::core::EnumValue(c.type()).shortName());
         *out++ = '(';
         switch (c.type()) {
         case CurveCommandType::Close:

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -139,7 +139,7 @@ void SketchModule::onCycleSketchFitMethod_() {
     VGC_INFO(
         LogVgcToolsSketch,
         "Switched Sketch Fit Method to: {}",
-        core::Enum::prettyName(fitMethod_));
+        core::EnumValue(fitMethod_).prettyName());
 
     recomputeEdgesWithFitMethod_();
 

--- a/libs/vgc/ui/combobox.cpp
+++ b/libs/vgc/ui/combobox.cpp
@@ -103,14 +103,12 @@ ComboBoxPtr ComboBox::create(std::string_view title) {
     return core::createObject<ComboBox>(title);
 }
 
-ComboBoxPtr ComboBox::create(core::TypeId enumTypeId, std::string_view title) {
+ComboBoxPtr ComboBox::create(core::EnumType enumType, std::string_view title) {
     if (title.empty()) {
-        if (auto name = core::Enum::shortTypeName(enumTypeId)) {
-            title = *name;
-        }
+        title = enumType.shortName();
     }
     ComboBoxPtr res = core::createObject<ComboBox>(title);
-    res->setItemsFromEnum(enumTypeId);
+    res->setItemsFromEnum(enumType);
     return res;
 }
 
@@ -170,24 +168,24 @@ void ComboBox::addItem(std::string_view text) {
 }
 
 void ComboBox::clearItems() {
-    enumTypeId_ = std::nullopt;
+    enumType_ = std::nullopt;
     unset();
     if (auto menu = menu_.lock()) {
         menu->clearItems();
     }
 }
 
-void ComboBox::setItemsFromEnum(core::TypeId enumTypeId) {
+void ComboBox::setItemsFromEnum(core::EnumType enumType) {
     clearItems();
-    for (const core::EnumValue& value : core::Enum::values(enumTypeId)) {
+    for (const core::EnumValue& value : enumType.values()) {
         addItem(value.prettyName());
     }
-    enumTypeId_ = enumTypeId;
+    enumType_ = enumType;
 }
 
 std::optional<core::EnumValue> ComboBox::enumValue() const {
-    if (enumTypeId_) {
-        const auto& values = core::Enum::values(*enumTypeId_);
+    if (enumType_) {
+        const auto& values = enumType_->values();
         Int i = index();
         if (0 <= i && i < values.length()) {
             return values[i];
@@ -202,10 +200,10 @@ std::optional<core::EnumValue> ComboBox::enumValue() const {
 }
 
 void ComboBox::setEnumValue(core::EnumValue enumValue) {
-    // XXX: Use a map? Publicize core::EnumDataBase::getIndex()?
-    if (enumTypeId_) {
+    // XXX: Use a map? Publicize core::detail::EnumTypeInfo_::getIndex()?
+    if (enumType_) {
         Int index = 0;
-        for (core::EnumValue value : core::Enum::values(*enumTypeId_)) {
+        for (core::EnumValue value : enumType_->values()) {
             if (value == enumValue) {
                 setIndex(index);
                 return;

--- a/libs/vgc/ui/combobox.h
+++ b/libs/vgc/ui/combobox.h
@@ -52,7 +52,7 @@ public:
     /// If `title` is empty (the default), the title of the combo box is set as
     /// the unqualified name of the enumeration.
     ///
-    static ComboBoxPtr create(core::TypeId enumTypeId, std::string_view title = "");
+    static ComboBoxPtr create(core::EnumType enumType, std::string_view title = "");
 
     /// Creates a `ComboBox`, and populates its items from a registered
     /// enumeration.
@@ -60,9 +60,9 @@ public:
     /// If `title` is empty (the default), the title of the combo box is set as
     /// the unqualified name of the enumeration.
     ///
-    template<typename EnumType, VGC_REQUIRES(core::isRegisteredEnum<EnumType>)>
+    template<typename TEnum, VGC_REQUIRES(core::isRegisteredEnum<TEnum>)>
     static ComboBoxPtr createFromEnum(std::string_view title = "") {
-        return create(core::typeId<EnumType>(), title);
+        return create(core::enumType<TEnum>(), title);
     }
 
     /// Returns the title of this combo box. This is the text that
@@ -117,13 +117,13 @@ public:
     /// Sets the items of this combo box from a registered enumeration
     /// given by its `TypeId`.
     ///
-    void setItemsFromEnum(core::TypeId enumTypeId);
+    void setItemsFromEnum(core::EnumType enumTypeId);
 
     /// Sets the items of this combo box from a registered enumeration.
     ///
-    template<typename EnumType, VGC_REQUIRES(core::isRegisteredEnum<EnumType>)>
+    template<typename TEnum, VGC_REQUIRES(core::isRegisteredEnum<TEnum>)>
     void setItemsFromEnum() {
-        setItemsFromEnum(core::typeId<EnumType>());
+        setItemsFromEnum(core::enumType<TEnum>());
     }
 
     /// Returns the `EnumValue` that corresponds to the current `index()`, if any.
@@ -142,11 +142,11 @@ public:
     /// Returns `std::nullopt` if there is no `enumValue()` of if `enumValue()`
     /// does not hold a value of type `EnumType`.
     ///
-    template<typename EnumType, VGC_REQUIRES(core::isRegisteredEnum<EnumType>)>
-    std::optional<EnumType> enumValueAs() const {
+    template<typename TEnum, VGC_REQUIRES(core::isRegisteredEnum<TEnum>)>
+    std::optional<TEnum> enumValueAs() const {
         if (auto value = enumValue()) {
-            if (value->has<EnumType>()) {
-                return value->getUnchecked<EnumType>();
+            if (value->has<TEnum>()) {
+                return value->getUnchecked<TEnum>();
             }
         }
         return std::nullopt;
@@ -165,10 +165,10 @@ private:
     Int index_ = -1;     // index of current item
     MenuSharedPtr menu_; // drop-down menu, storing all the item data
 
-    // Remembers which Enum type this combo box was set from, if any.
-    // This enforces type safety by ensuring that `getEnumValue()` always
+    // Remembers which EnumType this combo box was set from, if any.
+    // This enforces type safety by ensuring that `enumValue()` always
     // returns a registered Enum value.
-    std::optional<core::TypeId> enumTypeId_;
+    std::optional<core::EnumType> enumType_;
 
     void setText_(std::string_view text);
 

--- a/libs/vgc/ui/enumsetting.cpp
+++ b/libs/vgc/ui/enumsetting.cpp
@@ -53,7 +53,7 @@ EnumSettingPtr EnumSetting::create(
 //
 core::EnumValue EnumSetting::value() const {
     std::string name = settings()->getOrSetStringValue(key(), defaultValueString_);
-    if (auto value = core::Enum::fromShortName(enumTypeId(), name)) {
+    if (auto value = enumType().fromShortName(name)) {
         return *value;
     }
     else {
@@ -64,7 +64,7 @@ core::EnumValue EnumSetting::value() const {
 void EnumSetting::setValue(core::EnumValue newValue) {
     core::EnumValue oldValue = value();
     if (oldValue != newValue) {
-        if (newValue.typeId() != enumTypeId()) {
+        if (newValue.type() != enumType()) {
             VGC_WARNING(
                 LogVgcUi,
                 "Cannot set value '{}' to setting '{}': the value has a "

--- a/libs/vgc/ui/enumsetting.h
+++ b/libs/vgc/ui/enumsetting.h
@@ -57,8 +57,8 @@ public:
 
     /// Returns the `TypeId` of the enum type of this `EnumSetting`.
     ///
-    core::TypeId enumTypeId() const {
-        return defaultValue_.typeId();
+    core::EnumType enumType() const {
+        return defaultValue_.type();
     }
 
     /// Returns the current value of this `EnumSetting`.

--- a/libs/vgc/ui/enumsettingedit.cpp
+++ b/libs/vgc/ui/enumsettingedit.cpp
@@ -40,7 +40,7 @@ EnumSettingEdit::EnumSettingEdit(CreateKey key, EnumSettingPtr setting)
     }
 
     comboBox->setTitle(enumSetting->label());
-    comboBox->setItemsFromEnum(enumSetting->enumTypeId());
+    comboBox->setItemsFromEnum(enumSetting->enumType());
     comboBox->setEnumValue(enumSetting->value());
     comboBox->indexChanged().connect(onComboBoxIndexChanged_Slot());
 

--- a/libs/vgc/ui/shortcut.cpp
+++ b/libs/vgc/ui/shortcut.cpp
@@ -111,11 +111,11 @@ std::string toString(const Shortcut& shortcut) {
     }
 #endif
     if (shortcut.type() == ShortcutType::Keyboard) {
-        appendString(res, separator, core::Enum::prettyName(shortcut.key()));
+        appendString(res, separator, core::EnumValue(shortcut.key()).prettyName());
     }
     else if (shortcut.type() == ShortcutType::Mouse) {
         appendString(res, separator, "Mouse ");
-        res += core::Enum::prettyName(shortcut.mouseButton());
+        res += core::EnumValue(shortcut.mouseButton()).prettyName();
     }
     return res;
 }


### PR DESCRIPTION
#1751

The main idea of this change is to implement a new class `EnumType` that should be used instead of the more generic `TypeId` whenever referring to an enum type is needed. This allows us to guarantee that registered enums are always properly initialized before use.

But with the introduction of this new class, the previous class `Enum` felt a bit redundant, so it was removed.

Also, now that `TypeId` was upgraded to provided demangled unqualified and fully-qualified names, we do not need the `VGC_PRETTY_FUNCTION` trick anymore to get the type name, so this was changed as well.
