### PR TITLE
Rename header guards that still use INTERNAL instead of DETAIL (#748)

### DIFF
--- a/libs/vgc/core/detail/containerutil.h
+++ b/libs/vgc/core/detail/containerutil.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VGC_CORE_INTERNAL_CONTAINERUTIL_H
-#define VGC_CORE_INTERNAL_CONTAINERUTIL_H
+#ifndef VGC_CORE_DETAIL_CONTAINERUTIL_H
+#define VGC_CORE_DETAIL_CONTAINERUTIL_H
 
 #include <iterator>
 #include <type_traits>
@@ -72,4 +72,4 @@ inline constexpr bool isNoInitConstructible = std::is_constructible_v<T, NoInit>
 
 } // namespace vgc::core::detail
 
-#endif // VGC_CORE_INTERNAL_CONTAINERUTIL_H
+#endif // VGC_CORE_DETAIL_CONTAINERUTIL_H

--- a/libs/vgc/core/detail/parsebits.h
+++ b/libs/vgc/core/detail/parsebits.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VGC_CORE_INTERNAL_PARSEBITS_H
-#define VGC_CORE_INTERNAL_PARSEBITS_H
+#ifndef VGC_CORE_DETAIL_PARSEBITS_H
+#define VGC_CORE_DETAIL_PARSEBITS_H
 
 // This header helps avoiding a cyclic dependency between stringid.h and parse.h
 
@@ -34,4 +34,4 @@ std::string readStringUntilEof(std::string& s, IStream& in) {
 
 } // namespace vgc::core::detail
 
-#endif // VGC_CORE_INTERNAL_PARSEBITS_H
+#endif // VGC_CORE_DETAIL_PARSEBITS_H

--- a/libs/vgc/core/detail/signal.h
+++ b/libs/vgc/core/detail/signal.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VGC_CORE_INTERNAL_SIGNAL_H
-#define VGC_CORE_INTERNAL_SIGNAL_H
+#ifndef VGC_CORE_DETAIL_SIGNAL_H
+#define VGC_CORE_DETAIL_SIGNAL_H
 
 #include <any>
 #include <array>
@@ -1261,4 +1261,4 @@ private:
     VGC_PP_EXPAND(VGC_SLOT_DISPATCH_(__VA_ARGS__, NOOVERLOAD, VGC_SLOT2_, VGC_SLOT1_)(   \
         __VA_ARGS__))
 
-#endif // VGC_CORE_INTERNAL_SIGNAL_H
+#endif // VGC_CORE_DETAIL_SIGNAL_H

--- a/libs/vgc/ui/detail/paintutil.h
+++ b/libs/vgc/ui/detail/paintutil.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VGC_UI_INTERNAL_PAINTUTIL_H
-#define VGC_UI_INTERNAL_PAINTUTIL_H
+#ifndef VGC_UI_DETAIL_PAINTUTIL_H
+#define VGC_UI_DETAIL_PAINTUTIL_H
 
 #include <string>
 
@@ -144,4 +144,4 @@ float getLengthOrPercentageInPx(
 
 } // namespace vgc::ui::detail
 
-#endif // VGC_UI_INTERNAL_PAINTUTIL_H
+#endif // VGC_UI_DETAIL_PAINTUTIL_H


### PR DESCRIPTION
#748

The namespace `detail` was previously named `internal`. Some of the header guards were not renamed accordingly.