### PR TITLE
Clear modules map in Module::onDestroyed() to break ownership cycle (#1564)

### DIFF
--- a/libs/vgc/ui/module.cpp
+++ b/libs/vgc/ui/module.cpp
@@ -32,6 +32,10 @@ ModuleManagerPtr ModuleManager::create() {
     return core::createObject<ModuleManager>();
 }
 
+void ModuleManager::onDestroyed() {
+    modules_.clear();
+}
+
 // Inserts (ModuleType, ModulePtr()) in the map, or retrieve the existing
 // ModulePtr if the ModuleType was already in the map.
 //

--- a/libs/vgc/ui/module.h
+++ b/libs/vgc/ui/module.h
@@ -133,6 +133,8 @@ private:
     std::mutex mapMutex_; // Prevent inserting concurrently in the map
     std::unordered_map<core::ObjectType, Value_> modules_;
 
+    void onDestroyed() override;
+
     struct GetOrInsertInfo_ {
         Value_& value;
         bool inserted;


### PR DESCRIPTION
#1564

Before this change, the `ModuleManager` and the `Module`s were not destroyed at the end of the program, because:

- `ModuleManager` strongly owns the modules (stores `ModuleSharedPtr` in a map)
- each `Module` weakly owns the `ModuleManager` (stores a `ModuleManagerWeakPtr` in the `ModuleContext`)

This would be perfectly fine with `std::shared_ptr` and `std::weak_ptr`, but can cause issues with the current implementation of VGC's `ObjSharedPtr` and `ObjWeakPtr` if we are not careful by properly clearing both the weak and strong pointers in `onDestroyed()`. 

Indeed, with our smart pointers, `onDestroyed()` is called when the shared count reaches zero, but the actual destructor of the object is only called when the weak count reaches zero. This design was intentional and driven by the fact that the shared and weak count is intrusive and stored in the object itself. However, as we can see, it is a bit dangerous and makes memory leaks possible if `onDestroyed()` is not implemented to clear strong and weak pointers, which is error-prone.

For this reason, we may want to eventually improve our smart pointers (e.g., via placement new) so that the destructor would actually be called when the shared count reaches zero, which would be less error-prone.

In the meantime, implementing `ModuleManager::onDestroyed()` properly fixes this specific problem that modules where not destructed. Here is now the sequence of events:
- The `Application` instance is destructed, which is the only strong owner of its `ModuleManager` instance.
- `ModuleManager::onDestroyed()` is called.
- All `Module` instances have their shared count going to zero (since no-one is supposed to store a SharedPtr to another module).
- Any `Module` whose weak count is also zero (i.e., not referenced by any other module) is destructed.
- When a `Module` is destructed, if it had a weak pointer to another module, then the weak count of the other module decreases, potentially reaching zero too, and therefore being destructed recursively.
- Since there is normally no dependency cycles between modules, eventually all modules are destructed.

Note: The reason I found out that the modules were not destructed (neither their `onDestroyed()` method called), was by investigating why settings were not saved anymore after a seemingly unrelated and harmless change. The change was adding a `WidgetSharedPtr` data member to a module. When the widget in question was a `SettingEdit`, this would indirectly own the `Settings::session()` instance. Since the module was not destructed, neither was the session settings destructed, and therefore the settings were not saved when the application closed.
