### PR TITLE
Disable experimental minimal-latency stroke tip (#1191)

### DIFF
--- a/libs/vgc/tools/sketch.h
+++ b/libs/vgc/tools/sketch.h
@@ -614,8 +614,6 @@ protected:
     geometry::Vec2f lastImmediateCursorPos_ = {};
     geometry::Vec2d minimalLatencySnappedCursor_ = {};
 
-    graphics::GeometryViewPtr mouseInputGeometry_;
-
     // Assumes canvas() is non-null.
     void startCurve_(ui::MouseEvent* event);
     void continueCurve_(ui::MouseEvent* event);


### PR DESCRIPTION
#1191

An experimental method to minimize the perceived visual lag between the mouse cursor and sketched edge was previously implemented by drawing an extra “stroke tip” as an overlay, which was a straight line from the stroke endpoint (as set in the DOM when processing the mouse event) to the current mouse position (via `ui::globalCursorPosition()`  called during the draw event).

The result was useful in some cases, but it did have some issues:

- Didn’t work properly if the display mode was “Outline Only” (was drawing the actual stroke instead of the outline)
- Didn’t work properly if there was objects on top of the drawn stroke (since the stroke tip would always be drawn as an overlay)
- Didn’t look good if the processed stroke was for example forced to be a single line segment, or a single quadratic/cubic segment, or if the fitting was such that the stroke endpoint was not necessarily supposed to be equal to the last mouse event position
- Didn't always look good due to the fact that it was a straight line, ending up more distracting than useful

All of the above might be improved via some ad-hoc logic, but this would essentially duplicate the logic used to draw the normal stroke (which is not very maintainable), and as is it was deemed not ready for production, and more harmful than useful.

Therefore, this is for now disabled, but kept in the code since it is still an interesting idea that might be worth re-enabling later with more polish.