### PR TITLE
Implement automatic computation of chordal distances in sketch passes (#1148, #1191)

### DIFF
--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -331,12 +331,13 @@ void SketchModule::reFitExistingEdges_() {
 }
 
 void SketchPointsProcessingPass::updateCumulativeChordalDistances() {
+
     Int n = numPoints();
     if (n == 0) {
         return;
     }
 
-    Int start = std::max<Int>(numStablePoints(), 1);
+    Int start = std::max<Int>(lastNumStablePoints_, 1);
     const SketchPoint* p1 = &getPoint(start - 1);
     double s = p1->s();
     for (Int i = start; i < n; ++i) {
@@ -345,6 +346,8 @@ void SketchPointsProcessingPass::updateCumulativeChordalDistances() {
         p2.setS(s);
         p1 = &p2;
     }
+
+    areCumulativeChordalDistancesUpdated_ = true;
 }
 
 namespace detail {
@@ -387,7 +390,6 @@ Int TransformPass::update_(const SketchPointBuffer& input, Int lastNumStableInpu
     // Add all other points (some of which are now stable, some of which are
     // still unstable).
     //
-
     for (auto it = inputPoints.begin() + oldNumStablePoints; //
          it != inputPoints.end();
          ++it) {


### PR DESCRIPTION
#1148, #1191

Most passes actually forgot to manually compute it, resulting in incorrect computation of the snap falloff since we had `s == 0` for all points. Example with the Douglas-Peuckert pass:

https://github.com/vgc/vgc/assets/4809739/2c633df7-ea06-4410-93ca-f621f2a0fe9b

This is now fixed:

https://github.com/vgc/vgc/assets/4809739/cb1f2b50-3d19-46b9-be24-d10681218f7b

Note: the above videos also showcase the unrelated issues of "flickering" when using the current Douglas-Peuckert algorithm, which is why it is not used by default.