### PR TITLE
Cleanup SketchPoint and SketchPass classes; Move to different files (#1147)

### DIFF
--- a/libs/vgc/tools/CMakeLists.txt
+++ b/libs/vgc/tools/CMakeLists.txt
@@ -17,6 +17,9 @@ vgc_add_library(tools
         sculpt.h
         select.h
         sketch.h
+        sketchpoint.h
+        sketchpass.h
+        sketchpasses.h
         strings.h
         topology.h
         transform.h
@@ -32,6 +35,8 @@ vgc_add_library(tools
         sculpt.cpp
         select.cpp
         sketch.cpp
+        sketchpass.cpp
+        sketchpasses.cpp
         strings.cpp
         topology.cpp
         transform.cpp

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -16,8 +16,6 @@
 
 #include <vgc/tools/sketch.h>
 
-#include <array>
-
 #include <QBitmap>
 #include <QCursor>
 #include <QPainter>
@@ -169,17 +167,16 @@ double roundInput(double x) {
     return core::roundToSignificantDigits(x, 7);
 }
 
-std::unique_ptr<SketchPointsProcessingPass>
-makePostTransformPass(SketchFitMethod fitMethod) {
+std::unique_ptr<SketchPass> makePostTransformPass(SketchFitMethod fitMethod) {
     switch (fitMethod) {
     case SketchFitMethod::NoFit:
-        return std::make_unique<detail::EmptyPass>();
+        return std::make_unique<EmptyPass>();
     case SketchFitMethod::IndexGaussianSmoothing:
-        return std::make_unique<detail::SmoothingPass>();
+        return std::make_unique<SmoothingPass>();
     case SketchFitMethod::DouglasPeucker:
-        return std::make_unique<detail::DouglasPeuckerPass>();
+        return std::make_unique<DouglasPeuckerPass>();
     }
-    return std::make_unique<detail::EmptyPass>();
+    return std::make_unique<EmptyPass>();
 }
 
 // Sets the SketchPoint buffer and the transform matrix from saved input points.
@@ -290,8 +287,8 @@ void SketchModule::reFitExistingEdges_() {
     // post-processing step to make these match.
     //
     SketchPointBuffer inputPoints;
-    detail::EmptyPass preTransformPass;
-    detail::TransformPass transformPass;
+    EmptyPass preTransformPass;
+    TransformPass transformPass;
     auto postTransformPass = makePostTransformPass(fitMethod());
 
     // Create undo group
@@ -315,9 +312,9 @@ void SketchModule::reFitExistingEdges_() {
             postTransformPass->reset();
 
             // Apply passes
-            preTransformPass.updateResultFrom(inputPoints);
-            transformPass.updateResultFrom(preTransformPass);
-            postTransformPass->updateResultFrom(transformPass);
+            preTransformPass.updateFrom(inputPoints);
+            transformPass.updateFrom(preTransformPass);
+            postTransformPass->updateFrom(transformPass);
 
             // Save result to DOM
             updateEdgeGeometry(postTransformPass->buffer(), item);
@@ -329,572 +326,6 @@ void SketchModule::reFitExistingEdges_() {
         undoGroup->close();
     }
 }
-
-void SketchPointsProcessingPass::updateCumulativeChordalDistances() {
-
-    Int n = numPoints();
-    if (n == 0) {
-        return;
-    }
-
-    Int start = std::max<Int>(lastNumStablePoints_, 1);
-    const SketchPoint* p1 = &getPoint(start - 1);
-    double s = p1->s();
-    for (Int i = start; i < n; ++i) {
-        SketchPoint& p2 = getPointRef(i);
-        s += (p2.position() - p1->position()).length();
-        p2.setS(s);
-        p1 = &p2;
-    }
-
-    areCumulativeChordalDistancesUpdated_ = true;
-}
-
-namespace detail {
-
-Int EmptyPass::update_(const SketchPointBuffer& input, Int lastNumStableInputPoints) {
-
-    VGC_UNUSED(lastNumStableInputPoints);
-    const SketchPointArray& inputPoints = input.data();
-
-    // Remove all previously unstable points.
-    //
-    Int oldNumStablePoints = this->numStablePoints();
-    resizePoints(oldNumStablePoints);
-
-    // Add all other points (some of which are now stable, some of which are
-    // still unstable).
-    //
-    extendPoints(inputPoints.begin() + oldNumStablePoints, inputPoints.end());
-
-    // Set the new number of stable points as being the same as the input.
-    //
-    Int newNumStablePoints = input.numStablePoints();
-    return newNumStablePoints;
-}
-
-void EmptyPass::reset_() {
-    // no custom state
-}
-
-Int TransformPass::update_(const SketchPointBuffer& input, Int lastNumStableInputPoints) {
-
-    VGC_UNUSED(lastNumStableInputPoints);
-    const SketchPointArray& inputPoints = input.data();
-
-    // Remove all previously unstable points.
-    //
-    Int oldNumStablePoints = this->numStablePoints();
-    resizePoints(oldNumStablePoints);
-
-    // Add all other points (some of which are now stable, some of which are
-    // still unstable).
-    //
-    for (auto it = inputPoints.begin() + oldNumStablePoints; //
-         it != inputPoints.end();
-         ++it) {
-
-        SketchPoint p = *it;
-        p.setPosition(transformAffine(p.position()));
-        appendPoint(p);
-    }
-
-    // Set the new number of stable points as being the same as the input.
-    //
-    Int newNumStablePoints = input.numStablePoints();
-    return newNumStablePoints;
-}
-
-void TransformPass::reset_() {
-    // no custom state
-}
-
-namespace {
-
-// Returns the binomial coefficient C(n, k) for 0 <= k <= n.
-//
-// The returned array is of size n + 1.
-//
-// These are computed using the Pascal's triangle:
-//
-//  C(0, k) =       1
-//  C(1, k) =      1 1
-//  C(2, k) =     1 2 1
-//  C(3, k) =    1 3 3 1
-//  C(4, k) =   1 4 6 4 1
-//
-template<size_t n>
-constexpr std::array<Int, n + 1> binomialCoefficients() {
-    std::array<Int, n + 1> res{}; // Value-initialization required for constexprness.
-    res[0] = 1;
-    for (size_t m = 1; m <= n; ++m) {
-        // Compute C(m, k) coefficients from C(m-1, k) coefficients
-        res[m] = 1;
-        for (size_t k = m - 1; k >= 1; --k) {
-            res[k] = res[k] + res[k - 1];
-        }
-    }
-    return res;
-}
-
-bool clampMin_(double k, SketchPoint& p, const SketchPoint& minLimitor, double ds) {
-    double minWidth = minLimitor.width() - k * ds;
-    if (p.width() < minWidth) {
-        p.setWidth(minWidth);
-        return true;
-    }
-    return false;
-}
-
-void clampMax_(double k, SketchPoint& p, const SketchPoint& maxLimitor, double ds) {
-    double maxWidth = maxLimitor.width() + k * ds;
-    if (p.width() > maxWidth) {
-        p.setWidth(maxWidth);
-    }
-}
-
-// Clamps a point p based on a minLimitor before p.
-// Returns whether p was widened according to minLimitor.
-//
-bool clampMinForward(double k, SketchPoint& p, const SketchPoint& minLimitor) {
-    double dsMinLimitor = p.s() - minLimitor.s();
-    return clampMin_(k, p, minLimitor, dsMinLimitor);
-}
-
-// Clamps a point p based on a minLimitor after p.
-// Returns whether p was widened according to minLimitor.
-//
-bool clampMinBackward(double k, SketchPoint& p, const SketchPoint& minLimitor) {
-    double dsMinLimitor = minLimitor.s() - p.s();
-    return clampMin_(k, p, minLimitor, dsMinLimitor);
-}
-
-// Clamps a point p based on a maxLimitor before p.
-//
-void clampMaxForward(double k, SketchPoint& p, const SketchPoint& maxLimitor) {
-    double dsMaxLimitor = p.s() - maxLimitor.s();
-    clampMax_(k, p, maxLimitor, dsMaxLimitor);
-}
-
-// Clamps a point p based on a minLimitor and maxLimitor before p.
-// Returns whether p was widened according to minLimitor.
-//
-bool clampMinMaxForward(
-    double k,
-    SketchPoint& p,
-    const SketchPoint& minLimitor,
-    const SketchPoint& maxLimitor) {
-
-    if (clampMinForward(k, p, minLimitor)) {
-        return true;
-    }
-    else {
-        clampMaxForward(k, p, maxLimitor);
-        return false;
-    }
-}
-
-// Ensures that |dw/ds| <= k (e.g., k = 0.5).
-//
-// Importantly, we should have at least |dw/ds| <= 1, otherwise in the current
-// tesselation model with round caps, it causes the following ugly artifact:
-//
-// Mouse move #123:   (pos = (100, 0), width = 3)
-//
-// -------_
-//         =
-//      +   |
-//         =
-// -------'
-//
-// Mouse move #124:   (pos = (101, 0), width = 1)
-//
-// -------   <- Ugly temporal disontinuity (previously existing geometry disappears)
-//        .  <- Ugly geometric discontinuity (prone to cusps, etc.)
-//       + |
-//        '
-// -------
-//
-// The idea is that what users see should be as close as possible as the
-// "integral of disks" interpretation of a brush stroke. With a physical round
-// paint brush, if you push the brush more then it creates a bigger disk. If
-// you then pull a little without moving lateraly, then it doesn't remove what
-// was previously already painted.
-//
-// Algorithm pseudo-code when applied to a global list of points:
-//
-// 1. Sort samples by width in a list
-// 2. While the list isn't empty:
-//    a. Pop sample with largest width
-//    b. Modify the width of its two siblings to enforce |dw/ds| <= k
-//    c. Update the location of the two siblings in the sorted list to keep it sorted
-//
-// Unfortunately, the above algorithm have global effect: adding one point with
-// very large width might increase the width of all previous points. This is
-// undesirable for performance and user-predictibility, as we want to keep the
-// "unstable points" part of the sketched curve as small as possible.
-// Therefore, in the implementation below, we only allow for a given point to
-// affect `windowSize` points before itself.
-//
-void applyWidthRoughnessLimitor(
-    double k,
-    Int windowSize,
-    const SketchPoint* lastStablePoint, // nullptr if no stable points
-    core::Span<SketchPoint> unstablePoints) {
-
-    if (unstablePoints.isEmpty()) {
-        return;
-    }
-
-    // Apply width-limitor to first unstable point.
-    //
-    const SketchPoint* minLimitor = lastStablePoint;
-    const SketchPoint* maxLimitor = lastStablePoint;
-    if (lastStablePoint) {
-        clampMinMaxForward(k, unstablePoints[0], *minLimitor, *maxLimitor);
-    }
-
-    // Apply width-limitor to subsequent unstable points.
-    //
-    for (Int i = 1; i < unstablePoints.length(); ++i) {
-
-        //                   window size = 3    (each point influences up to
-        //                <------------------|    3 points before itself)
-        //
-        //          p[windowStart]   p[i-1] p[i]
-        // x-----x--------x--------x----x----x
-        //   maxLimitor
-        //
-        Int windowStart = i - windowSize;
-        if (windowStart > 0) {
-            maxLimitor = &unstablePoints[windowStart - 1];
-        }
-        else {
-            windowStart = 0;
-            // maxLimitor == lastStablePoint
-        }
-        SketchPoint& p = unstablePoints[i];
-
-        // Widen current point p[i] based on p[windowStart - 1]
-        // Shorten current point p[i] based on p[i - 1]
-        minLimitor = &unstablePoints[i - 1];
-        bool widened = maxLimitor ? clampMinMaxForward(k, p, *minLimitor, *maxLimitor)
-                                  : clampMinForward(k, p, *minLimitor);
-
-        // Widen previous points within window if necessary.
-        // Note: whenever a point is not itself widened, we know that previous
-        // points will not be widened either, so we can skip computation.
-        if (!widened) {
-            for (Int j = i - 1; j >= windowStart; --j) {
-                if (!clampMinBackward(k, unstablePoints[j], p)) {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-} // namespace
-
-Int SmoothingPass::update_(const SketchPointBuffer& input, Int lastNumStableInputPoints) {
-
-    VGC_UNUSED(lastNumStableInputPoints);
-
-    const SketchPointArray& inputPoints = input.data();
-    Int numPoints = inputPoints.length();
-    Int numStablePoints = this->numStablePoints();
-    if (numPoints == numStablePoints) {
-        return numPoints;
-    }
-
-    // Keep our stable points, fill the rest with the input points.
-    Int unstableIndexStart = numStablePoints;
-    resizePoints(numStablePoints);
-    extendPoints(inputPoints.begin() + unstableIndexStart, inputPoints.end());
-
-    Int instabilityDelta = 0;
-
-    Int pointsSmoothingLevel = 2;
-    if (pointsSmoothingLevel > 0 && numPoints >= 3) {
-        // Apply gaussian smoothing.
-        Int iStart = unstableIndexStart;
-        if (pointsSmoothingLevel == 1) {
-            iStart = std::max<Int>(1, iStart);
-            for (Int i = iStart; i < numPoints - 1; ++i) {
-                getPointRef(i).setPosition(                                  //
-                    (1 / 4.0) * inputPoints.getUnchecked(i - 1).position() + //
-                    (2 / 4.0) * inputPoints.getUnchecked(i + 0).position() + //
-                    (1 / 4.0) * inputPoints.getUnchecked(i + 1).position());
-            }
-        }
-        else if (pointsSmoothingLevel == 2) {
-            if (iStart <= 1) {
-                getPointRef(1).setPosition(                              //
-                    (1 / 4.0) * inputPoints.getUnchecked(0).position() + //
-                    (2 / 4.0) * inputPoints.getUnchecked(1).position() + //
-                    (1 / 4.0) * inputPoints.getUnchecked(2).position());
-                iStart = 2;
-            }
-            for (Int i = iStart; i < numPoints - 2; ++i) {
-                getPointRef(i).setPosition(                                   //
-                    (1 / 16.0) * inputPoints.getUnchecked(i - 2).position() + //
-                    (4 / 16.0) * inputPoints.getUnchecked(i - 1).position() + //
-                    (6 / 16.0) * inputPoints.getUnchecked(i + 0).position() + //
-                    (4 / 16.0) * inputPoints.getUnchecked(i + 1).position() + //
-                    (1 / 16.0) * inputPoints.getUnchecked(i + 2).position());
-            }
-            if (numPoints - 2 >= iStart) {
-                Int i = numPoints - 2;
-                getPointRef(i).setPosition(                                  //
-                    (1 / 4.0) * inputPoints.getUnchecked(i - 1).position() + //
-                    (2 / 4.0) * inputPoints.getUnchecked(i + 0).position() + //
-                    (1 / 4.0) * inputPoints.getUnchecked(i + 1).position());
-            }
-        }
-    }
-    instabilityDelta = std::max<Int>(instabilityDelta, pointsSmoothingLevel);
-
-    // Smooth width.
-    //
-    // This is different as smoothing points since we don't need to keep
-    // the first/last width unchanged.
-    //
-    constexpr size_t widthSmoothingLevel = 2;
-    if constexpr (widthSmoothingLevel != 0) {
-
-        // Get binomial coefficients
-        constexpr Int l = widthSmoothingLevel;
-        constexpr Int m = 2 * widthSmoothingLevel + 1;
-        constexpr std::array<Int, m> coeffs =
-            binomialCoefficients<2 * widthSmoothingLevel>();
-
-        // Apply convolution with coefficients
-        for (Int i = unstableIndexStart; i < numPoints; ++i) {
-            double value = {};
-            double sumCoeffs = 0;
-            Int j = i - l;
-            for (Int k = 0; k < m; ++k, ++j) {
-                if (0 <= j && j < numPoints) {
-                    sumCoeffs += coeffs[k];
-                    value += coeffs[k] * inputPoints[j].width();
-                }
-            }
-            getPointRef(i).setWidth(value / sumCoeffs);
-        }
-        instabilityDelta = std::max<Int>(instabilityDelta, widthSmoothingLevel);
-    }
-
-    // compute chordal lengths
-    updateCumulativeChordalDistances();
-
-    // Width limitor
-    constexpr double widthRoughness = 0.8;
-    constexpr Int roughnessLimitorWindowSize = 3;
-    const SketchPoint* lastStablePoint =
-        numStablePoints == 0 ? nullptr : &getPoint(numStablePoints - 1);
-    applyWidthRoughnessLimitor(
-        widthRoughness, roughnessLimitorWindowSize, lastStablePoint, unstablePoints());
-    instabilityDelta += roughnessLimitorWindowSize;
-
-    return std::max<Int>(0, input.numStablePoints() - instabilityDelta);
-}
-
-void SmoothingPass::reset_() {
-    // no custom state
-}
-
-namespace {
-
-// This is a variant of Douglas-Peucker designed to dequantize mouse inputs
-// from integer to float coordinates.
-//
-// To this end, the distance test checks if the current line segment AB passes
-// through all pixel squares of the samples in the interval. We call
-// `threshold` the minimal distance between AB and the pixel center such that
-// AB does not passes through the pixel square.
-//
-//     ---------------
-//    |               |
-//    |     pixel     |             threshold = distance(pixelCenter, A'B'),
-//    |     center    |         B'  where A'B' is a line parallel to AB and
-//    |       x       |       '     touching the pixel square.
-//    |               |     '
-//    |               |   '
-//    |               | '
-//     ---------------'
-//                  '
-//                ' A'
-//
-// This threshold only depends on the angle AB. If AB is perfectly horizontal
-// or vertical, the threshold is equal to 0.5. If AB is at 45°, the threshold
-// is equal to sqrt(2)/2 (the half-diagonal).
-//
-// We then scale this threshold is scaled with the given `thresholdCoefficient`
-// and add the given `tolerance`.
-//
-// If the current segment does not pass the test, then the farthest samples is
-// selected for the next iteration.
-//
-// In some variants of this algorithm, we may also slighly move the position of
-// selected samples towards the segment AB (e.g., by 0.75 * threshold), which
-// seems to empirically give nicer results in some circumstances.
-//
-Int reconstructInputStep(
-    core::Span<SketchPoint> points,
-    core::IntArray& indices,
-    Int intervalStart,
-    double thresholdCoefficient,
-    double tolerance = 1e-10) {
-
-    Int i = intervalStart;
-    Int endIndex = indices[i + 1];
-    while (indices[i] != endIndex) {
-
-        // Get line AB. Fast discard if AB too small.
-        Int iA = indices[i];
-        Int iB = indices[i + 1];
-        geometry::Vec2d a = points[iA].position();
-        geometry::Vec2d b = points[iB].position();
-        geometry::Vec2d ab = b - a;
-        double abLen = ab.length();
-        if (abLen < core::epsilon) {
-            ++i;
-            continue;
-        }
-
-        // Compute `threshold`
-        constexpr double sqrtOf2 = 1.4142135623730950488017;
-        double abMaxNormalizedAbsoluteCoord =
-            (std::max)(std::abs(ab.x()), std::abs(ab.y())) / abLen;
-        double abAngleWithClosestAxis = std::acos(abMaxNormalizedAbsoluteCoord);
-        double threshold =
-            std::cos(core::pi / 4 - abAngleWithClosestAxis) * (sqrtOf2 / 2);
-
-        // Apply threshold coefficient and additive tolerance
-        double adjustedThreshold = thresholdCoefficient * threshold + tolerance;
-
-        // Compute which sample between A and B is furthest from the line AB
-        double maxDist = 0;
-        Int farthestPointSide = 0;
-        Int farthestPointIndex = -1;
-        for (Int j = iA + 1; j < iB; ++j) {
-            geometry::Vec2d p = points[j].position();
-            geometry::Vec2d ap = p - a;
-            double dist = ab.det(ap) / abLen;
-            // ┌─── x
-            // │    ↑ side 1
-            // │ A ───→ B
-            // y    ↓ side 0
-            Int side = 0;
-            if (dist < 0) {
-                dist = -dist;
-                side = 1;
-            }
-            if (dist > maxDist) {
-                maxDist = dist;
-                farthestPointSide = side;
-                farthestPointIndex = j;
-            }
-        }
-
-        // If the furthest point is too far from AB, then recurse.
-        // Otherwise, stop the recursion and move one to the next segment.
-        if (maxDist > adjustedThreshold) {
-
-            // Add sample to the list of selected samples
-            indices.insert(i + 1, farthestPointIndex);
-
-            // Move the position of the selected sample slightly towards AB
-            constexpr bool isMoveEnabled = true;
-            if (isMoveEnabled) {
-                geometry::Vec2d n = ab.orthogonalized() / abLen;
-                if (farthestPointSide != 0) {
-                    n = -n;
-                }
-                // TODO: scale delta based on some data to prevent shrinkage?
-                double delta = 0.8 * threshold;
-                SketchPoint& p = points[farthestPointIndex];
-                p.setPosition(p.position() - delta * n);
-            }
-        }
-        else {
-            ++i;
-        }
-    }
-    return i;
-}
-
-} // namespace
-
-Int DouglasPeuckerPass::update_(
-    const SketchPointBuffer& input,
-    Int lastNumStableInputPoints) {
-
-    VGC_UNUSED(lastNumStableInputPoints);
-
-    // A copy required to make a mutable span, which the Douglas-Peuckert
-    // algorithm needs (it modifies the points slightly).
-    //
-    SketchPointArray inputPoints = input.data();
-
-    Int firstIndex = 0;
-    Int lastIndex = inputPoints.length() - 1;
-    core::IntArray indices = {firstIndex, lastIndex};
-    Int intervalStart = 0;
-
-    core::Span<SketchPoint> span = inputPoints;
-    double thresholdCoefficient = 1.0;
-    reconstructInputStep(span, indices, intervalStart, thresholdCoefficient);
-
-    Int numSimplifiedPoints = indices.length();
-    resizePoints(numSimplifiedPoints);
-    for (Int i = 0; i < numSimplifiedPoints; ++i) {
-        getPointRef(i) = inputPoints[indices[i]];
-    }
-
-    // For now, for simplicity, we do not provide any stable points guarantees
-    // and simply recompute the Douglas-Peuckert algorithm from scratch{
-    //
-    Int numStablePoints = 0;
-    return numStablePoints;
-}
-
-void DouglasPeuckerPass::reset_() {
-    // no custom state
-}
-
-} // namespace detail
-
-namespace {
-
-geometry::Vec2d getSnapPosition(workspace::Element* snapVertex) {
-    if (vacomplex::Cell* cell = snapVertex->vacCell()) {
-        vacomplex::KeyVertex* keyVertex = cell->toKeyVertex();
-        if (keyVertex) {
-            return keyVertex->position();
-        }
-    }
-    VGC_WARNING(
-        LogVgcToolsSketch,
-        "Snap vertex didn't have an associated KeyVertex: using (0, 0) as position.");
-    return geometry::Vec2d();
-}
-
-// Assumes 0 <= s <= snapFalloff
-//
-geometry::Vec2d applySnapFalloff(
-    const geometry::Vec2d& position,
-    const geometry::Vec2d& delta,
-    double s,
-    double snapFalloff) {
-
-    // Cubic Ease-Out
-    double t = s / snapFalloff;
-    double x = 1 - t;
-    return position + delta * x * x * x;
-}
-
-} // namespace
 
 Sketch::Sketch(CreateKey key)
     : CanvasTool(key) {
@@ -1112,6 +543,24 @@ void Sketch::onPaintCreate(graphics::Engine* engine) {
     reload_ = true;
 }
 
+namespace {
+
+// Assumes 0 <= s <= snapFalloff
+//
+geometry::Vec2d applySnapFalloff(
+    const geometry::Vec2d& position,
+    const geometry::Vec2d& delta,
+    double s,
+    double snapFalloff) {
+
+    // Cubic Ease-Out
+    double t = s / snapFalloff;
+    double x = 1 - t;
+    return position + delta * x * x * x;
+}
+
+} // namespace
+
 void Sketch::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
 
     SuperClass::onPaintDraw(engine, options);
@@ -1255,6 +704,23 @@ Int Sketch::numStableCleanInputPoints_() const {
     const SketchPointBuffer& allCleanInputPoints = postTransformPassesResult_();
     return allCleanInputPoints.numStablePoints() - cleanInputStartIndex_;
 }
+
+namespace {
+
+geometry::Vec2d getSnapPosition(workspace::Element* snapVertex) {
+    if (vacomplex::Cell* cell = snapVertex->vacCell()) {
+        vacomplex::KeyVertex* keyVertex = cell->toKeyVertex();
+        if (keyVertex) {
+            return keyVertex->position();
+        }
+    }
+    VGC_WARNING(
+        LogVgcToolsSketch,
+        "Snap vertex didn't have an associated KeyVertex: using (0, 0) as position.");
+    return geometry::Vec2d();
+}
+
+} // namespace
 
 // Assumes postTransformPassesResult_() points have computed arclengths.
 void Sketch::updateStartSnappedCleanInputPositions_() {
@@ -1786,9 +1252,9 @@ void Sketch::continueCurve_(ui::MouseEvent* event) {
 
     // Apply all processing steps
 
-    preTransformPass_.updateResultFrom(inputPoints_);
-    transformPass_.updateResultFrom(preTransformPass_);
-    postTransformPass_->updateResultFrom(transformPass_);
+    preTransformPass_.updateFrom(inputPoints_);
+    transformPass_.updateFrom(preTransformPass_);
+    postTransformPass_->updateFrom(transformPass_);
 
     updatePendingPositions_();
     updatePendingWidths_();

--- a/libs/vgc/tools/sketchpass.cpp
+++ b/libs/vgc/tools/sketchpass.cpp
@@ -1,0 +1,62 @@
+// Copyright 2023 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vgc/tools/sketchpass.h>
+
+namespace vgc::tools {
+
+void SketchPass::reset() {
+    buffer_.clear();
+    lastNumStablePoints_ = 0;
+    lastNumStableInputPoints_ = 0;
+    doReset();
+}
+
+void SketchPass::updateFrom(const SketchPointBuffer& input) {
+    areCumulativeChordalDistancesUpdated_ = false;
+    Int numStablePoints = doUpdateFrom(input, lastNumStableInputPoints_);
+    if (!areCumulativeChordalDistancesUpdated_) {
+        updateCumulativeChordalDistances();
+    }
+    buffer_.setNumStablePoints(numStablePoints);
+    lastNumStablePoints_ = numStablePoints;
+    lastNumStableInputPoints_ = input.numStablePoints();
+}
+
+void SketchPass::updateCumulativeChordalDistances() {
+
+    Int n = numPoints();
+    if (n == 0) {
+        return;
+    }
+
+    Int start = std::max<Int>(lastNumStablePoints_, 1);
+    const SketchPoint* p1 = &getPoint(start - 1);
+    double s = p1->s();
+    for (Int i = start; i < n; ++i) {
+        SketchPoint& p2 = getPointRef(i);
+        s += (p2.position() - p1->position()).length();
+        p2.setS(s);
+        p1 = &p2;
+    }
+
+    areCumulativeChordalDistancesUpdated_ = true;
+}
+
+void SketchPass::doReset() {
+}
+
+} // namespace vgc::tools

--- a/libs/vgc/tools/sketchpass.h
+++ b/libs/vgc/tools/sketchpass.h
@@ -1,0 +1,327 @@
+// Copyright 2023 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VGC_TOOLS_SKETCHPASS_H
+#define VGC_TOOLS_SKETCHPASS_H
+
+#include <vgc/core/span.h>
+#include <vgc/tools/api.h>
+#include <vgc/tools/sketchpoint.h>
+
+namespace vgc::tools {
+
+/// \class vgc::tools::SketchPointBuffer
+/// \brief An array of SketchPoint together with information on which part is stable.
+///
+/// When sketching, the raw input points go through some processing passes (see
+/// `SketchPass`) in order to perform dequantization, curve fitting, smoothing,
+/// etc. These passes are performed continuously while sketching, that is, they
+/// are done each time a new input point is given.
+///
+/// For performance reasons, but also for increased predictability for users,
+/// it is typically a good idea for each pass to only modify the last few
+/// output points when a new input point is given. That is, we want to have a
+/// long "stable" part at the beginning of the stroke (whose points are
+/// guaranteed to never change anymore), and a short "unstable" part at the end
+/// of the stroke (whose points may be updated when a new input point is
+/// given).
+///
+/// This class is a convenient helper to store and edit an array of SketchPoint
+/// together with information on which part of the array is stable and which
+/// part is unstable. Attempting to edit a point in the stable part throws an
+/// exception, making it easier to catch bugs in the implementation of passes.
+///
+class VGC_TOOLS_API SketchPointBuffer {
+public:
+    /// Creates an empty `SketchPointBuffer`.
+    ///
+    SketchPointBuffer() noexcept = default;
+
+    /// Resets this `SketchPointBuffer` to its initial state with no points
+    /// (but preserving capacity).
+    ///
+    /// This is the only method modifying the stable part of this
+    /// `SketchPointBuffer`. You must not call it when implementing a
+    /// `SketchPass`, as it would break the invariant that stable points are
+    /// not modified or removed during a pass update.
+    ///
+    void clear() {
+        points_.clear();
+        numStablePoints_ = 0;
+    }
+
+    /// Returns the `SketchPoint` at index `i` as an immutable reference.
+    ///
+    const SketchPoint& operator[](Int i) const {
+        return points_[i];
+    }
+
+    /// Returns the `SketchPoint` at index `i` as a immutable reference.
+    ///
+    /// Throws an exception if `i` refers to a stable point.
+    ///
+    SketchPoint& getRef(Int i) {
+        if (i < numStablePoints_) {
+            throw core::LogicError(
+                "getRef(): cannot get a non-const reference to a stable point.");
+        }
+        return points_[i];
+    }
+
+    /// Returns the unstable subset of this `SketchPointBuffer`.
+    ///
+    core::Span<SketchPoint> unstablePoints() {
+        return core::Span<SketchPoint>(points_.begin() + numStablePoints_, points_.end());
+    }
+
+    /// Returns the underlying `SketchPointArray` stored in this `SketchPointBuffer`.
+    ///
+    const SketchPointArray& data() const {
+        return points_;
+    }
+
+    /// Allows iteration over all points in this `SketchPointBuffer`.
+    ///
+    SketchPointArray::const_iterator begin() const {
+        return points_.begin();
+    }
+
+    /// Allows iteration over all points in this `SketchPointBuffer`.
+    ///
+    SketchPointArray::const_iterator end() const {
+        return points_.end();
+    }
+
+    /// Returns the number of points in this `SketchPointBuffer`.
+    ///
+    Int length() const {
+        return points_.length();
+    }
+
+    /// Increases the capacity of `data()`.
+    ///
+    void reserve(Int numPoints) {
+        return points_.reserve(numPoints);
+    }
+
+    /// Changes the number of points in this `SketchPointBuffer`.
+    ///
+    /// Throws an exception if `numPoints < numStablePoints()`.
+    ///
+    void resize(Int numPoints) {
+        if (numPoints < numStablePoints_) {
+            throw core::LogicError("resize(): cannot decrease number of stable points.");
+        }
+        return points_.resize(numPoints);
+    }
+
+    /// Returns the number of stable points in this `SketchPointBuffer`.
+    ///
+    Int numStablePoints() const {
+        return numStablePoints_;
+    }
+
+    /// Sets the number of stable points in this `SketchPointBuffer`.
+    ///
+    /// Throws an exception if `numPoints < numStablePoints()`.
+    ///
+    /// Throws an exception if `numPoints > length()`.
+    ///
+    void setNumStablePoints(Int numPoints) {
+        if (numPoints < numStablePoints_) {
+            throw core::LogicError(
+                "setNumStablePoints(): cannot decrease number of stable points.");
+        }
+        else if (numPoints > points_.length()) {
+            throw core::LogicError("setNumStablePoints(): number of stable points cannot "
+                                   "be greater than number of points.");
+        }
+        numStablePoints_ = numPoints;
+    }
+
+    /// Appends an (unstable) point.
+    ///
+    SketchPoint& append(const SketchPoint& point) {
+        points_.append(point);
+        return points_.last();
+    }
+
+    /// Appends an (unstable) point with the given values.
+    ///
+    SketchPoint& emplaceLast(
+        const geometry::Vec2d& position,
+        double pressure,
+        double timestamp,
+        double width,
+        double s = 0) {
+
+        return points_.emplaceLast(position, pressure, timestamp, width, s);
+    }
+
+    /// Appends a sequence of (unstable) points.
+    ///
+    template<typename InputIt, VGC_REQUIRES(core::isInputIterator<InputIt>)>
+    void extend(InputIt first, InputIt last) {
+        points_.extend(first, last);
+    }
+
+private:
+    SketchPointArray points_;
+    Int numStablePoints_ = 0;
+};
+
+/// \class vgc::tools::SketchPass
+/// \brief Transforms an input SketchPointBuffer into another.
+///
+/// This is a base abstract class for implementing a processing step that
+/// transforms an input SketchPointBuffer into another.
+///
+/// Subclasses should reimplement the virtual method `doUpdateFrom()`, and also
+/// possibly `doReset()` if they store additional state that needs to be
+/// reinitialized when starting processing a new SketchPointBuffer from
+/// scratch.
+///
+class VGC_TOOLS_API SketchPass {
+protected:
+    SketchPass() noexcept = default;
+
+public:
+    virtual ~SketchPass() = default;
+
+    /// Resets this pass, clearing the `buffer` in preparation of processing a
+    /// new input from scratch.
+    ///
+    /// This calls `doReset()` which subclass should reimplement if they store
+    /// additional state that needs to be reinitialized.
+    ///
+    void reset();
+
+    /// Updates the output `buffer()` based on the given `input`.
+    ///
+    /// This calls `doUpdateFrom()` which subclass should reimplement.
+    ///
+    void updateFrom(const SketchPointBuffer& input);
+
+    /// \overload
+    void updateFrom(const SketchPass& input) {
+        updateFrom(input.buffer());
+    }
+
+    /// Returns the output buffer that this pass computes during its
+    /// `doUpdateFrom()` implementation.
+    ///
+    const SketchPointBuffer& buffer() const {
+        return buffer_;
+    }
+
+protected:
+    // The methods below are available for subclasses in their
+    // implementation of `doUpdateFrom()`.
+
+    const SketchPoint& getPoint(Int i) {
+        return buffer_[i];
+    }
+
+    SketchPoint& getPointRef(Int i) {
+        return buffer_.getRef(i);
+    }
+
+    core::Span<SketchPoint> unstablePoints() {
+        return buffer_.unstablePoints();
+    }
+
+    const SketchPointArray& points() const {
+        return buffer_.data();
+    }
+
+    Int numPoints() const {
+        return buffer_.length();
+    }
+
+    void reservePoints(Int count) {
+        return buffer_.reserve(count);
+    }
+
+    void resizePoints(Int count) {
+        return buffer_.resize(count);
+    }
+
+    Int numStablePoints() const {
+        return buffer_.numStablePoints();
+    }
+
+    void appendPoint(const SketchPoint& point) {
+        buffer_.append(point);
+    }
+
+    void emplaceLastPoint(
+        const geometry::Vec2d& position,
+        double pressure,
+        double timestamp,
+        double width,
+        double s = 0) {
+
+        buffer_.emplaceLast(position, pressure, timestamp, width, s);
+    }
+
+    template<typename InputIt, VGC_REQUIRES(core::isInputIterator<InputIt>)>
+    void extendPoints(InputIt first, InputIt last) {
+        buffer_.extend(first, last);
+    }
+
+    // Updates the cumulative chordal distances (`SketchPoint::s()`) of all
+    // points after the last stable point.
+    //
+    // This is automatically called after `update_()`, unless you manually call
+    // it yourself in `update_()`. Calling it yourself is therefore only needed
+    // if part of your algorithm (e.g., computing the widths) requires them.
+    //
+    void updateCumulativeChordalDistances();
+
+protected:
+    // This is the main function that subclasses should implement. It should update
+    // its own `buffer` based on the new `input`.
+    //
+    // The current number of input stable points is `input.numStablePoints()`.
+    //
+    // The last number of input stable points is `lastNumStableInputPoints`.
+    //
+    // The last number of output stable points is `this->numStablePoints()`.
+    //
+    // This function should return the number of output stable points after
+    // this pass. This number must not be less than its previous value.
+    //
+    virtual Int
+    doUpdateFrom(const SketchPointBuffer& input, Int lastNumStableInputPoints) = 0;
+
+    /// This method should be reimplemented by subclasses if they store
+    /// additional state that needs to be reinitialized before processing a new
+    /// input from scratch.
+    ///
+    /// The default implementation does nothing.
+    ///
+    virtual void doReset();
+
+private:
+    SketchPointBuffer buffer_;
+    Int lastNumStablePoints_ = 0;
+    Int lastNumStableInputPoints_ = 0;
+    bool areCumulativeChordalDistancesUpdated_ = false;
+};
+
+} // namespace vgc::tools
+
+#endif // VGC_TOOLS_SKETCHPASS_H

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -1,0 +1,524 @@
+// Copyright 2023 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vgc/tools/sketchpasses.h>
+
+#include <array>
+
+namespace vgc::tools {
+
+Int EmptyPass::doUpdateFrom(
+    const SketchPointBuffer& input,
+    Int lastNumStableInputPoints) {
+
+    VGC_UNUSED(lastNumStableInputPoints);
+    const SketchPointArray& inputPoints = input.data();
+
+    // Remove all previously unstable points.
+    //
+    Int oldNumStablePoints = this->numStablePoints();
+    resizePoints(oldNumStablePoints);
+
+    // Add all other points (some of which are now stable, some of which are
+    // still unstable).
+    //
+    extendPoints(inputPoints.begin() + oldNumStablePoints, inputPoints.end());
+
+    // Set the new number of stable points as being the same as the input.
+    //
+    Int newNumStablePoints = input.numStablePoints();
+    return newNumStablePoints;
+}
+
+Int TransformPass::doUpdateFrom(
+    const SketchPointBuffer& input,
+    Int lastNumStableInputPoints) {
+
+    VGC_UNUSED(lastNumStableInputPoints);
+    const SketchPointArray& inputPoints = input.data();
+
+    // Remove all previously unstable points.
+    //
+    Int oldNumStablePoints = this->numStablePoints();
+    resizePoints(oldNumStablePoints);
+
+    // Add all other points (some of which are now stable, some of which are
+    // still unstable).
+    //
+    for (auto it = inputPoints.begin() + oldNumStablePoints; //
+         it != inputPoints.end();
+         ++it) {
+
+        SketchPoint p = *it;
+        p.setPosition(transformAffine(p.position()));
+        appendPoint(p);
+    }
+
+    // Set the new number of stable points as being the same as the input.
+    //
+    Int newNumStablePoints = input.numStablePoints();
+    return newNumStablePoints;
+}
+
+namespace {
+
+// Returns the binomial coefficient C(n, k) for 0 <= k <= n.
+//
+// The returned array is of size n + 1.
+//
+// These are computed using the Pascal's triangle:
+//
+//  C(0, k) =       1
+//  C(1, k) =      1 1
+//  C(2, k) =     1 2 1
+//  C(3, k) =    1 3 3 1
+//  C(4, k) =   1 4 6 4 1
+//
+template<size_t n>
+constexpr std::array<Int, n + 1> binomialCoefficients() {
+    std::array<Int, n + 1> res{}; // Value-initialization required for constexprness.
+    res[0] = 1;
+    for (size_t m = 1; m <= n; ++m) {
+        // Compute C(m, k) coefficients from C(m-1, k) coefficients
+        res[m] = 1;
+        for (size_t k = m - 1; k >= 1; --k) {
+            res[k] = res[k] + res[k - 1];
+        }
+    }
+    return res;
+}
+
+bool clampMin_(double k, SketchPoint& p, const SketchPoint& minLimitor, double ds) {
+    double minWidth = minLimitor.width() - k * ds;
+    if (p.width() < minWidth) {
+        p.setWidth(minWidth);
+        return true;
+    }
+    return false;
+}
+
+void clampMax_(double k, SketchPoint& p, const SketchPoint& maxLimitor, double ds) {
+    double maxWidth = maxLimitor.width() + k * ds;
+    if (p.width() > maxWidth) {
+        p.setWidth(maxWidth);
+    }
+}
+
+// Clamps a point p based on a minLimitor before p.
+// Returns whether p was widened according to minLimitor.
+//
+bool clampMinForward(double k, SketchPoint& p, const SketchPoint& minLimitor) {
+    double dsMinLimitor = p.s() - minLimitor.s();
+    return clampMin_(k, p, minLimitor, dsMinLimitor);
+}
+
+// Clamps a point p based on a minLimitor after p.
+// Returns whether p was widened according to minLimitor.
+//
+bool clampMinBackward(double k, SketchPoint& p, const SketchPoint& minLimitor) {
+    double dsMinLimitor = minLimitor.s() - p.s();
+    return clampMin_(k, p, minLimitor, dsMinLimitor);
+}
+
+// Clamps a point p based on a maxLimitor before p.
+//
+void clampMaxForward(double k, SketchPoint& p, const SketchPoint& maxLimitor) {
+    double dsMaxLimitor = p.s() - maxLimitor.s();
+    clampMax_(k, p, maxLimitor, dsMaxLimitor);
+}
+
+// Clamps a point p based on a minLimitor and maxLimitor before p.
+// Returns whether p was widened according to minLimitor.
+//
+bool clampMinMaxForward(
+    double k,
+    SketchPoint& p,
+    const SketchPoint& minLimitor,
+    const SketchPoint& maxLimitor) {
+
+    if (clampMinForward(k, p, minLimitor)) {
+        return true;
+    }
+    else {
+        clampMaxForward(k, p, maxLimitor);
+        return false;
+    }
+}
+
+// Ensures that |dw/ds| <= k (e.g., k = 0.5).
+//
+// Importantly, we should have at least |dw/ds| <= 1, otherwise in the current
+// tesselation model with round caps, it causes the following ugly artifact:
+//
+// Mouse move #123:   (pos = (100, 0), width = 3)
+//
+// -------_
+//         =
+//      +   |
+//         =
+// -------'
+//
+// Mouse move #124:   (pos = (101, 0), width = 1)
+//
+// -------   <- Ugly temporal disontinuity (previously existing geometry disappears)
+//        .  <- Ugly geometric discontinuity (prone to cusps, etc.)
+//       + |
+//        '
+// -------
+//
+// The idea is that what users see should be as close as possible as the
+// "integral of disks" interpretation of a brush stroke. With a physical round
+// paint brush, if you push the brush more then it creates a bigger disk. If
+// you then pull a little without moving lateraly, then it doesn't remove what
+// was previously already painted.
+//
+// Algorithm pseudo-code when applied to a global list of points:
+//
+// 1. Sort samples by width in a list
+// 2. While the list isn't empty:
+//    a. Pop sample with largest width
+//    b. Modify the width of its two siblings to enforce |dw/ds| <= k
+//    c. Update the location of the two siblings in the sorted list to keep it sorted
+//
+// Unfortunately, the above algorithm have global effect: adding one point with
+// very large width might increase the width of all previous points. This is
+// undesirable for performance and user-predictibility, as we want to keep the
+// "unstable points" part of the sketched curve as small as possible.
+// Therefore, in the implementation below, we only allow for a given point to
+// affect `windowSize` points before itself.
+//
+void applyWidthRoughnessLimitor(
+    double k,
+    Int windowSize,
+    const SketchPoint* lastStablePoint, // nullptr if no stable points
+    core::Span<SketchPoint> unstablePoints) {
+
+    if (unstablePoints.isEmpty()) {
+        return;
+    }
+
+    // Apply width-limitor to first unstable point.
+    //
+    const SketchPoint* minLimitor = lastStablePoint;
+    const SketchPoint* maxLimitor = lastStablePoint;
+    if (lastStablePoint) {
+        clampMinMaxForward(k, unstablePoints[0], *minLimitor, *maxLimitor);
+    }
+
+    // Apply width-limitor to subsequent unstable points.
+    //
+    for (Int i = 1; i < unstablePoints.length(); ++i) {
+
+        //                   window size = 3    (each point influences up to
+        //                <------------------|    3 points before itself)
+        //
+        //          p[windowStart]   p[i-1] p[i]
+        // x-----x--------x--------x----x----x
+        //   maxLimitor
+        //
+        Int windowStart = i - windowSize;
+        if (windowStart > 0) {
+            maxLimitor = &unstablePoints[windowStart - 1];
+        }
+        else {
+            windowStart = 0;
+            // maxLimitor == lastStablePoint
+        }
+        SketchPoint& p = unstablePoints[i];
+
+        // Widen current point p[i] based on p[windowStart - 1]
+        // Shorten current point p[i] based on p[i - 1]
+        minLimitor = &unstablePoints[i - 1];
+        bool widened = maxLimitor ? clampMinMaxForward(k, p, *minLimitor, *maxLimitor)
+                                  : clampMinForward(k, p, *minLimitor);
+
+        // Widen previous points within window if necessary.
+        // Note: whenever a point is not itself widened, we know that previous
+        // points will not be widened either, so we can skip computation.
+        if (!widened) {
+            for (Int j = i - 1; j >= windowStart; --j) {
+                if (!clampMinBackward(k, unstablePoints[j], p)) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+} // namespace
+
+Int SmoothingPass::doUpdateFrom(
+    const SketchPointBuffer& input,
+    Int lastNumStableInputPoints) {
+
+    VGC_UNUSED(lastNumStableInputPoints);
+
+    const SketchPointArray& inputPoints = input.data();
+    Int numPoints = inputPoints.length();
+    Int numStablePoints = this->numStablePoints();
+    if (numPoints == numStablePoints) {
+        return numPoints;
+    }
+
+    // Keep our stable points, fill the rest with the input points.
+    Int unstableIndexStart = numStablePoints;
+    resizePoints(numStablePoints);
+    extendPoints(inputPoints.begin() + unstableIndexStart, inputPoints.end());
+
+    Int instabilityDelta = 0;
+
+    Int pointsSmoothingLevel = 2;
+    if (pointsSmoothingLevel > 0 && numPoints >= 3) {
+        // Apply gaussian smoothing.
+        Int iStart = unstableIndexStart;
+        if (pointsSmoothingLevel == 1) {
+            iStart = std::max<Int>(1, iStart);
+            for (Int i = iStart; i < numPoints - 1; ++i) {
+                getPointRef(i).setPosition(                                  //
+                    (1 / 4.0) * inputPoints.getUnchecked(i - 1).position() + //
+                    (2 / 4.0) * inputPoints.getUnchecked(i + 0).position() + //
+                    (1 / 4.0) * inputPoints.getUnchecked(i + 1).position());
+            }
+        }
+        else if (pointsSmoothingLevel == 2) {
+            if (iStart <= 1) {
+                getPointRef(1).setPosition(                              //
+                    (1 / 4.0) * inputPoints.getUnchecked(0).position() + //
+                    (2 / 4.0) * inputPoints.getUnchecked(1).position() + //
+                    (1 / 4.0) * inputPoints.getUnchecked(2).position());
+                iStart = 2;
+            }
+            for (Int i = iStart; i < numPoints - 2; ++i) {
+                getPointRef(i).setPosition(                                   //
+                    (1 / 16.0) * inputPoints.getUnchecked(i - 2).position() + //
+                    (4 / 16.0) * inputPoints.getUnchecked(i - 1).position() + //
+                    (6 / 16.0) * inputPoints.getUnchecked(i + 0).position() + //
+                    (4 / 16.0) * inputPoints.getUnchecked(i + 1).position() + //
+                    (1 / 16.0) * inputPoints.getUnchecked(i + 2).position());
+            }
+            if (numPoints - 2 >= iStart) {
+                Int i = numPoints - 2;
+                getPointRef(i).setPosition(                                  //
+                    (1 / 4.0) * inputPoints.getUnchecked(i - 1).position() + //
+                    (2 / 4.0) * inputPoints.getUnchecked(i + 0).position() + //
+                    (1 / 4.0) * inputPoints.getUnchecked(i + 1).position());
+            }
+        }
+    }
+    instabilityDelta = std::max<Int>(instabilityDelta, pointsSmoothingLevel);
+
+    // Smooth width.
+    //
+    // This is different as smoothing points since we don't need to keep
+    // the first/last width unchanged.
+    //
+    constexpr size_t widthSmoothingLevel = 2;
+    if constexpr (widthSmoothingLevel != 0) {
+
+        // Get binomial coefficients
+        constexpr Int l = widthSmoothingLevel;
+        constexpr Int m = 2 * widthSmoothingLevel + 1;
+        constexpr std::array<Int, m> coeffs =
+            binomialCoefficients<2 * widthSmoothingLevel>();
+
+        // Apply convolution with coefficients
+        for (Int i = unstableIndexStart; i < numPoints; ++i) {
+            double value = {};
+            double sumCoeffs = 0;
+            Int j = i - l;
+            for (Int k = 0; k < m; ++k, ++j) {
+                if (0 <= j && j < numPoints) {
+                    sumCoeffs += coeffs[k];
+                    value += coeffs[k] * inputPoints[j].width();
+                }
+            }
+            getPointRef(i).setWidth(value / sumCoeffs);
+        }
+        instabilityDelta = std::max<Int>(instabilityDelta, widthSmoothingLevel);
+    }
+
+    // compute chordal lengths
+    updateCumulativeChordalDistances();
+
+    // Width limitor
+    constexpr double widthRoughness = 0.8;
+    constexpr Int roughnessLimitorWindowSize = 3;
+    const SketchPoint* lastStablePoint =
+        numStablePoints == 0 ? nullptr : &getPoint(numStablePoints - 1);
+    applyWidthRoughnessLimitor(
+        widthRoughness, roughnessLimitorWindowSize, lastStablePoint, unstablePoints());
+    instabilityDelta += roughnessLimitorWindowSize;
+
+    return std::max<Int>(0, input.numStablePoints() - instabilityDelta);
+}
+
+namespace {
+
+// This is a variant of Douglas-Peucker designed to dequantize mouse inputs
+// from integer to float coordinates.
+//
+// To this end, the distance test checks if the current line segment AB passes
+// through all pixel squares of the samples in the interval. We call
+// `threshold` the minimal distance between AB and the pixel center such that
+// AB does not passes through the pixel square.
+//
+//     ---------------
+//    |               |
+//    |     pixel     |             threshold = distance(pixelCenter, A'B'),
+//    |     center    |         B'  where A'B' is a line parallel to AB and
+//    |       x       |       '     touching the pixel square.
+//    |               |     '
+//    |               |   '
+//    |               | '
+//     ---------------'
+//                  '
+//                ' A'
+//
+// This threshold only depends on the angle AB. If AB is perfectly horizontal
+// or vertical, the threshold is equal to 0.5. If AB is at 45°, the threshold
+// is equal to sqrt(2)/2 (the half-diagonal).
+//
+// We then scale this threshold is scaled with the given `thresholdCoefficient`
+// and add the given `tolerance`.
+//
+// If the current segment does not pass the test, then the farthest samples is
+// selected for the next iteration.
+//
+// In some variants of this algorithm, we may also slighly move the position of
+// selected samples towards the segment AB (e.g., by 0.75 * threshold), which
+// seems to empirically give nicer results in some circumstances.
+//
+Int douglasPeucker(
+    core::Span<SketchPoint> points,
+    core::IntArray& indices,
+    Int intervalStart,
+    double thresholdCoefficient,
+    double tolerance = 1e-10) {
+
+    Int i = intervalStart;
+    Int endIndex = indices[i + 1];
+    while (indices[i] != endIndex) {
+
+        // Get line AB. Fast discard if AB too small.
+        Int iA = indices[i];
+        Int iB = indices[i + 1];
+        geometry::Vec2d a = points[iA].position();
+        geometry::Vec2d b = points[iB].position();
+        geometry::Vec2d ab = b - a;
+        double abLen = ab.length();
+        if (abLen < core::epsilon) {
+            ++i;
+            continue;
+        }
+
+        // Compute `threshold`
+        constexpr double sqrtOf2 = 1.4142135623730950488017;
+        double abMaxNormalizedAbsoluteCoord =
+            (std::max)(std::abs(ab.x()), std::abs(ab.y())) / abLen;
+        double abAngleWithClosestAxis = std::acos(abMaxNormalizedAbsoluteCoord);
+        double threshold =
+            std::cos(core::pi / 4 - abAngleWithClosestAxis) * (sqrtOf2 / 2);
+
+        // Apply threshold coefficient and additive tolerance
+        double adjustedThreshold = thresholdCoefficient * threshold + tolerance;
+
+        // Compute which sample between A and B is furthest from the line AB
+        double maxDist = 0;
+        Int farthestPointSide = 0;
+        Int farthestPointIndex = -1;
+        for (Int j = iA + 1; j < iB; ++j) {
+            geometry::Vec2d p = points[j].position();
+            geometry::Vec2d ap = p - a;
+            double dist = ab.det(ap) / abLen;
+            // ┌─── x
+            // │    ↑ side 1
+            // │ A ───→ B
+            // y    ↓ side 0
+            Int side = 0;
+            if (dist < 0) {
+                dist = -dist;
+                side = 1;
+            }
+            if (dist > maxDist) {
+                maxDist = dist;
+                farthestPointSide = side;
+                farthestPointIndex = j;
+            }
+        }
+
+        // If the furthest point is too far from AB, then recurse.
+        // Otherwise, stop the recursion and move one to the next segment.
+        if (maxDist > adjustedThreshold) {
+
+            // Add sample to the list of selected samples
+            indices.insert(i + 1, farthestPointIndex);
+
+            // Move the position of the selected sample slightly towards AB
+            constexpr bool isMoveEnabled = true;
+            if (isMoveEnabled) {
+                geometry::Vec2d n = ab.orthogonalized() / abLen;
+                if (farthestPointSide != 0) {
+                    n = -n;
+                }
+                // TODO: scale delta based on some data to prevent shrinkage?
+                double delta = 0.8 * threshold;
+                SketchPoint& p = points[farthestPointIndex];
+                p.setPosition(p.position() - delta * n);
+            }
+        }
+        else {
+            ++i;
+        }
+    }
+    return i;
+}
+
+} // namespace
+
+Int DouglasPeuckerPass::doUpdateFrom(
+    const SketchPointBuffer& input,
+    Int lastNumStableInputPoints) {
+
+    VGC_UNUSED(lastNumStableInputPoints);
+
+    // A copy required to make a mutable span, which the Douglas-Peuckert
+    // algorithm needs (it modifies the points slightly).
+    //
+    SketchPointArray inputPoints = input.data();
+
+    Int firstIndex = 0;
+    Int lastIndex = inputPoints.length() - 1;
+    core::IntArray indices = {firstIndex, lastIndex};
+    Int intervalStart = 0;
+
+    core::Span<SketchPoint> span = inputPoints;
+    double thresholdCoefficient = 1.0;
+    douglasPeucker(span, indices, intervalStart, thresholdCoefficient);
+
+    Int numSimplifiedPoints = indices.length();
+    resizePoints(numSimplifiedPoints);
+    for (Int i = 0; i < numSimplifiedPoints; ++i) {
+        getPointRef(i) = inputPoints[indices[i]];
+    }
+
+    // For now, for simplicity, we do not provide any stable points guarantees
+    // and simply recompute the Douglas-Peuckert algorithm from scratch{
+    //
+    Int numStablePoints = 0;
+    return numStablePoints;
+}
+
+} // namespace vgc::tools

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -1,0 +1,72 @@
+// Copyright 2023 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VGC_TOOLS_SKETCHPASSES_H
+#define VGC_TOOLS_SKETCHPASSES_H
+
+#include <vgc/geometry/mat3d.h>
+#include <vgc/tools/api.h>
+#include <vgc/tools/sketchpass.h>
+
+namespace vgc::tools {
+
+class VGC_TOOLS_API EmptyPass : public SketchPass {
+protected:
+    Int
+    doUpdateFrom(const SketchPointBuffer& input, Int lastNumStableInputPoints) override;
+};
+
+class VGC_TOOLS_API TransformPass : public SketchPass {
+public:
+    const geometry::Mat3d& transformMatrix() const {
+        return transform_;
+    }
+
+    void setTransformMatrix(const geometry::Mat3d& transform) {
+        transform_ = transform;
+    }
+
+    geometry::Vec2d transform(const geometry::Vec2d& v) {
+        return transform_.transform(v);
+    }
+
+    geometry::Vec2d transformAffine(const geometry::Vec2d& v) {
+        return transform_.transformAffine(v);
+    }
+
+protected:
+    Int
+    doUpdateFrom(const SketchPointBuffer& input, Int lastNumStableInputPoints) override;
+
+private:
+    geometry::Mat3d transform_;
+};
+
+class VGC_TOOLS_API SmoothingPass : public SketchPass {
+protected:
+    Int
+    doUpdateFrom(const SketchPointBuffer& input, Int lastNumStableInputPoints) override;
+};
+
+class VGC_TOOLS_API DouglasPeuckerPass : public SketchPass {
+protected:
+    Int
+    doUpdateFrom(const SketchPointBuffer& input, Int lastNumStableInputPoints) override;
+};
+
+} // namespace vgc::tools
+
+#endif // VGC_TOOLS_SKETCHPASSES_H

--- a/libs/vgc/tools/sketchpoint.h
+++ b/libs/vgc/tools/sketchpoint.h
@@ -1,0 +1,142 @@
+// Copyright 2023 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VGC_TOOLS_SKETCHPOINT_H
+#define VGC_TOOLS_SKETCHPOINT_H
+
+#include <vgc/core/array.h>
+#include <vgc/geometry/vec2d.h>
+#include <vgc/tools/api.h>
+
+namespace vgc::tools {
+
+/// \class vgc::tools::SketchPoint
+/// \brief Stores data about one sample when sketching
+///
+class VGC_TOOLS_API SketchPoint {
+public:
+    /// Creates a zero-initialized `SketchPoint`.
+    ///
+    constexpr SketchPoint() noexcept
+        : position_()
+        , pressure_(0)
+        , timestamp_(0)
+        , width_(0)
+        , s_(0) {
+    }
+
+    VGC_WARNING_PUSH
+    VGC_WARNING_MSVC_DISABLE(26495) // member variable uninitialized
+
+    /// Creates an uninitialized `SketchPoint`.
+    ///
+    SketchPoint(core::NoInit) noexcept
+        : position_(core::noInit) {
+    }
+
+    VGC_WARNING_POP
+
+    /// Creates a `SketchPoint` initialized with the given values.
+    ///
+    SketchPoint(
+        const geometry::Vec2d& position,
+        double pressure,
+        double timestamp,
+        double width,
+        double s = 0) noexcept
+
+        : position_(position)
+        , pressure_(pressure)
+        , timestamp_(timestamp)
+        , width_(width)
+        , s_(s) {
+    }
+
+    /// Returns the position of this `SketchPoint`.
+    ///
+    const geometry::Vec2d& position() const {
+        return position_;
+    }
+
+    /// Sets the position of this `SketchPoint`.
+    ///
+    void setPosition(const geometry::Vec2d& position) {
+        position_ = position;
+    }
+
+    /// Returns the pressure of this `SketchPoint`.
+    ///
+    double pressure() const {
+        return pressure_;
+    }
+
+    /// Sets the pressure of this `SketchPoint`.
+    ///
+    void setPressure(double pressure) {
+        pressure_ = pressure;
+    }
+
+    /// Returns the timestamp of this `SketchPoint`.
+    ///
+    double timestamp() const {
+        return timestamp_;
+    }
+
+    /// Sets the timestamp of this `SketchPoint`.
+    ///
+    void setTimestamp(double timestamp) {
+        timestamp_ = timestamp;
+    }
+
+    /// Returns the width of this `SketchPoint`.
+    ///
+    double width() const {
+        return width_;
+    }
+
+    /// Sets the width of this `SketchPoint`.
+    ///
+    void setWidth(double width) {
+        width_ = width;
+    }
+
+    /// Returns the cumulative chordal distance from the first point to this
+    /// point.
+    ///
+    double s() const {
+        return s_;
+    }
+
+    /// Sets the cumulative chordal distance from the first point to this
+    /// point.
+    ///
+    void setS(double s) {
+        s_ = s;
+    }
+
+private:
+    geometry::Vec2d position_;
+    double pressure_;
+    double timestamp_;
+    double width_;
+    double s_;
+};
+
+using SketchPointArray = core::Array<SketchPoint>;
+
+} // namespace vgc::tools
+
+#endif // VGC_TOOLS_SKETCHPOINT_H


### PR DESCRIPTION
#1147

The files `sketch.h` / `sketch.cpp` started to be a little too big. So I extracted `SketchPoint` and `SketchPointsProcessingPass` (and its subclasses) to different files.

I also used this as an opportunity to add more documentation, rename  `SketchPointsProcessingPass` to `SketchPass` for conciseness (and publicized it out of `detail`) , and renamed a few functions.