### PR TITLE
Add and improve Engine methods for creating/updating geometry buffers (#1201)

### DIFF
--- a/libs/vgc/canvas/canvas.cpp
+++ b/libs/vgc/canvas/canvas.cpp
@@ -579,7 +579,7 @@ void Canvas::onPaintCreate(graphics::Engine* engine) {
     fillRS_ = engine->createRasterizerState(createInfo);
     createInfo.setFillMode(FillMode::Wireframe);
     wireframeRS_ = engine->createRasterizerState(createInfo);
-    bgGeometry_ = engine->createDynamicTriangleStripView(BuiltinGeometryLayout::XYRGB);
+    bgGeometry_ = engine->createTriangleStrip(BuiltinGeometryLayout::XYRGB);
 
     reload_ = true;
 }
@@ -647,7 +647,7 @@ void doPaintInputSketchPoints(
     // Create the graphics resource
     //
     if (!geometryView) {
-        geometryView = engine->createDynamicTriangleStripView(
+        geometryView = engine->createTriangleStrip(
             graphics::BuiltinGeometryLayout::XYDxDy_iXYRotWRGBA);
     }
 
@@ -711,8 +711,8 @@ void doPaintInputSketchPoints(
         //                     X           Y        Rot   W    R    G    B    A
     }
 
-    engine->updateBufferData(geometryView->vertexBuffer(0), std::move(sharedInstData));
-    engine->updateBufferData(geometryView->vertexBuffer(1), std::move(perInstData));
+    engine->updateVertexBufferData(geometryView, std::move(sharedInstData));
+    engine->updateInstanceBufferData(geometryView, std::move(perInstData));
 
     engine->setProgram(graphics::BuiltinProgram::ScreenSpaceDisplacement);
     engine->drawInstanced(geometryView);

--- a/libs/vgc/graphics/buffer.h
+++ b/libs/vgc/graphics/buffer.h
@@ -50,7 +50,7 @@ class VGC_GRAPHICS_API BufferCreateInfo {
 public:
     constexpr BufferCreateInfo() noexcept = default;
 
-    constexpr BufferCreateInfo(BindFlags bindFlags, bool isDynamic) noexcept
+    constexpr BufferCreateInfo(BindFlags bindFlags, bool isDynamic = true) noexcept
         : usage_(isDynamic ? Usage::Dynamic : Usage::Immutable)
         , bindFlags_(bindFlags)
         , cpuAccessFlags_(isDynamic ? CpuAccessFlag::Write : CpuAccessFlag::None) {
@@ -118,8 +118,9 @@ protected:
         }
         if (bindFlags & BindFlag::ConstantBuffer) {
             if (bindFlags != BindFlag::ConstantBuffer) {
-                throw core::LogicError("BindFlags::UniformBuffer cannot be combined with "
-                                       "any other bind flag");
+                throw core::LogicError(
+                    "BindFlags::ConstantBuffer cannot be combined with "
+                    "any other bind flag");
             }
         }
     }

--- a/libs/vgc/graphics/d3d11/d3d11engine.cpp
+++ b/libs/vgc/graphics/d3d11/d3d11engine.cpp
@@ -1138,7 +1138,7 @@ BufferPtr D3d11Engine::constructBuffer_(const BufferCreateInfo& createInfo) {
     if (bindFlags & BindFlag::ConstantBuffer) {
         desc.BindFlags |= D3D11_BIND_FLAG::D3D11_BIND_CONSTANT_BUFFER;
         if (bindFlags != BindFlag::ConstantBuffer) {
-            throw core::LogicError("D3d11Buffer: BindFlag::UniformBuffer cannot be "
+            throw core::LogicError("D3d11Buffer: BindFlag::ConstantBuffer cannot be "
                                    "combined with any other bind flag.");
         }
     }
@@ -1817,6 +1817,7 @@ void D3d11Engine::setStageConstantBuffers_(
     Int startIndex,
     Int count,
     ShaderStage shaderStage) {
+
     const Int stageIdx = core::toUnderlying(shaderStage);
     StageConstantBufferArray& boundConstantBufferArray =
         boundConstantBufferArrays_[core::toUnderlying(shaderStage)];

--- a/libs/vgc/graphics/detail/shapeutil.cpp
+++ b/libs/vgc/graphics/detail/shapeutil.cpp
@@ -38,7 +38,7 @@ void updateScreenSpaceInstance(
         const float rot = isRotationEnabled ? 1.f : 0.f;
         core::FloatArray instanceData(
             {position.x(), position.y(), rot, dispS, c.r(), c.g(), c.b(), c.a()});
-        engine->updateBufferData(geometry->vertexBuffer(1), std::move(instanceData));
+        engine->updateInstanceBufferData(geometry, std::move(instanceData));
     }
 }
 
@@ -261,7 +261,7 @@ void updateRectangleWithScreenSpaceThickness(
         // XYDxDy
         geometry::Vec4fArray vertices =
             createRectangleWithScreenSpaceThicknessVertexData(rect);
-        engine->updateBufferData(geometry->vertexBuffer(0), std::move(vertices));
+        engine->updateVertexBufferData(geometry, std::move(vertices));
     }
 }
 

--- a/libs/vgc/graphics/geometryview.h
+++ b/libs/vgc/graphics/geometryview.h
@@ -216,21 +216,37 @@ public:
         return info_.vertexBuffers();
     }
 
-    const BufferPtr& vertexBuffer(Int i) const {
-        return info_.vertexBuffer(i);
+    const BufferPtr& vertexBuffer(Int bufferIndex) const {
+        return info_.vertexBuffer(bufferIndex);
+    }
+
+    const BufferPtr& vertexBuffer() const {
+        return info_.vertexBuffer(0);
+    }
+
+    const BufferPtr& instanceBuffer() const {
+        return info_.vertexBuffer(1);
     }
 
     const VertexBufferStridesArray& strides() const {
         return info_.strides();
     }
 
+    Int stride(Int bufferIndex) const {
+        return info_.strides()[bufferIndex];
+    }
+
     const VertexBufferOffsetsArray& offsets() const {
         return info_.offsets();
     }
 
+    Int offset(Int bufferIndex) const {
+        return info_.offsets()[bufferIndex];
+    }
+
     Int numIndices() const {
         IndexFormat format = indexFormat();
-        const BufferPtr& buffer = info_.indexBuffer();
+        const BufferPtr& buffer = indexBuffer();
         if (!buffer || format == IndexFormat::None) {
             return 0;
         }
@@ -239,22 +255,20 @@ public:
     }
 
     Int numVertices() const {
-        const BufferPtr& buffer = info_.vertexBuffers()[0];
+        const BufferPtr& buffer = vertexBuffer(0);
         if (!buffer) {
             return 0;
         }
-        Int elementSize = info_.strides()[0];
-        return (elementSize > 0) ? buffer->lengthInBytes() / elementSize : 1;
-        // elementSize == 0 is a really special case of void vertex that enables
+        Int bytesPerVertex = stride(0);
+        return (bytesPerVertex > 0) ? buffer->lengthInBytes() / bytesPerVertex : 1;
+        // Note: stride == 0 is a special case of void vertex that enables
         // shader invocation without input geometry.
     }
 
     Int numInstances() const {
-        Int instanceElementSize = info_.strides()[1];
-        const BufferPtr& buffer = info_.vertexBuffers()[1];
-        return (instanceElementSize > 0 && buffer)
-                   ? buffer->lengthInBytes() / instanceElementSize
-                   : 0;
+        const BufferPtr& buffer = vertexBuffers()[1];
+        Int bytesPerInst = stride(1);
+        return (bytesPerInst > 0 && buffer) ? buffer->lengthInBytes() / bytesPerInst : 0;
     }
 
 protected:

--- a/libs/vgc/graphics/geometryview.h
+++ b/libs/vgc/graphics/geometryview.h
@@ -261,12 +261,12 @@ public:
         }
         Int bytesPerVertex = stride(0);
         return (bytesPerVertex > 0) ? buffer->lengthInBytes() / bytesPerVertex : 1;
-        // Note: stride == 0 is a special case of void vertex that enables
+        // Note: bytesPerVertex == 0 is a special case of void vertex that enables
         // shader invocation without input geometry.
     }
 
     Int numInstances() const {
-        const BufferPtr& buffer = vertexBuffers()[1];
+        const BufferPtr& buffer = vertexBuffer(1);
         Int bytesPerInst = stride(1);
         return (bytesPerInst > 0 && buffer) ? buffer->lengthInBytes() / bytesPerInst : 0;
     }

--- a/libs/vgc/graphics/icon.cpp
+++ b/libs/vgc/graphics/icon.cpp
@@ -57,7 +57,7 @@ struct Batch {
     ColorSpec colorSpec;
     core::FloatArray vertices;
 
-    // Data that needs to be recreatesd on Engine change
+    // Data that needs to be recreated on Engine change
     BufferPtr instanceBuffer;
     GeometryViewPtr geometryView;
 };

--- a/libs/vgc/tools/colorpalette.cpp
+++ b/libs/vgc/tools/colorpalette.cpp
@@ -940,8 +940,7 @@ void ColorPaletteSelector::setContinuous(bool isContinuous) {
 
 void ColorPaletteSelector::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    triangles_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
+    triangles_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
 }
 
 namespace {
@@ -2495,8 +2494,7 @@ void ColorPreview::onResize() {
 
 void ColorPreview::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    triangles_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
+    triangles_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
 }
 
 void ColorPreview::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
@@ -2681,8 +2679,7 @@ void ColorListView::onResize() {
 
 void ColorListView::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    triangles_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
+    triangles_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
 }
 
 namespace {

--- a/libs/vgc/tools/paintbucket.cpp
+++ b/libs/vgc/tools/paintbucket.cpp
@@ -169,7 +169,7 @@ void PaintBucket::onMouseLeave() {
 void PaintBucket::onPaintCreate(graphics::Engine* engine) {
     using Layout = graphics::BuiltinGeometryLayout;
     SuperClass::onPaintCreate(engine);
-    faceCandidateFillGeometry_ = engine->createDynamicTriangleListView(Layout::XY_iRGBA);
+    faceCandidateFillGeometry_ = engine->createTriangleList(Layout::XY_iRGBA);
 }
 
 void PaintBucket::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options) {
@@ -183,11 +183,11 @@ void PaintBucket::onPaintDraw(graphics::Engine* engine, ui::PaintOptions options
     if (hasFaceCandidate_() && faceCandidateFillGeometry_) {
         core::Color c = color();
         if (isFaceCandidateGraphicsDirty_) {
-            engine->updateBufferData(
-                faceCandidateFillGeometry_->vertexBuffer(0), //
+            engine->updateVertexBufferData(
+                faceCandidateFillGeometry_, //
                 faceCandidateTriangles_);
-            engine->updateBufferData(
-                faceCandidateFillGeometry_->vertexBuffer(1), //
+            engine->updateInstanceBufferData(
+                faceCandidateFillGeometry_, //
                 core::Array<float>({c.r(), c.g(), c.b(), 1}));
             isFaceCandidateGraphicsDirty_ = false;
         }

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -555,8 +555,8 @@ constexpr bool isMinimalLatencyTipEnabled = false;
 void Sketch::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
     if (isMinimalLatencyTipEnabled) {
-        minimalLatencyStrokeGeometry_ = engine->createTriangleStrip(
-            graphics::BuiltinGeometryLayout::XY_iRGBA);
+        minimalLatencyStrokeGeometry_ =
+            engine->createTriangleStrip(graphics::BuiltinGeometryLayout::XY_iRGBA);
     }
     reload_ = true;
 }

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -555,7 +555,7 @@ constexpr bool isMinimalLatencyTipEnabled = false;
 void Sketch::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
     if (isMinimalLatencyTipEnabled) {
-        minimalLatencyStrokeGeometry_ = engine->createDynamicTriangleStripView(
+        minimalLatencyStrokeGeometry_ = engine->createTriangleStrip(
             graphics::BuiltinGeometryLayout::XY_iRGBA);
     }
     reload_ = true;

--- a/libs/vgc/tools/transform.cpp
+++ b/libs/vgc/tools/transform.cpp
@@ -1132,14 +1132,14 @@ void TransformBox::onPaintCreate(graphics::Engine* engine) {
     //cornersGeometry_ = graphics::detail::createScreenSpaceSquare(
     //    engine, geometry::Vec2f(), 2.f, core::Color());
     for (Int i = 0; i < 4; ++i) {
-        cornerGeometry_[i] = engine->createDynamicGeometryView(
+        cornerGeometry_[i] = engine->createGeometry(
             graphics::PrimitiveType::TriangleStrip,
             graphics::BuiltinGeometryLayout::XYDxDy_iXYRotWRGBA);
     }
 
     pivotCircleGeometry_ = graphics::detail::createCircleWithScreenSpaceThickness(
         engine, 1.f, core::Color(), 15);
-    pivotCross0Geometry_ = engine->createDynamicGeometryView(
+    pivotCross0Geometry_ = engine->createGeometry(
         graphics::PrimitiveType::TriangleStrip,
         graphics::BuiltinGeometryLayout::XYDxDy_iXYRotWRGBA);
     geometry::Vec2fArray cross0Vertices = {
@@ -1154,7 +1154,7 @@ void TransformBox::onPaintCreate(graphics::Engine* engine) {
     };
     engine->updateBufferData(
         pivotCross0Geometry_->vertexBuffer(0), std::move(cross0Vertices));
-    pivotCross1Geometry_ = engine->createDynamicGeometryView(
+    pivotCross1Geometry_ = engine->createGeometry(
         graphics::PrimitiveType::TriangleStrip,
         graphics::BuiltinGeometryLayout::XYDxDy_iXYRotWRGBA);
     geometry::Vec2fArray cross1Vertices = {

--- a/libs/vgc/ui/imagebox.cpp
+++ b/libs/vgc/ui/imagebox.cpp
@@ -49,8 +49,7 @@ void ImageBox::onResize() {
 
 void ImageBox::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    quad_ =
-        engine->createDynamicTriangleStripView(graphics::BuiltinGeometryLayout::XYUVRGBA);
+    quad_ = engine->createTriangleStrip(graphics::BuiltinGeometryLayout::XYUVRGBA);
 }
 
 void ImageBox::onPaintDraw(graphics::Engine* engine, PaintOptions options) {

--- a/libs/vgc/ui/label.cpp
+++ b/libs/vgc/ui/label.cpp
@@ -59,8 +59,7 @@ void Label::onResize() {
 
 void Label::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    triangles_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
+    triangles_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
 }
 
 void Label::onPaintDraw(graphics::Engine* engine, PaintOptions options) {

--- a/libs/vgc/ui/lineedit.cpp
+++ b/libs/vgc/ui/lineedit.cpp
@@ -130,8 +130,7 @@ void LineEdit::onResize() {
 
 void LineEdit::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    triangles_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
+    triangles_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
 }
 
 void LineEdit::onPaintDraw(graphics::Engine* engine, PaintOptions options) {

--- a/libs/vgc/ui/panelarea.cpp
+++ b/libs/vgc/ui/panelarea.cpp
@@ -737,8 +737,7 @@ void PanelArea::updateChildrenGeometry() {
 
 void PanelArea::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    triangles_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
+    triangles_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
 }
 
 void PanelArea::onPaintDraw(graphics::Engine* engine, PaintOptions options) {

--- a/libs/vgc/ui/plot2d.cpp
+++ b/libs/vgc/ui/plot2d.cpp
@@ -112,14 +112,10 @@ void Plot2d::onResize() {
 
 void Plot2d::onPaintCreate(graphics::Engine* engine) {
     SuperClass::onPaintCreate(engine);
-    plotGeom_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
-    plotTextGeom_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
-    hintBgGeom_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
-    hintTextGeom_ =
-        engine->createDynamicTriangleListView(graphics::BuiltinGeometryLayout::XYRGB);
+    plotGeom_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
+    plotTextGeom_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
+    hintBgGeom_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
+    hintTextGeom_ = engine->createTriangleList(graphics::BuiltinGeometryLayout::XYRGB);
 }
 
 void Plot2d::onPaintDraw(graphics::Engine* engine, PaintOptions options) {

--- a/libs/vgc/ui/widget.cpp
+++ b/libs/vgc/ui/widget.cpp
@@ -535,7 +535,7 @@ void Widget::paint(graphics::Engine* engine, PaintOptions options) {
 
 void Widget::onPaintCreate(graphics::Engine* engine) {
     auto layout = graphics::BuiltinGeometryLayout::XYRGB;
-    triangles_ = engine->createDynamicTriangleListView(layout);
+    triangles_ = engine->createTriangleList(layout);
 }
 
 void Widget::onPaintPrepare(graphics::Engine* engine, PaintOptions options) {

--- a/libs/vgc/workspace/face.cpp
+++ b/libs/vgc/workspace/face.cpp
@@ -186,7 +186,7 @@ void VacKeyFace::onPaintDraw(
         hasNewFillGraphics = true;
 
         graphics.setFillGeometry(
-            engine->createDynamicTriangleListView(BuiltinGeometryLayout::XY_iRGBA));
+            engine->createTriangleList(BuiltinGeometryLayout::XY_iRGBA));
 
         engine->updateBufferData(
             graphics.fillGeometry()->vertexBuffer(0), //


### PR DESCRIPTION
#1201

Summary of changes:

- Change `createDynamicGeometryView(primType, ...)` to `createGeometry(primType, ..., isDynamic = true)`:
  - It is a shorter and more readable name (less scary...)
  - Having dynamic geometry by default makes sense (it is safer) so there is no need to explicitly state it in the method name (keep it simple).  For more advanced usage, `isDynamic` is added as an optional param.
  - It does not just create the geometry view, but also the buffers that the view refers to, so it actually creates geometry (despite returning a `GeometryView`), so the new name is more accurate.
- Same for `createDynamicTriangle[List/Strip]View()`
- Add convenient `GeometryView::vertexBuffer()` and `GeometryView::instanceBuffer()` getters, instead of having to use the magic indices `0` and `1`.
- Add convenient `Engine::updateVertexBufferData(geometryView)` and `Engine::updateInstanceBufferData(geometryView)` methods
- Remove the unused `initialLength` arguments, since in practice, client code either initializes the buffer as empty then call `updateBufferData()` later, or directly initializes the buffers with non-zero data. So there was almost no need for zero-initializing methods. The only exception was when creating a `ConstantBuffer`, so we did keep the `initialLength` argument for the most low-level `createBuffer()` method. 
- Remove `IndexFormat` argument for `createIndexBuffer`, since it is not actually a property of the `Buffer`, but a property of the `GeometryView`. Maybe we should actually make it a property of the `Buffer` though? This is left for future work.
- Update client code accordingly
- Add doc