### PR TITLE
Implement quadratic blend fit (#1147)

### DIFF
--- a/libs/vgc/geometry/catmullrom.h
+++ b/libs/vgc/geometry/catmullrom.h
@@ -63,6 +63,20 @@ void catmullRomToBezier(
 
 } // namespace detail
 
+/// Overload of `uniformCatmullRomToBezier` expecting a pointer to a contiguous sequence
+/// of 4 control points in input and output.
+///
+template<typename T>
+void uniformCatmullRomToBezier(const T* inFourPoints, T* outFourPoints) {
+    constexpr double k = 1.0 / 6; // = 1/6 up to double precision
+    T p1 = inFourPoints[1] + k * (inFourPoints[2] - inFourPoints[0]);
+    T p2 = inFourPoints[2] - k * (inFourPoints[3] - inFourPoints[1]);
+    outFourPoints[0] = inFourPoints[1]; // These two lines must be done first in order
+    outFourPoints[3] = inFourPoints[2]; // to support inFourPoints == outFourPoints
+    outFourPoints[1] = p1;
+    outFourPoints[2] = p2;
+}
+
 /// Convert four uniform Catmull-Rom control points into the four cubic Bézier
 /// control points corresponding to the same cubic curve. The formula is the
 /// following:
@@ -149,20 +163,6 @@ void uniformCatmullRomToBezier(
     b1 = c1 + k * (c2 - c0);
     b2 = c2 - k * (c3 - c1);
     b3 = c2;
-}
-
-/// Overload of `uniformCatmullRomToBezier` expecting a pointer to a contiguous sequence
-/// of 4 control points in input and output.
-///
-template<typename T>
-void uniformCatmullRomToBezier(const T* inFourPoints, T* outFourPoints) {
-    constexpr double k = 1.0 / 6; // = 1/6 up to double precision
-    T p1 = inFourPoints[1] + k * (inFourPoints[2] - inFourPoints[0]);
-    T p2 = inFourPoints[2] - k * (inFourPoints[3] - inFourPoints[1]);
-    outFourPoints[0] = inFourPoints[1]; // These two lines must be done first in order
-    outFourPoints[3] = inFourPoints[2]; // to support inFourPoints == outFourPoints
-    outFourPoints[1] = p1;
-    outFourPoints[2] = p2;
 }
 
 /// Variant of `uniformCatmullRomToBezier` that caps the tangents

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -23,7 +23,6 @@
 #include <vgc/canvas/documentmanager.h>
 #include <vgc/canvas/experimental.h>
 #include <vgc/core/arithmetic.h> // roundToSignificantDigits
-#include <vgc/core/colors.h>
 #include <vgc/core/profile.h>
 #include <vgc/core/stringid.h>
 #include <vgc/geometry/curve.h>

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -329,9 +329,11 @@ void SketchModule::reFitExistingEdges_() {
 
             // Setup passes
             preTransformPass->reset();
+            preTransformPass->setTransformMatrix(transform);
             transformPass.reset();
             transformPass.setTransformMatrix(transform);
             postTransformPass->reset();
+            postTransformPass->setTransformMatrix(transform);
 
             // Apply passes
             preTransformPass->updateFrom(inputPoints);

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -119,7 +119,8 @@ VGC_DEFINE_ENUM( //
     (SingleLineSegmentWithFreeEndpoints, "Single Line Segment (Free Endpoints)"),
     (SingleQuadraticSegmentWithFixedEndpoints,
      "Single Quadratic Segment (Fixed Endpoints)"),
-    (QuadraticSpline, "Quadratic Spline"))
+    (QuadraticSpline, "Quadratic Spline"),
+    (QuadraticBlend, "Quadratic Blend"))
 
 SketchModule::SketchModule(CreateKey key, const ui::ModuleContext& context)
     : Module(key, context) {
@@ -188,6 +189,8 @@ std::unique_ptr<SketchPass> makePreTransformPass(SketchFitMethod fitMethod) {
         return std::make_unique<SingleQuadraticSegmentWithFixedEndpointsPass>();
     case SketchFitMethod::QuadraticSpline:
         return std::make_unique<QuadraticSplinePass>();
+    case SketchFitMethod::QuadraticBlend:
+        return std::make_unique<QuadraticBlendPass>();
     }
     return std::make_unique<EmptyPass>();
 }

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -23,6 +23,7 @@
 #include <vgc/canvas/documentmanager.h>
 #include <vgc/canvas/experimental.h>
 #include <vgc/core/arithmetic.h> // roundToSignificantDigits
+#include <vgc/core/colors.h>
 #include <vgc/core/profile.h>
 #include <vgc/core/stringid.h>
 #include <vgc/geometry/curve.h>
@@ -1171,6 +1172,8 @@ void Sketch::startCurve_(ui::MouseEvent* event) {
         preTransformPass_ = makePreTransformPass(fitMethod);
         postTransformPass_ = makePostTransformPass(fitMethod);
     }
+    preTransformPass_->setTransformMatrix(transformPass_.transformMatrix());
+    postTransformPass_->setTransformMatrix(transformPass_.transformMatrix());
 
     // Append start point to geometry
     continueCurve_(event);
@@ -1274,7 +1277,6 @@ void Sketch::continueCurve_(ui::MouseEvent* event) {
     inputPoints_.setNumStablePoints(inputPoints_.length());
 
     // Apply all processing steps
-
     preTransformPass_->updateFrom(inputPoints_);
     transformPass_.updateFrom(*preTransformPass_);
     postTransformPass_->updateFrom(transformPass_);

--- a/libs/vgc/tools/sketch.h
+++ b/libs/vgc/tools/sketch.h
@@ -55,6 +55,9 @@ enum class SketchFitMethod : Int8 {
 
     // Fits a sequence of quadratic segments through the input points.
     QuadraticSpline,
+
+    // Blends overlapping local quadratic fits together.
+    QuadraticBlend,
 };
 
 VGC_TOOLS_API

--- a/libs/vgc/tools/sketchpass.h
+++ b/libs/vgc/tools/sketchpass.h
@@ -18,6 +18,7 @@
 #define VGC_TOOLS_SKETCHPASS_H
 
 #include <vgc/core/span.h>
+#include <vgc/geometry/mat3d.h>
 #include <vgc/tools/api.h>
 #include <vgc/tools/sketchpoint.h>
 
@@ -279,6 +280,32 @@ public:
         return output_;
     }
 
+    /// Returns the transform matrix from view coordinates to scene coordinate
+    /// for the currently processed points.
+    ///
+    const geometry::Mat3d& transformMatrix() const {
+        return transform_;
+    }
+
+    /// Sets the transform matrix.
+    ///
+    void setTransformMatrix(const geometry::Mat3d& transform) {
+        transform_ = transform;
+    }
+
+    /// Transforms `v` using the `transformMatrix()`.
+    ///
+    geometry::Vec2d transform(const geometry::Vec2d& v) {
+        return transform_.transform(v);
+    }
+
+    /// Transforms `v` using the `transformMatrix()` interpreted as a 2D affine
+    /// transformation, that is, ignoring the projective components.
+    ///
+    geometry::Vec2d transformAffine(const geometry::Vec2d& v) {
+        return transform_.transformAffine(v);
+    }
+
 protected:
     /// This method should be reimplemented by subclasses if they store
     /// additional state that needs to be reinitialized before processing a new
@@ -296,7 +323,15 @@ protected:
 
 private:
     SketchPointBuffer output_;
+    geometry::Mat3d transform_;
 };
+
+#define VGC_TOOLS_DEBUG_SKETCH_PASS 1
+
+#if VGC_TOOLS_DEBUG_SKETCH_PASS
+
+#else
+#endif
 
 } // namespace vgc::tools
 

--- a/libs/vgc/tools/sketchpass.h
+++ b/libs/vgc/tools/sketchpass.h
@@ -326,13 +326,6 @@ private:
     geometry::Mat3d transform_;
 };
 
-#define VGC_TOOLS_DEBUG_SKETCH_PASS 1
-
-#if VGC_TOOLS_DEBUG_SKETCH_PASS
-
-#else
-#endif
-
 } // namespace vgc::tools
 
 #endif // VGC_TOOLS_SKETCHPASS_H

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -2218,9 +2218,10 @@ std::pair<Int, Int> getProgressiveBlendIndexRange(
 
     constexpr bool allowSharedLastInputIndex = true;
     constexpr Int i2MinOffset = allowSharedLastInputIndex ? 0 : 1;
-    Int i2MaxOffset = isRelativeToStart     //
-                          ? splitOffset + 1 // +1 allows growth
-                          : core::IntMax;
+    std::optional<Int> i2MaxOffset = std::nullopt;
+    if (isRelativeToStart) {
+        i2MaxOffset = splitOffset + 1; // +1 allows growing
+    }
     Int i2Min = i1 + settings_.minFitPoints - 1;
     if (!fits_.isEmpty() && i2Min < fits_.last().lastInputIndex + i2MinOffset) {
         i2Min = fits_.last().lastInputIndex + i2MinOffset;
@@ -2229,19 +2230,19 @@ std::pair<Int, Int> getProgressiveBlendIndexRange(
     if (i2Max > numInputPoints - 1) {
         i2Max = numInputPoints - 1;
     }
-    if (fits_.isEmpty()) {
-        // If there is a maximum offset between an i2 and the next i2, then
-        // we want the first output fit to have numFitPoints <= minFitPoints,
-        // and progressively grow from there.
-        if (i2MaxOffset < core::IntMax) {
+    if (i2MaxOffset) {
+        // If there is a maximum offset between an i2 and the next i2
+        if (fits_.isEmpty()) {
+            // then we want the first output fit to have numFitPoints <= minFitPoints
             if (i2Max > settings_.minFitPoints - 1) {
                 i2Max = settings_.minFitPoints - 1;
             }
         }
-    }
-    else {
-        if (i2Max > fits_.last().lastInputIndex + i2MaxOffset) {
-            i2Max = fits_.last().lastInputIndex + i2MaxOffset;
+        else {
+            // and subsequent fits to progressively grow from there.
+            if (i2Max > fits_.last().lastInputIndex + *i2MaxOffset) {
+                i2Max = fits_.last().lastInputIndex + *i2MaxOffset;
+            }
         }
     }
 

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -2101,7 +2101,7 @@ void addLastGoodFit(
         lastGoodLastInputIndex,
         firstOutputIndex,
         lastOutputIndex,
-        d.bezier});
+        bezier});
 
     Int numInputPoints = lastGoodLastInputIndex - lastGoodFirstInputIndex + 1;
     std::string whitespace(lastGoodFirstInputIndex, ' ');

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -2196,12 +2196,7 @@ void computeDenseProgressiveBlendFits(
     while (!finished()) {
         Int i1 = fits_.last().firstInputIndex;
         Int i2 = fits_.last().lastInputIndex;
-        if (i2 == numInputPoints - 1) {
-            // Reached last input point => cannot grow or move
-            // Note: this is only possible if smallStart is true.
-            shrink(i1, i2);
-        }
-        else if (i2 - i1 + 1 == maxFitPoints) {
+        if (i2 - i1 + 1 == maxFitPoints) {
             if (i2 - i1 + 1 == minFitPoints) {
                 // Fixed fit size => cannot grow or shrink
                 move(i1, i2);

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -26,13 +26,11 @@
 #include <vgc/geometry/catmullrom.h>
 #include <vgc/tools/logcategories.h>
 
-#include <vgc/core/profile.h>
-
 namespace vgc::tools {
 
 namespace {
 
-constexpr bool enableDebugFits = true;
+constexpr bool enableDebugFits = false;
 
 }
 
@@ -2483,8 +2481,6 @@ void computeBlendFits(
     Int& numStableFits,
     detail::FitBuffer& buffer) {
 
-    VGC_PROFILE_FUNCTION
-
     // Remove all previously unstable fits.
     //
     Int oldNumStableFits = numStableFits;
@@ -2563,15 +2559,6 @@ void computeBlendFits(
     // Update cached value for numStableFits.
 
     numStableFits = newNumStableFits;
-
-    VGC_DEBUG_TMP("num stable input points = {}", input.numStablePoints());
-
-    VGC_DEBUG_TMP(
-        "old stable fits = {}, added fits = {}, total = {}, new stable fits = {}",
-        oldNumStableFits,
-        fits.length() - oldNumStableFits,
-        fits.length(),
-        newNumStableFits);
 }
 
 // Improve width by using Catmull-Rom interpolation instead linear by part.
@@ -2727,8 +2714,6 @@ void computeBlendBetweenFits(
     Int numStableFits,
     SketchPointBuffer& output) {
 
-    VGC_PROFILE_FUNCTION
-
     // Remove previously unstable points
     Int oldNumStableOutputPoints = output.numStablePoints();
     Int newNumStableOutputPoints = oldNumStableOutputPoints;
@@ -2883,14 +2868,6 @@ void computeBlendBetweenFits(
     // Update chord-lengths and number of stable output points.
     output.updateChordLengths();
     output.setNumStablePoints(newNumStableOutputPoints);
-
-    VGC_DEBUG_TMP(
-        "old stable output points = {}, added output points = {}, total = {}, new stable "
-        "output points = {}",
-        oldNumStableOutputPoints,
-        output.length() - oldNumStableOutputPoints,
-        output.length(),
-        newNumStableOutputPoints);
 }
 
 void debugFits(
@@ -2950,9 +2927,6 @@ void QuadraticBlendPass::doUpdateFrom(
     SketchPointBuffer& output) {
 
     Int numInputPoints = input.length();
-    VGC_DEBUG_TMP("doUpdateFrom(numInputPoints={})", numInputPoints);
-
-    VGC_PROFILE_FUNCTION
 
     if (handleSmallInputWithFixedEndpoints(input, output)) {
         return;

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -2374,7 +2374,7 @@ std::pair<Int, Int> getSparseBlendIndexRange(
 // e.g, force all output fits to have a fixed number of input point.
 //
 // The terminology "sparse" refers to the fact that the next i1 is computed via
-// the SpitStrategy, therefore the output fits look like:
+// the SplitStrategy, therefore the output fits look like:
 //
 // Input points: .........
 // Output fits:  ----

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -2488,11 +2488,6 @@ void computeBlendFits(
 
     // Compute new fits.
     //
-    using experimental::FitSplitStrategy;
-    using experimental::FitSplitType;
-    const FitSplitStrategy& splitStrategy = settings.splitStrategy;
-    bool isRelativeToStart = splitStrategy.type() == FitSplitType::RelativeToStart;
-    bool isDense = isRelativeToStart && splitStrategy.offset() == 0;
     if (settings.type == experimental::BlendFitType::Dense) {
         computeDenseBlendFits(input, settings, fits, buffer);
     }

--- a/libs/vgc/tools/sketchpasses.cpp
+++ b/libs/vgc/tools/sketchpasses.cpp
@@ -2106,11 +2106,12 @@ void addLastGoodFit(
     Int numInputPoints = lastGoodLastInputIndex - lastGoodFirstInputIndex + 1;
     std::string whitespace(lastGoodFirstInputIndex, ' ');
     std::string dashes(numInputPoints, '-');
-    VGC_DEBUG_TMP(whitespace + dashes);
-    // VGC_DEBUG_TMP(
-    //     "addLastGoodFit(firstInputIndex={}, lastInputIndex={})",
-    //     lastGoodFirstInputIndex,
-    //     lastGoodLastInputIndex);
+    std::string text = core::format( //
+        " {}-{} ({})",
+        lastGoodFirstInputIndex,
+        lastGoodLastInputIndex,
+        numInputPoints);
+    VGC_DEBUG_TMP(whitespace + dashes + text);
 }
 
 } // namespace

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -379,10 +379,6 @@ struct BlendFitInfo {
     geometry::QuadraticBezier2d bezier;
     Int furthestIndex = 0;
     bool isGoodFit = false;
-
-    // Mapping with output points
-    Int firstOutputIndex = 0;
-    Int lastOutputIndex = 0;
 };
 
 } // namespace detail
@@ -394,12 +390,7 @@ struct fmt::formatter<vgc::tools::detail::BlendFitInfo> : fmt::formatter<vgc::In
     template<typename FormatContext>
     auto format(const vgc::tools::detail::BlendFitInfo& i, FormatContext& ctx) {
         return format_to(
-            ctx.out(),
-            "(inFirst={}, inLast={}, outFirst={}, outLast={})",
-            i.firstInputIndex,
-            i.lastInputIndex,
-            i.firstOutputIndex,
-            i.lastOutputIndex);
+            ctx.out(), "(i1={}, i2={})", i.firstInputIndex, i.lastInputIndex);
     }
 };
 
@@ -423,6 +414,7 @@ private:
     experimental::BlendFitSettings settings_;
     core::Array<detail::BlendFitInfo> fits_;
     detail::FitBuffer buffer_;
+    Int numStableFits_ = 0;
 
     // more buffers
     core::DoubleArray lastGoodParams;

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -84,7 +84,8 @@ enum class SplineFitSplitStrategy {
     ///
     Furthest,
 
-    /// Split at the input point which is just before the last input point of the current fit.
+    /// Split at the input point which is just before the last input point of
+    /// the current fit.
     ///
     /// This can be a good choice in interactive use cases where input points
     /// are added one by one, since in this case, having a bad fit for the input
@@ -96,6 +97,14 @@ enum class SplineFitSplitStrategy {
     /// possibly resulting in a slightly worse final result.
     ///
     SecondLast,
+
+    /// Split at the input point which is two points before the last input point
+    /// of the current fit.
+    ///
+    /// This is similar to SecondLast but is sometimes preferrable as it gives
+    /// a bit more overlap between the local fits.
+    ///
+    ThirdLast,
 
     /// Split at a given ratio in terms number of points.
     ///
@@ -269,11 +278,27 @@ struct BlendFitSettings {
 
     /// Where to split a Bézier segment that isn't a good-enough fit.
     ///
-    SplineFitSplitStrategy splitStrategy = SplineFitSplitStrategy::IndexRatio;
+    SplineFitSplitStrategy splitStrategy = SplineFitSplitStrategy::ThirdLast;
 
     /// The ratio to use when `splitStrategy` is `IndexRatio`.
     ///
     double indexRatio = 0.75;
+
+    /// The minimal number of input points used for each local fit. If the
+    /// input has fewer points than this, then the output consists of a single
+    /// fit.
+    ///
+    // TODO: minFitLength for minimal arc-length per local fit?
+    //
+    Int minFitPoints = 5;
+
+    /// The maximal number of input points used for each local fit. If the
+    /// input has fewer points than this, then the output consists of a single
+    /// fit.
+    ///
+    // TODO: maxFitLength for minimal arc-length per local fit?
+    //
+    Int maxFitPoints = 5;
 };
 
 } // namespace experimental

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -313,6 +313,7 @@ struct BlendFitInfo {
     Int lastInputIndex;
     Int firstOutputIndex;
     Int lastOutputIndex;
+    Int furthestIndex;
     geometry::QuadraticBezier2d bezier;
 };
 

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -83,15 +83,6 @@ struct FitBuffer {
     core::DoubleArray params;
 };
 
-// Info about the mapping between input points and output points
-// of one of the fit part of a recursive fit.
-//
-struct FitInfo {
-    Int lastInputIndex;
-    Int lastOutputIndex;
-    geometry::QuadraticBezier2d bezier;
-};
-
 } // namespace detail
 
 class VGC_TOOLS_API SingleQuadraticSegmentWithFixedEndpointsPass : public SketchPass {
@@ -199,6 +190,31 @@ struct SplineFitSettings {
 
 } // namespace experimental
 
+namespace detail {
+
+// Info about the mapping between input points and output points
+// of one of the fit part of a recursive fit.
+//
+struct SplineFitInfo {
+    Int lastInputIndex;
+    Int lastOutputIndex;
+    geometry::QuadraticBezier2d bezier;
+};
+
+} // namespace detail
+
+} // namespace vgc::tools
+
+template<>
+struct fmt::formatter<vgc::tools::detail::SplineFitInfo> : fmt::formatter<vgc::Int> {
+    template<typename FormatContext>
+    auto format(const vgc::tools::detail::SplineFitInfo& i, FormatContext& ctx) {
+        return format_to(ctx.out(), "({}, {})", i.lastInputIndex, i.lastOutputIndex);
+    }
+};
+
+namespace vgc::tools {
+
 class VGC_TOOLS_API QuadraticSplinePass : public SketchPass {
 public:
     QuadraticSplinePass();
@@ -215,18 +231,127 @@ protected:
 
 private:
     experimental::SplineFitSettings settings_;
-    core::Array<detail::FitInfo> info_;
+    core::Array<detail::SplineFitInfo> info_;
     detail::FitBuffer buffer_;
 };
+
+namespace experimental {
+
+struct BlendFitSettings {
+
+    /// The number of output points (excluding the first) to generate
+    /// for each quadratic Bézier segment in the spline.
+    ///
+    Int numOutputPointsPerBezier = 8;
+
+    /// How far from a Bézier fit are the input points allowed to be
+    /// for the fit to be considered a good fit.
+    ///
+    /// The distance is expressed in the same unit as the input points
+    /// coordinates, which is typically screen physical pixels.
+    ///
+    double distanceThreshold = 1.8;
+
+    /// Whether to always pre-emptively split the last good fit into two fits.
+    ///
+    /// This tends to reduce flickering when sketching, since when a new input
+    /// point is added, if the last fit now needs to be split, the new result
+    /// will be more similar to the previous result.
+    ///
+    /// It is recommended to set this to false if `splitStrategy` is
+    /// `SecondLast`.
+    ///
+    bool splitLastGoodFitOnce = true;
+
+    /// How "flat" should a quadratic Bézier segment be in order to be considered
+    /// a good fit. It is computed as the ratio between the length of (B2-B0) and the
+    /// length of 2*(B0-2B1+B2) (= the second derivative of the quadratic Bézier).
+    ///
+    /// This prevents outputting quadratic Bézier segments with too high a
+    /// curvature, which may be undesirable.
+    ///
+    /// A value of 1 corresponds to the following quadratic Bézier segment:
+    /// - B0 = (0, 0)
+    /// - B1 = (2, 1)
+    /// - B2 = (4, 0)
+    ///
+    /// A value of -1 disables the flatness threshold.
+    ///
+    double flatnessThreshold = -1;
+
+    /// The minimum number of input points required before the flatness
+    /// threshold is used.
+    ///
+    /// This is useful since when there are very few input points (e.g., 3
+    /// points), then it is typically preferable to have one high-curvature
+    /// segment rather than splitting it further into several segments.
+    ///
+    Int flatnessThresholdMinPoints = 4;
+
+    /// Where to split a Bézier segment that isn't a good-enough fit.
+    ///
+    SplineFitSplitStrategy splitStrategy = SplineFitSplitStrategy::IndexRatio;
+
+    /// The ratio to use when `splitStrategy` is `IndexRatio`.
+    ///
+    double indexRatio = 0.67;
+};
+
+} // namespace experimental
+
+namespace detail {
+
+// Info about the mapping between input points and output points
+// of one of the fit part of a recursive fit.
+//
+struct BlendFitInfo {
+    Int firstInputIndex;
+    Int lastInputIndex;
+    Int firstOutputIndex;
+    Int lastOutputIndex;
+    geometry::QuadraticBezier2d bezier;
+};
+
+} // namespace detail
 
 } // namespace vgc::tools
 
 template<>
-struct fmt::formatter<vgc::tools::detail::FitInfo> : fmt::formatter<vgc::Int> {
+struct fmt::formatter<vgc::tools::detail::BlendFitInfo> : fmt::formatter<vgc::Int> {
     template<typename FormatContext>
-    auto format(const vgc::tools::detail::FitInfo& i, FormatContext& ctx) {
-        return format_to(ctx.out(), "({}, {})", i.lastInputIndex, i.lastOutputIndex);
+    auto format(const vgc::tools::detail::BlendFitInfo& i, FormatContext& ctx) {
+        return format_to(
+            ctx.out(),
+            "(inFirst={}, inLast={}, outFirst={}, outLast={})",
+            i.firstInputIndex,
+            i.lastInputIndex,
+            i.firstOutputIndex,
+            i.lastOutputIndex);
     }
 };
+
+namespace vgc::tools {
+
+class VGC_TOOLS_API QuadraticBlendPass : public SketchPass {
+public:
+    QuadraticBlendPass();
+
+    /// A constructor with manually specified experimental settings.
+    ///
+    /// This is not considered stable API and may change at any time.
+    ///
+    explicit QuadraticBlendPass(const experimental::BlendFitSettings& settings);
+
+protected:
+    void doReset() override;
+    void doUpdateFrom(const SketchPointBuffer& input, SketchPointBuffer& output) override;
+
+private:
+    experimental::BlendFitSettings settings_;
+    core::Array<detail::BlendFitInfo> info_;
+    detail::FitBuffer buffer_;
+};
+
+} // namespace vgc::tools
 
 #endif // VGC_TOOLS_SKETCHPASSES_H

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -383,6 +383,29 @@ struct BlendFitSettings {
     ///
     Int maxFitPoints = 50;
 
+    // This is only used if `type` is `Dense`.
+    //
+    // Having the first fit be the largest possible good fit is usually not a
+    // good idea for dense fits, since this means that there would only be a
+    // single fit covering the first input point, and a possibly unaesthetic
+    // transition between the first and second fit (which would start at the
+    // second input point). The same reasoning also applies at the end of the
+    // curve.
+    //
+    // This setting solves this problem by enforcing that the first input point
+    // and the last input point are covered by at least a certain number of
+    // fits, whenever possible. A value of at least 3 typically reduce
+    // flickering and makes the curve ends look smoother.
+    //
+    // It is also possible to set numStartFits = IntMax to enforce that the
+    // first and last fit always have a size equal to `minFitPoints` (or equal
+    // to the number of input points, whichever is smaller), but this is
+    // usually not recommended since using small fits is prone to overfitting,
+    // which also tends to cause flickering and cause curve ends to be less
+    // smooth than the middle of the curve.
+    //
+    Int numStartFits = 5;
+
     /// The target arclength distance between samples that is used when
     /// computing the blend between local fits as a uniform sampling.
     ///

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -335,7 +335,7 @@ struct BlendFitSettings {
 
     /// Where to split a Bézier segment that isn't a good-enough fit.
     ///
-    FitSplitStrategy splitStrategy = FitSplitStrategy::indexRatio(0.4);
+    FitSplitStrategy splitStrategy = FitSplitStrategy::indexRatio(0.25);
 
     /// The minimal number of input points used for each local fit. If the
     /// input has fewer points than this, then the output consists of a single

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -18,7 +18,6 @@
 #define VGC_TOOLS_SKETCHPASSES_H
 
 #include <vgc/geometry/bezier.h>
-#include <vgc/geometry/mat3d.h>
 #include <vgc/tools/api.h>
 #include <vgc/tools/sketchpass.h>
 
@@ -30,28 +29,8 @@ protected:
 };
 
 class VGC_TOOLS_API TransformPass : public SketchPass {
-public:
-    const geometry::Mat3d& transformMatrix() const {
-        return transform_;
-    }
-
-    void setTransformMatrix(const geometry::Mat3d& transform) {
-        transform_ = transform;
-    }
-
-    geometry::Vec2d transform(const geometry::Vec2d& v) {
-        return transform_.transform(v);
-    }
-
-    geometry::Vec2d transformAffine(const geometry::Vec2d& v) {
-        return transform_.transformAffine(v);
-    }
-
 protected:
     void doUpdateFrom(const SketchPointBuffer& input, SketchPointBuffer& output) override;
-
-private:
-    geometry::Mat3d transform_;
 };
 
 class VGC_TOOLS_API SmoothingPass : public SketchPass {

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -90,6 +90,10 @@ enum class FitSplitType {
     /// to exaustively compute all overlapping fits of a given size, you
     /// can use RelativeToStart with an offset of 1.
     ///
+    /// Using RelativeToStart with an offset of 0 has the special meaning to
+    /// allow a fit to start at the same point than the previous fit, as long
+    /// as the fit ends strictly after the previous fit and is a good fit.
+    ///
     RelativeToStart,
 
     /// Split at an index relative to the end point of the current fit.
@@ -335,7 +339,7 @@ struct BlendFitSettings {
 
     /// Where to split a Bézier segment that isn't a good-enough fit.
     ///
-    FitSplitStrategy splitStrategy = FitSplitStrategy::indexRatio(0.25);
+    FitSplitStrategy splitStrategy = FitSplitStrategy::relativeToStart(0);
 
     /// The minimal number of input points used for each local fit. If the
     /// input has fewer points than this, then the output consists of a single

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -327,6 +327,12 @@ struct BlendFitSettings {
     /// The distance is expressed in the same unit as the input points
     /// coordinates, which is typically screen physical pixels.
     ///
+    /// A value around 1.2 tends to work well for input rounded to integer
+    /// pixel values (typically mouse input) as it is large enough to smooth
+    /// out quantization artifacts. A smaller value (e.g., 0.5) can be used
+    /// when the input has sub-pixel precision, resulting in a more precise
+    /// output preserving more detail.
+    ///
     double distanceThreshold = 1.2;
 
     /// How "flat" should a quadratic Bézier segment be in order to be considered

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -316,6 +316,10 @@ struct BlendFitInfo {
     Int firstInputIndex = 0;
     Int lastInputIndex = 0;
 
+    // Chord-length of first and last input points
+    double s1 = 0;
+    double s2 = 0;
+
     // Best fit
     geometry::QuadraticBezier2d bezier;
     Int furthestIndex = 0;

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -250,7 +250,7 @@ struct BlendFitSettings {
     /// The distance is expressed in the same unit as the input points
     /// coordinates, which is typically screen physical pixels.
     ///
-    double distanceThreshold = 1.8;
+    double distanceThreshold = 1.2;
 
     /// Whether to always pre-emptively split the last good fit into two fits.
     ///
@@ -261,7 +261,7 @@ struct BlendFitSettings {
     /// It is recommended to set this to false if `splitStrategy` is
     /// `SecondLast`.
     ///
-    bool splitLastGoodFitOnce = true;
+    bool splitLastGoodFitOnce = false;
 
     /// How "flat" should a quadratic Bézier segment be in order to be considered
     /// a good fit. It is computed as the ratio between the length of (B2-B0) and the
@@ -294,7 +294,7 @@ struct BlendFitSettings {
 
     /// The ratio to use when `splitStrategy` is `IndexRatio`.
     ///
-    double indexRatio = 0.67;
+    double indexRatio = 0.75;
 };
 
 } // namespace experimental
@@ -350,6 +350,9 @@ private:
     experimental::BlendFitSettings settings_;
     core::Array<detail::BlendFitInfo> info_;
     detail::FitBuffer buffer_;
+
+    // more buffers
+    core::DoubleArray lastGoodParams;
 };
 
 } // namespace vgc::tools

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -286,11 +286,6 @@ namespace experimental {
 
 struct BlendFitSettings {
 
-    /// The number of output points (excluding the first) to generate
-    /// for each quadratic Bézier segment in the spline.
-    ///
-    Int numOutputPointsPerBezier = 8;
-
     /// How far from a Bézier fit are the input points allowed to be
     /// for the fit to be considered a good fit.
     ///
@@ -298,19 +293,6 @@ struct BlendFitSettings {
     /// coordinates, which is typically screen physical pixels.
     ///
     double distanceThreshold = 1.2;
-
-    /*
-    /// Whether to always pre-emptively split the last good fit into two fits.
-    ///
-    /// This tends to reduce flickering when sketching, since when a new input
-    /// point is added, if the last fit now needs to be split, the new result
-    /// will be more similar to the previous result.
-    ///
-    /// It is recommended to set this to false if `splitStrategy` is
-    /// `SecondLast`.
-    ///
-    bool splitLastGoodFitOnce = false;
-    */
 
     /// How "flat" should a quadratic Bézier segment be in order to be considered
     /// a good fit. It is computed as the ratio between the length of (B2-B0) and the
@@ -345,17 +327,25 @@ struct BlendFitSettings {
     /// input has fewer points than this, then the output consists of a single
     /// fit.
     ///
-    // TODO: minFitLength for minimal arc-length per local fit?
-    //
+    /// Using a value of 4 or greater is recommended to avoid overfitting
+    /// (there always exists a quadratic going exactly through 3 given points).
+    ///
     Int minFitPoints = 5;
 
     /// The maximal number of input points used for each local fit. If the
-    /// input has fewer points than this, then the output consists of a single
-    /// fit.
+    /// input has more points than this, then several local fits are used even
+    /// if the whole input can be well-approximated by a single fit.
     ///
-    // TODO: maxFitLength for minimal arc-length per local fit?
-    //
+    /// This ensures that the unstable part of the curve stays under a
+    /// reasonable size, improving performance and locality (each input point
+    /// should not affect input points that are far away).
+    ///
     Int maxFitPoints = 50;
+
+    /// The target arclength distance between samples that is used when
+    /// computing the blend between local fits as a uniform sampling.
+    ///
+    double ds = 3.0;
 };
 
 } // namespace experimental

--- a/libs/vgc/tools/sketchpasses.h
+++ b/libs/vgc/tools/sketchpasses.h
@@ -240,6 +240,7 @@ struct BlendFitSettings {
     ///
     double distanceThreshold = 1.2;
 
+    /*
     /// Whether to always pre-emptively split the last good fit into two fits.
     ///
     /// This tends to reduce flickering when sketching, since when a new input
@@ -250,6 +251,7 @@ struct BlendFitSettings {
     /// `SecondLast`.
     ///
     bool splitLastGoodFitOnce = false;
+    */
 
     /// How "flat" should a quadratic Bézier segment be in order to be considered
     /// a good fit. It is computed as the ratio between the length of (B2-B0) and the
@@ -309,12 +311,19 @@ namespace detail {
 // of one of the fit part of a recursive fit.
 //
 struct BlendFitInfo {
-    Int firstInputIndex;
-    Int lastInputIndex;
-    Int firstOutputIndex;
-    Int lastOutputIndex;
-    Int furthestIndex;
+
+    // Input points
+    Int firstInputIndex = 0;
+    Int lastInputIndex = 0;
+
+    // Best fit
     geometry::QuadraticBezier2d bezier;
+    Int furthestIndex = 0;
+    bool isGoodFit = false;
+
+    // Mapping with output points
+    Int firstOutputIndex = 0;
+    Int lastOutputIndex = 0;
 };
 
 } // namespace detail
@@ -353,7 +362,7 @@ protected:
 
 private:
     experimental::BlendFitSettings settings_;
-    core::Array<detail::BlendFitInfo> info_;
+    core::Array<detail::BlendFitInfo> fits_;
     detail::FitBuffer buffer_;
 
     // more buffers


### PR DESCRIPTION
#1147

This is a new method for removing quantization artifacts and smoother the input based on averaging overlapping local fits. It is similar to what is done in VPaint, but improved by using adaptive fit sizes, and using the more accurate quadratic best fit implemented earlier.