### PR TITLE
Implement formatter for SketchPoint (#1191)

### DIFF
--- a/libs/vgc/tools/sketchpoint.h
+++ b/libs/vgc/tools/sketchpoint.h
@@ -280,4 +280,19 @@ using SketchPointArray = core::Array<SketchPoint>;
 
 } // namespace vgc::tools
 
+template<>
+struct fmt::formatter<vgc::tools::SketchPoint> : fmt::formatter<double> {
+    template<typename FormatContext>
+    auto format(const vgc::tools::SketchPoint& p, FormatContext& ctx) {
+        return format_to(
+            ctx.out(),
+            "(p={}, pr={} t={}, w={}, s={})",
+            p.position(),
+            p.pressure(),
+            p.timestamp(),
+            p.width(),
+            p.s());
+    }
+};
+
 #endif // VGC_TOOLS_SKETCHPOINT_H


### PR DESCRIPTION
#1191

This is useful for debugging sketch passes, e.g.: `VGC_DEBUG_TMP_EXPR(input.data())`