### PR TITLE
Fix self-snapping (sketching closed edges) not working reliably (#1148)

### DIFF
--- a/libs/vgc/tools/sketch.h
+++ b/libs/vgc/tools/sketch.h
@@ -260,6 +260,7 @@ protected:
 
     VertexInfo* searchVertexInfo_(core::Id itemId);
     void appendVertexInfo_(const geometry::Vec2d& position, core::Id itemId);
+    void updateVertexInfo_(const geometry::Vec2d& position, core::Id itemId);
 
     EdgeInfo* searchEdgeInfo_(core::Id itemId);
     // void appendEdgeInfo_(); when adding a vertex on cut.


### PR DESCRIPTION
#1148

The issue was that snap detection uses the selection mechanism in order to avoid snapping to vertices that are occluded by faces.

This selection mechanism requires providing an input position and a distance threshold. For snapping, we use:
- input position = the position of the snap candidate vertex
- threshold = `snapDistance * core::epsilon`. 

The problem was that due to caching vertex positions in `vertexInfos_`, in the case of the start vertex of the currently sketched edge, we were actually not giving as input position the current vertex position, but the initial position it was given in `startCurve_(event)`. But in `continueCurve_()`, the start vertex position may be updated by the processing passes, including performing some rounding. This was done here:

https://github.com/vgc/vgc/pull/1774

Because `snapDistance * core::epsilon` was smaller than the rounding, the start vertex was considered not selectable at the given input position.

The fix is of course to correctly update the cache in `vertexInfos_` if/when the position of the start vertex changes.

This changes also make another related fix: the start vertex appeared twice in `vertexInfos_` when there was a start snap vertex.