### PR TITLE
Remove smoothing from preprocessing enum: redundant with smoothing pass (#1147)

### DIFF
--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -171,7 +171,6 @@ VGC_DEFINE_ENUM( //
     SketchPreprocessing,
     (Default, "Default (Quadratic Blend)"),
     (NoPreprocessing, "No Preprocessing"),
-    (IndexGaussianSmoothing, "Index-Based Gaussian Smoothing"),
     (DouglasPeucker, "Douglas-Peucker"),
     (SingleLineSegmentWithFixedEndpoints, "Single Line Segment (Fixed Endpoints)"),
     (SingleLineSegmentWithFreeEndpoints, "Single Line Segment (Free Endpoints)"),
@@ -246,9 +245,6 @@ void SketchModule::setupPipeline(SketchPipeline& pipeline) {
         // We add an empty pass rather than not adding a pass
         // to keep the memory cache of following passes
         replaceOrAdd<EmptyPass>(pipeline, i++);
-        break;
-    case SketchPreprocessing::IndexGaussianSmoothing:
-        replaceOrAdd<SmoothingPass>(pipeline, i++);
         break;
     case SketchPreprocessing::DouglasPeucker:
         replaceOrAdd<DouglasPeuckerPass>(pipeline, i++);

--- a/libs/vgc/tools/sketch.h
+++ b/libs/vgc/tools/sketch.h
@@ -39,9 +39,6 @@ enum class SketchPreprocessing : Int8 {
     // The input points are used as is as control points.
     NoPreprocessing,
 
-    // A gaussian smoothing is applied to the input points.
-    IndexGaussianSmoothing,
-
     // The Douglas-Peucker algorithm is used to discard some of the input
     // points.
     DouglasPeucker,


### PR DESCRIPTION
#1147