### PR TITLE
Fix Experimental panel becomes empty after closing/reopening it (#1810)

### DIFF
--- a/libs/vgc/canvas/experimental.h
+++ b/libs/vgc/canvas/experimental.h
@@ -93,6 +93,9 @@ private:
 
     void onModuleWidgetAdded_(ui::Widget& widget);
     VGC_SLOT(onModuleWidgetAdded_)
+
+    void onAboutToBeDestroyed_();
+    VGC_SLOT(onAboutToBeDestroyed_)
 };
 
 } // namespace vgc::canvas


### PR DESCRIPTION
#1810