### PR TITLE
[skip ci] Fix 'conclusiont' typo in clang-format action (#1825)

### DIFF
--- a/.github/workflows/clang-format-comment.yml
+++ b/.github/workflows/clang-format-comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      - name: Print conclusiont
+      - name: Print conclusion
         run: echo ${{ github.event.workflow_run.conclusion }}
 
       - name: Download artifacts


### PR DESCRIPTION
#1825