### PR TITLE
More consistent usage of github.workspace vs GITHUB_WORKSPACE in actions (#1825)

### DIFF
--- a/.github/workflows/clang-format-comment.yml
+++ b/.github/workflows/clang-format-comment.yml
@@ -33,7 +33,7 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/clang_format_artifacts.zip', Buffer.from(download.data));
+            fs.writeFileSync('$GITHUB_WORKSPACE/clang_format_artifacts.zip', Buffer.from(download.data));
       - run: unzip clang_format_artifacts.zip
 
       - name: Comment on PR

--- a/.github/workflows/linuxbuild.yml
+++ b/.github/workflows/linuxbuild.yml
@@ -98,7 +98,12 @@ jobs:
         mkdir build
         cd build
         cmake --version
-        cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DVGC_COMMIT_BRANCH="$COMMIT_BRANCH" -DQt5_DIR="/opt/qt/$QT_VERSION/gcc_64/lib/cmake/Qt5" -DVGC_PEDANTIC=ON -DVGC_WERROR=ON
+        cmake .. \
+          -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+          -DVGC_COMMIT_BRANCH="$COMMIT_BRANCH" \
+          -DQt5_DIR="/opt/qt/$QT_VERSION/gcc_64/lib/cmake/Qt5" \
+          -DVGC_PEDANTIC=ON \
+          -DVGC_WERROR=ON
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/macosbuild.yml
+++ b/.github/workflows/macosbuild.yml
@@ -86,30 +86,35 @@ jobs:
         setup-python: false
 
     - name: Install other dependencies
-      working-directory: ${{runner.workspace}}
+      working-directory: ${{github.workspace}}
       run: |
         brew install freetype
         brew install harfbuzz
         pip install dmgbuild
 
     - name: Configure
-      working-directory: ${{runner.workspace}}
+      working-directory: ${{github.workspace}}
       run: |
         mkdir build
         cd build
         cmake --version
-        cmake "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DVGC_COMMIT_BRANCH="$COMMIT_BRANCH" -DPython_ROOT_DIR="$pythonLocation" -DQt5_DIR="${{runner.workspace}}/Qt/$QT_VERSION/clang_64/lib/cmake/Qt5" -DVGC_PEDANTIC=ON -DVGC_WERROR=ON
+        cmake .. \
+          -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+          -DVGC_COMMIT_BRANCH="$COMMIT_BRANCH" \
+          -DPython_ROOT_DIR="$pythonLocation" \
+          -DQt5_DIR="$GITHUB_WORKSPACE/Qt/$QT_VERSION/clang_64/lib/cmake/Qt5" \
+          -DVGC_PEDANTIC=ON -DVGC_WERROR=ON
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{github.workspace}}/build
       run: cmake --build . --parallel $PARALLEL_JOBS
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{github.workspace}}/build
       run: cmake --build . --target check --parallel $PARALLEL_JOBS
 
     - name: Deploy
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{github.workspace}}/build
       env:
         VGC_GITHUB_KEY: ${{secrets.VGC_GITHUB_KEY}}
       run: cmake --build . --target deploy --parallel $PARALLEL_JOBS

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Configure vckpg
       working-directory: ${{github.workspace}}
       run: |
-        PARENT="${{github.workspace}}"
+        PARENT="$GITHUB_WORKSPACE"
         echo "VCPKG_ROOT_PARENT=$PARENT" >> $GITHUB_ENV
         echo "VCPKG_ROOT=$PARENT/vcpkg" >> $GITHUB_ENV
         echo "VCPKG_TOOLCHAIN_FILE=$PARENT/vcpkg/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
@@ -128,7 +128,7 @@ jobs:
       working-directory: ${{env.VCPKG_ROOT}}
       run: |
         # Delete manifest file, otherwise, we cannot manually install packages
-        rm "${{github.workspace}}/vcpkg.json"
+        rm "$GITHUB_WORKSPACE/vcpkg.json"
 
         # Create custom triplet that only compile binaries with the given VCPKG_BUILD_TYPE
         mkdir "$VCPKG_OVERLAY_TRIPLETS"


### PR DESCRIPTION
#1825

The idea is to only use `${{github.workspace}}` for the `working-directory` field, and only use `$GITHUB_WORKSPACE` in the `run` script, due to inconsistencies between the two when running in a container.

See comment in the Linux action:

```
    # https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables
    #
    # Note: in a Docker container, we have:
    # - ${{github.workspace}} = /home/runner/work/test-cpp-github-actions/test-cpp-github-actions
    # - $GITHUB_WORKSPACE     = /__w/test-cpp-github-actions/test-cpp-github-actions
    #
    # It's best to use ${{github.workspace}} in `working-directory`, and $GITHUB_WORKSPACE in `run`
    #
```

Also see:
- https://github.com/actions/checkout/issues/785