### PR TITLE
Rename GitHub build actions and jobs (#1825)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: Linux Build
+name: Linux
 
 on: [push, pull_request]
 
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     container: vgcsoftware/vgc-ci-ubuntu-18.04:2023-03-08.0
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: macOS Build
+name: macOS
 
 on: [push, pull_request]
 
@@ -15,6 +15,7 @@ defaults:
 
 jobs:
   build:
+    name: Build
     runs-on: macos-12
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Windows Build
+name: Windows
 
 on: [push, pull_request]
 
@@ -18,6 +18,7 @@ defaults:
 
 jobs:
   build:
+    name: Build
     runs-on: windows-2019
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![VGC](https://github.com/vgc/vgc/blob/master/hero.png)
 
-[![Windows Build](https://github.com/vgc/vgc/actions/workflows/windowsbuild.yml/badge.svg?branch=master&event=push)](https://github.com/vgc/vgc/actions/workflows/windowsbuild.yml)
-[![macOS Build](https://github.com/vgc/vgc/actions/workflows/macosbuild.yml/badge.svg?branch=master&event=push)](https://github.com/vgc/vgc/actions/workflows/macosbuild.yml)
-[![Linux Build](https://github.com/vgc/vgc/actions/workflows/linuxbuild.yml/badge.svg?branch=master&event=push)](https://github.com/vgc/vgc/actions/workflows/linuxbuild.yml)
+[![Windows Build](https://github.com/vgc/vgc/actions/workflows/windows.yml/badge.svg?branch=master&event=push)](https://github.com/vgc/vgc/actions/workflows/windows.yml)
+[![macOS Build](https://github.com/vgc/vgc/actions/workflows/macos.yml/badge.svg?branch=master&event=push)](https://github.com/vgc/vgc/actions/workflows/macos.yml)
+[![Linux Build](https://github.com/vgc/vgc/actions/workflows/linux.yml/badge.svg?branch=master&event=push)](https://github.com/vgc/vgc/actions/workflows/linuxb.yml)
 
 VGC is an upcoming suite of applications for graphic design and 2D animation,
 in which the lines and shapes you draw are connected to each others both in


### PR DESCRIPTION
#1825

This prepares having separate Build and Deploy jobs (to allow only re-running Deploy if it fails).

The new name also removes the redundant "build" work in the GitHub interface:

![image](https://github.com/user-attachments/assets/fa365d27-9fee-4aba-be7f-3043fe928e8a)

which now appears like:

![image](https://github.com/user-attachments/assets/6b06d989-fb5a-481e-8400-b7b9c0cc9c8f)
