### PR TITLE
Implement minimal working Auto-Cut between sketched edges (#1815)

### DIFF
--- a/libs/vgc/tools/CMakeLists.txt
+++ b/libs/vgc/tools/CMakeLists.txt
@@ -7,6 +7,7 @@ vgc_add_library(tools
 
     CPP_HEADER_FILES
         api.h
+        autocut.h
         colorpalette.h
         copypaste.h
         currentcolor.h
@@ -25,6 +26,7 @@ vgc_add_library(tools
         transform.h
 
     CPP_SOURCE_FILES
+        autocut.cpp
         colorpalette.cpp
         copypaste.cpp
         currentcolor.cpp

--- a/libs/vgc/tools/autocut.cpp
+++ b/libs/vgc/tools/autocut.cpp
@@ -1,0 +1,31 @@
+// Copyright 2024 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vgc/tools/autocut.h>
+
+#include <vgc/core/array.h>
+#include <vgc/vacomplex/cell.h>
+
+using vgc::vacomplex::KeyEdge;
+using vgc::vacomplex::KeyFace;
+using vgc::vacomplex::KeyVertex;
+
+namespace vgc::tools {
+
+void autoCut(KeyEdge* edge, const AutoCutParams& params) {
+}
+
+} // namespace vgc::tools

--- a/libs/vgc/tools/autocut.cpp
+++ b/libs/vgc/tools/autocut.cpp
@@ -26,15 +26,29 @@ namespace vgc::tools {
 
 namespace {
 
-core::Array<geometry::CurveParameter> computeSelfIntersections(vacomplex::KeyEdge* edge) {
+struct IntersectionParameters {
+    geometry::CurveParameter param1;
+    geometry::CurveParameter param2;
+};
+
+bool isStartOrEnd(vacomplex::KeyEdge* edge, const geometry::CurveParameter& param) {
+    if (edge->isClosed()) {
+        return false;
+    }
+    else {
+        return param == edge->stroke()->startParameter()
+               || param == edge->stroke()->endParameter();
+    }
+}
+
+core::Array<IntersectionParameters> computeSelfIntersections(vacomplex::KeyEdge* edge) {
 
     const geometry::AbstractStroke2d* stroke = edge->stroke();
     const geometry::StrokeSampling2d& sampling = edge->strokeSampling();
     const geometry::StrokeSample2dArray& samples = sampling.samples();
-    core::Array<geometry::CurveParameter> res;
 
-    //geometry::CurveParameter startParam = stroke->startParameter();
-    //geometry::CurveParameter endParam = stroke->endParameter();
+    core::Array<IntersectionParameters> res;
+
     Int n = samples.length();
     for (Int i = 0; i < n - 1; ++i) {
         Int jEnd = n - 1;
@@ -59,9 +73,9 @@ core::Array<geometry::CurveParameter> computeSelfIntersections(vacomplex::KeyEdg
                 geometry::CurveParameter param1 = stroke->resolveParameter(sParam1);
                 geometry::CurveParameter param2 = stroke->resolveParameter(sParam2);
 
-                res.append(param1);
-                res.append(param2);
-
+                if (!(isStartOrEnd(edge, param1) || isStartOrEnd(edge, param2))) {
+                    res.append(IntersectionParameters{param1, param2});
+                }
                 // TODO: handle special case when params are exactly equal to
                 // startParam/endParam for open edges? What if some params are
                 // exactly equal? Do we still want to cut twice?
@@ -71,28 +85,140 @@ core::Array<geometry::CurveParameter> computeSelfIntersections(vacomplex::KeyEdg
     return res;
 }
 
+core::Array<IntersectionParameters>
+computeIntersections(vacomplex::KeyEdge* edge1, vacomplex::KeyEdge* edge2) {
+
+    if (!edge1->boundingBox().intersects(edge2->boundingBox())) {
+        return {};
+    }
+
+    const geometry::AbstractStroke2d* stroke1 = edge1->stroke();
+    const geometry::StrokeSampling2d& sampling1 = edge1->strokeSampling();
+    const geometry::StrokeSample2dArray& samples1 = sampling1.samples();
+
+    const geometry::AbstractStroke2d* stroke2 = edge2->stroke();
+    const geometry::StrokeSampling2d& sampling2 = edge2->strokeSampling();
+    const geometry::StrokeSample2dArray& samples2 = sampling2.samples();
+
+    core::Array<IntersectionParameters> res;
+
+    Int n1 = samples1.length();
+    Int n2 = samples2.length();
+    for (Int i1 = 0; i1 < n1 - 1; ++i1) {
+        for (Int i2 = 0; i2 < n2 - 1; ++i2) {
+
+            const geometry::Vec2d& a1 = samples1[i1].position();
+            const geometry::Vec2d& b1 = samples1[i1 + 1].position();
+            const geometry::Vec2d& a2 = samples2[i2].position();
+            const geometry::Vec2d& b2 = samples2[i2 + 1].position();
+            if (auto intersection = fastSegmentIntersection(a1, b1, a2, b2)) {
+
+                const geometry::CurveParameter& p1 = samples1[i1].parameter();
+                const geometry::CurveParameter& q1 = samples1[i1 + 1].parameter();
+                const geometry::CurveParameter& p2 = samples2[i2].parameter();
+                const geometry::CurveParameter& q2 = samples2[i2 + 1].parameter();
+
+                geometry::SampledCurveParameter sParam1(p1, q1, intersection->t1());
+                geometry::SampledCurveParameter sParam2(p2, q2, intersection->t2());
+                geometry::CurveParameter param1 = stroke1->resolveParameter(sParam1);
+                geometry::CurveParameter param2 = stroke2->resolveParameter(sParam2);
+
+                if (!(isStartOrEnd(edge1, param1) || isStartOrEnd(edge2, param2))) {
+                    res.append(IntersectionParameters{param1, param2});
+                }
+                // TODO: handle special case when params are exactly equal to
+                // startParam/endParam for open edges? What if some params are
+                // exactly equal? Do we still want to cut twice?
+            }
+        }
+    }
+    return res;
+}
+
+using CurveParameterArray = core::Array<geometry::CurveParameter>;
+
+// Stores at what params should a given edge be cut, as well as the result of
+// the cut operation.
+//
+struct CutInfo {
+    CurveParameterArray params;
+    vacomplex::CutEdgeResult res;
+};
+
+// Stores the information that the `index1` cut vertex of `edge1` should be
+// glued with the `index2` cut vertex of `edge2`.
+//
+struct GlueInfo {
+    vacomplex::KeyEdge* edge1;
+    Int index1;
+    vacomplex::KeyEdge* edge2;
+    Int index2;
+};
+
 } // namespace
 
 void autoCut(vacomplex::KeyEdge* edge, const AutoCutParams& params) {
 
+    std::unordered_map<vacomplex::KeyEdge*, CutInfo> cutInfos;
+    core::Array<GlueInfo> glueInfos;
+
     // Compute self-intersections.
     //
-    core::Array<geometry::CurveParameter> selfIntersections;
     if (params.cutItself()) {
-        selfIntersections = computeSelfIntersections(edge);
+        auto intersections = computeSelfIntersections(edge);
+        CurveParameterArray& cutParams = cutInfos[edge].params;
+        cutParams.reserve(intersections.length() * 2);
+        for (const IntersectionParameters& intersection : intersections) {
+            Int n = cutParams.length();
+            cutParams.append(intersection.param1);
+            cutParams.append(intersection.param2);
+            glueInfos.append(GlueInfo{edge, n, edge, n + 1});
+        }
     }
 
-    // Cut the edge.
+    // Compute intersections with other edges.
     //
-    vacomplex::CutEdgeResult cutEdgeRes =
-        vacomplex::ops::cutEdge(edge, selfIntersections);
+    if (params.cutEdges()) {
+        vacomplex::KeyEdge* edge1 = edge;
+        for (vacomplex::Node* node : *edge1->parentGroup()) {
+            if (vacomplex::Cell* cell = node->toCell()) {
+                if (vacomplex::KeyEdge* edge2 = cell->toKeyEdge()) {
+                    if (edge2 != edge1) {
+                        auto intersections = computeIntersections(edge1, edge2);
+                        if (intersections.isEmpty()) {
+                            continue;
+                        }
+                        CurveParameterArray& cutParams1 = cutInfos[edge1].params;
+                        CurveParameterArray& cutParams2 = cutInfos[edge2].params;
+                        cutParams1.reserve(cutParams1.length() + intersections.length());
+                        cutParams2.reserve(cutParams2.length() + intersections.length());
+                        for (const IntersectionParameters& intersection : intersections) {
+                            Int n1 = cutParams1.length();
+                            Int n2 = cutParams2.length();
+                            cutParams1.append(intersection.param1);
+                            cutParams2.append(intersection.param2);
+                            glueInfos.append(GlueInfo{edge1, n1, edge2, n2});
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-    // Glue the new vertices two by two.
+    // Cut the edges.
     //
-    for (Int i = 0; i < selfIntersections.length() - 1; i += 2) {
+    for (auto& [edge, cutInfo] : cutInfos) {
+        cutInfo.res = vacomplex::ops::cutEdge(edge, cutInfo.params);
+    }
+
+    // Glue the new vertices.
+    //
+    for (const GlueInfo& glueInfo : glueInfos) {
+        const CutInfo& cutInfo1 = cutInfos[glueInfo.edge1];
+        const CutInfo& cutInfo2 = cutInfos[glueInfo.edge2];
         std::array<vacomplex::KeyVertex*, 2> vertices = {
-            cutEdgeRes.vertices()[i], //
-            cutEdgeRes.vertices()[i + 1]};
+            cutInfo1.res.vertices()[glueInfo.index1], //
+            cutInfo2.res.vertices()[glueInfo.index2]};
         vacomplex::ops::glueKeyVertices(vertices, vertices[0]->position());
     }
 }

--- a/libs/vgc/tools/autocut.cpp
+++ b/libs/vgc/tools/autocut.cpp
@@ -17,15 +17,28 @@
 #include <vgc/tools/autocut.h>
 
 #include <vgc/core/array.h>
+#include <vgc/geometry/intersect.h>
 #include <vgc/vacomplex/cell.h>
-
-using vgc::vacomplex::KeyEdge;
-using vgc::vacomplex::KeyFace;
-using vgc::vacomplex::KeyVertex;
+#include <vgc/vacomplex/keyedge.h>
+#include <vgc/vacomplex/operations.h>
 
 namespace vgc::tools {
 
-void autoCut(KeyEdge* edge, const AutoCutParams& params) {
+void autoCut(vacomplex::KeyEdge* edge, const AutoCutParams& params) {
+    vacomplex::Group* group = edge->parentGroup();
+    geometry::Polyline2d polyline = edge->strokeSampling().centerline();
+    Int n = polyline.length();
+    for (Int i = 0; i < n - 1; ++i) {
+        for (Int j = i + 2; j < n - 1; ++j) {
+            const geometry::Vec2d& a1 = polyline[i];
+            const geometry::Vec2d& b1 = polyline[i + 1];
+            const geometry::Vec2d& a2 = polyline[j];
+            const geometry::Vec2d& b2 = polyline[j + 1];
+            if (auto intersection = geometry::fastSegmentIntersection(a1, b1, a2, b2)) {
+                vacomplex::ops::createKeyVertex(intersection->position(), group);
+            }
+        }
+    }
 }
 
 } // namespace vgc::tools

--- a/libs/vgc/tools/autocut.cpp
+++ b/libs/vgc/tools/autocut.cpp
@@ -26,15 +26,22 @@ namespace vgc::tools {
 
 void autoCut(vacomplex::KeyEdge* edge, const AutoCutParams& params) {
     vacomplex::Group* group = edge->parentGroup();
-    geometry::Polyline2d polyline = edge->strokeSampling().centerline();
-    Int n = polyline.length();
+    const geometry::StrokeSampling2d& sampling = edge->strokeSampling();
+    const geometry::StrokeSample2dArray& samples = sampling.samples();
+    //geometry::Polyline2d polyline = edge->strokeSampling().centerline();
+    Int n = samples.length();
     for (Int i = 0; i < n - 1; ++i) {
         for (Int j = i + 2; j < n - 1; ++j) {
-            const geometry::Vec2d& a1 = polyline[i];
-            const geometry::Vec2d& b1 = polyline[i + 1];
-            const geometry::Vec2d& a2 = polyline[j];
-            const geometry::Vec2d& b2 = polyline[j + 1];
-            if (auto intersection = geometry::fastSegmentIntersection(a1, b1, a2, b2)) {
+            const geometry::Vec2d& a1 = samples[i].position();
+            const geometry::Vec2d& b1 = samples[i + 1].position();
+            const geometry::Vec2d& a2 = samples[j].position();
+            const geometry::Vec2d& b2 = samples[j + 1].position();
+            if (auto intersection = fastSegmentIntersection(a1, b1, a2, b2)) {
+                // TODO:
+                // const geometry::CurveParameter& p1 = samples[i].parameter();
+                // const geometry::CurveParameter& q1 = samples[i + 1].parameter();
+                // const geometry::CurveParameter& p2 = samples[j].parameter();
+                // const geometry::CurveParameter& q2 = samples[j + 1].parameter();
                 vacomplex::ops::createKeyVertex(intersection->position(), group);
             }
         }

--- a/libs/vgc/tools/autocut.cpp
+++ b/libs/vgc/tools/autocut.cpp
@@ -157,7 +157,7 @@ struct GlueInfo {
 
 } // namespace
 
-void autoCut(vacomplex::KeyEdge* edge, const AutoCutParams& params) {
+void autoCut(vacomplex::KeyEdge* edge1, const AutoCutParams& params) {
 
     std::unordered_map<vacomplex::KeyEdge*, CutInfo> cutInfos;
     core::Array<GlueInfo> glueInfos;
@@ -165,21 +165,20 @@ void autoCut(vacomplex::KeyEdge* edge, const AutoCutParams& params) {
     // Compute self-intersections.
     //
     if (params.cutItself()) {
-        auto intersections = computeSelfIntersections(edge);
-        CurveParameterArray& cutParams = cutInfos[edge].params;
+        auto intersections = computeSelfIntersections(edge1);
+        CurveParameterArray& cutParams = cutInfos[edge1].params;
         cutParams.reserve(intersections.length() * 2);
         for (const IntersectionParameters& intersection : intersections) {
             Int n = cutParams.length();
             cutParams.append(intersection.param1);
             cutParams.append(intersection.param2);
-            glueInfos.append(GlueInfo{edge, n, edge, n + 1});
+            glueInfos.append(GlueInfo{edge1, n, edge1, n + 1});
         }
     }
 
     // Compute intersections with other edges.
     //
     if (params.cutEdges()) {
-        vacomplex::KeyEdge* edge1 = edge;
         for (vacomplex::Node* node : *edge1->parentGroup()) {
             if (vacomplex::Cell* cell = node->toCell()) {
                 if (vacomplex::KeyEdge* edge2 = cell->toKeyEdge()) {

--- a/libs/vgc/tools/autocut.h
+++ b/libs/vgc/tools/autocut.h
@@ -1,0 +1,89 @@
+// Copyright 2024 The VGC Developers
+// See the COPYRIGHT file at the top-level directory of this distribution
+// and at https://github.com/vgc/vgc/blob/master/COPYRIGHT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vgc/tools/api.h>
+
+#include <vgc/vacomplex/cell.h>
+
+namespace vgc::tools {
+
+/// \class vgc::tools::AutoCutParams
+/// \brief Parameters for the autoCut() algorithm.
+///
+class VGC_TOOLS_API AutoCutParams {
+public:
+    /// Returns the tolerance to use for intersection tests.
+    ///
+    double tolerance() const {
+        return tolerance_;
+    }
+
+    /// Sets the value for `tolerance()`.
+    ///
+    void setTolerance(double value) {
+        tolerance_ = value;
+    }
+
+    /// Whether to compute self-intersections for the given edge.
+    ///
+    bool cutItself() const {
+        return cutItself_;
+    }
+
+    /// Sets the value for `interesectWithSelf()`.
+    ///
+    void setCutItself(bool value) {
+        cutItself_ = value;
+    }
+
+    /// Whether to compute intersections between the given edge and other edges.
+    ///
+    bool cutEdges() const {
+        return cutEdges_;
+    }
+
+    /// Sets the value for `cutEdges()`.
+    ///
+    void setCutEdges(bool value) {
+        cutEdges_ = value;
+    }
+
+    /// Whether to compute intersections between the given edge and faces.
+    ///
+    bool cutFaces() const {
+        return cutFaces_;
+    }
+
+    /// Sets the value for `cutEdges()`.
+    ///
+    void setCutFaces(bool value) {
+        cutFaces_ = value;
+    }
+
+private:
+    double tolerance_ = 1.e-6;
+    bool cutItself_ = true;
+    bool cutEdges_ = true;
+    bool cutFaces_ = true;
+};
+
+/// Computes intersections between the given edge and other edges/faces, and
+/// split them as appropriate.
+///
+VGC_TOOLS_API
+void autoCut(vacomplex::KeyEdge* edge, const AutoCutParams& params);
+
+} // namespace vgc::tools

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -1642,8 +1642,10 @@ void Sketch::finishCurve_(ui::MouseEvent* event) {
     }
 
     if (isAutoCutEnabled()) {
-        AutoCutParams params;
-        autoCut(params);
+        if (vacomplex::KeyEdge* keyEdge = toKeyEdge(workspace.get(), edgeItemId_)) {
+            AutoCutParams params;
+            autoCut(keyEdge, params);
+        }
     }
 
     resetData_();

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -1642,6 +1642,7 @@ void Sketch::finishCurve_(ui::MouseEvent* event) {
     }
 
     if (isAutoCutEnabled()) {
+        workspace->sync();
         if (vacomplex::KeyEdge* keyEdge = toKeyEdge(workspace.get(), edgeItemId_)) {
             AutoCutParams params;
             autoCut(keyEdge, params);

--- a/libs/vgc/tools/sketch.cpp
+++ b/libs/vgc/tools/sketch.cpp
@@ -27,6 +27,7 @@
 #include <vgc/core/stringid.h>
 #include <vgc/geometry/curve.h>
 #include <vgc/graphics/strings.h>
+#include <vgc/tools/autocut.h>
 #include <vgc/tools/logcategories.h>
 #include <vgc/ui/boolsettingedit.h>
 #include <vgc/ui/column.h>
@@ -97,6 +98,12 @@ ui::NumberSetting* snapFalloff() {
         100,
         0,
         1000);
+    return setting.get();
+}
+
+ui::BoolSetting* autoCut() {
+    static ui::BoolSettingPtr setting = ui::BoolSetting::create(
+        ui::settings::session(), "tools.sketch.autoCut", "Auto-Cut", false);
     return setting.get();
 }
 
@@ -186,6 +193,10 @@ ui::BoolSetting* reProcessExistingEdges() {
 }
 
 } // namespace options_
+
+bool isAutoCutEnabled() {
+    return options_::autoCut()->value();
+}
 
 bool isAutoFillEnabled() {
     return options_::autoFill()->value();
@@ -595,6 +606,7 @@ ui::WidgetPtr Sketch::doCreateOptionsWidget() const {
     res->createChild<ui::BoolSettingEdit>(options_::snapping());
     res->createChild<ui::NumberSettingEdit>(options_::snapDistance());
     res->createChild<ui::NumberSettingEdit>(options_::snapFalloff());
+    res->createChild<ui::BoolSettingEdit>(options_::autoCut());
     res->createChild<ui::BoolSettingEdit>(options_::autoFill());
     return res;
 }
@@ -1627,6 +1639,11 @@ void Sketch::finishCurve_(ui::MouseEvent* event) {
                 }
             }
         }
+    }
+
+    if (isAutoCutEnabled()) {
+        AutoCutParams params;
+        autoCut(params);
     }
 
     resetData_();


### PR DESCRIPTION
#1815

Note that this minimal implementation doesn't yet:
- Cut faces
- Take snapping distance into account to:
  - cluster cuts
  - remove small leftover edges at T-junctions
  - extend the sketch edge a little to create a T-junction if there is "almost" an intersection