### PR TITLE
Use parentheses instead of square brackets in Triangle formatting (#864)

### DIFF
--- a/libs/vgc/geometry/tests/test_triangle.py
+++ b/libs/vgc/geometry/tests/test_triangle.py
@@ -23,7 +23,7 @@ from vgc.geometry import Triangle2d, Triangle2f, Vec2d, Vec2f
 Triangle2Types = [Triangle2d, Triangle2f]
 Triangle2Vec2Types = [(Triangle2d, Vec2d), (Triangle2f, Vec2f)]
 
-class TestVec2(unittest.TestCase):
+class TestTriangle2(unittest.TestCase):
 
     def testDefaultConstructor(self):
         for Triangle2 in Triangle2Types:

--- a/libs/vgc/geometry/tools/triangle2x.h
+++ b/libs/vgc/geometry/tools/triangle2x.h
@@ -317,16 +317,14 @@ using Triangle2xConstSpan = StrideSpan<const float, const Triangle2x>;
 /// \sa `vgc::core::zero<T>()`.
 ///
 inline void setZero(Triangle2x& t) {
-    t[0] = Vec2x();
-    t[1] = Vec2x();
-    t[2] = Vec2x();
+    t = Triangle2x();
 }
 
 /// Writes the given `Triangle2x` to the output stream.
 ///
 template<typename OStream>
 void write(OStream& out, const Triangle2x& t) {
-    write(out, '[', t[0], ", ", t[1], ", ", t[2], ']');
+    write(out, '(', t[0], ", ", t[1], ", ", t[2], ')');
 }
 
 /// Reads a `Triangle2x` from the input stream, and stores it in the given output
@@ -336,13 +334,13 @@ void write(OStream& out, const Triangle2x& t) {
 ///
 template<typename IStream>
 void readTo(Triangle2x& t, IStream& in) {
-    skipWhitespacesAndExpectedCharacter(in, '[');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(t[0], in);
     skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(t[1], in);
     skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(t[2], in);
-    skipWhitespacesAndExpectedCharacter(in, ']');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry
@@ -359,7 +357,7 @@ struct fmt::formatter<vgc::geometry::Triangle2x> {
     }
     template<typename FormatContext>
     auto format(const vgc::geometry::Triangle2x& t, FormatContext& ctx) {
-        return format_to(ctx.out(), "[{}, {}, {}]", t[0], t[1], t[2]);
+        return format_to(ctx.out(), "({}, {}, {})", t[0], t[1], t[2]);
     }
 };
 

--- a/libs/vgc/geometry/triangle2d.h
+++ b/libs/vgc/geometry/triangle2d.h
@@ -317,16 +317,14 @@ using Triangle2dConstSpan = StrideSpan<const double, const Triangle2d>;
 /// \sa `vgc::core::zero<T>()`.
 ///
 inline void setZero(Triangle2d& t) {
-    t[0] = Vec2d();
-    t[1] = Vec2d();
-    t[2] = Vec2d();
+    t = Triangle2d();
 }
 
 /// Writes the given `Triangle2d` to the output stream.
 ///
 template<typename OStream>
 void write(OStream& out, const Triangle2d& t) {
-    write(out, '[', t[0], ", ", t[1], ", ", t[2], ']');
+    write(out, '(', t[0], ", ", t[1], ", ", t[2], ')');
 }
 
 /// Reads a `Triangle2d` from the input stream, and stores it in the given output
@@ -336,13 +334,13 @@ void write(OStream& out, const Triangle2d& t) {
 ///
 template<typename IStream>
 void readTo(Triangle2d& t, IStream& in) {
-    skipWhitespacesAndExpectedCharacter(in, '[');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(t[0], in);
     skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(t[1], in);
     skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(t[2], in);
-    skipWhitespacesAndExpectedCharacter(in, ']');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry
@@ -359,7 +357,7 @@ struct fmt::formatter<vgc::geometry::Triangle2d> {
     }
     template<typename FormatContext>
     auto format(const vgc::geometry::Triangle2d& t, FormatContext& ctx) {
-        return format_to(ctx.out(), "[{}, {}, {}]", t[0], t[1], t[2]);
+        return format_to(ctx.out(), "({}, {}, {})", t[0], t[1], t[2]);
     }
 };
 

--- a/libs/vgc/geometry/triangle2f.h
+++ b/libs/vgc/geometry/triangle2f.h
@@ -317,16 +317,14 @@ using Triangle2fConstSpan = StrideSpan<const float, const Triangle2f>;
 /// \sa `vgc::core::zero<T>()`.
 ///
 inline void setZero(Triangle2f& t) {
-    t[0] = Vec2f();
-    t[1] = Vec2f();
-    t[2] = Vec2f();
+    t = Triangle2f();
 }
 
 /// Writes the given `Triangle2f` to the output stream.
 ///
 template<typename OStream>
 void write(OStream& out, const Triangle2f& t) {
-    write(out, '[', t[0], ", ", t[1], ", ", t[2], ']');
+    write(out, '(', t[0], ", ", t[1], ", ", t[2], ')');
 }
 
 /// Reads a `Triangle2f` from the input stream, and stores it in the given output
@@ -336,13 +334,13 @@ void write(OStream& out, const Triangle2f& t) {
 ///
 template<typename IStream>
 void readTo(Triangle2f& t, IStream& in) {
-    skipWhitespacesAndExpectedCharacter(in, '[');
+    skipWhitespacesAndExpectedCharacter(in, '(');
     readTo(t[0], in);
     skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(t[1], in);
     skipWhitespacesAndExpectedCharacter(in, ',');
     readTo(t[2], in);
-    skipWhitespacesAndExpectedCharacter(in, ']');
+    skipWhitespacesAndExpectedCharacter(in, ')');
 }
 
 } // namespace vgc::geometry
@@ -359,7 +357,7 @@ struct fmt::formatter<vgc::geometry::Triangle2f> {
     }
     template<typename FormatContext>
     auto format(const vgc::geometry::Triangle2f& t, FormatContext& ctx) {
-        return format_to(ctx.out(), "[{}, {}, {}]", t[0], t[1], t[2]);
+        return format_to(ctx.out(), "({}, {}, {})", t[0], t[1], t[2]);
     }
 };
 

--- a/libs/vgc/geometry/wraps/wrap_triangle.cpp
+++ b/libs/vgc/geometry/wraps/wrap_triangle.cpp
@@ -93,10 +93,6 @@ void wrap_triangle(py::module& m, const std::string& name) {
         .def_property("b", &This::b, py::overload_cast<const Vec2x&>(&This::setB))
         .def_property("c", &This::c, py::overload_cast<const Vec2x&>(&This::setC))
 
-        .def("setA", py::overload_cast<T, T>(&This::setA))
-        .def("setB", py::overload_cast<T, T>(&This::setB))
-        .def("setC", py::overload_cast<T, T>(&This::setC))
-
         .def(py::self += py::self)
         .def(py::self + py::self)
         .def(+py::self)


### PR DESCRIPTION
#864