### PR TITLE
Fix generateRandomInteger() declaration/definition name mismatch (#752)

### DIFF
--- a/libs/vgc/core/random.cpp
+++ b/libs/vgc/core/random.cpp
@@ -27,7 +27,7 @@ thread_local std::random_device randomDevice_;
 
 namespace vgc::core::detail {
 
-UInt32 hardwareRandom() {
+UInt32 generateRandomInteger() {
     return randomDevice_();
 }
 


### PR DESCRIPTION
#752