### PR TITLE
Add -Wshadow to Clang pedantic compile flags (#1577)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(VGC_COMPILER_WARNING_FLAGS -Wfloat-conversion)
     set(VGC_COMPILER_WARNING_DEFINITIONS "")
-    set(VGC_PEDANTIC_COMPILE_FLAGS -Wall -Wextra)
+    set(VGC_PEDANTIC_COMPILE_FLAGS -Wall -Wextra -Wshadow)
     set(VGC_WERROR_FLAG -Werror)
 elseif(MSVC)
     # /wd4251: class 'Foo' needs to have dll-interface to be used by clients of class 'Bar'

--- a/libs/vgc/ui/paneldefaultarea.h
+++ b/libs/vgc/ui/paneldefaultarea.h
@@ -25,7 +25,7 @@ namespace vgc::ui {
 /// \enum vgc::ui::PanelDefaultArea
 /// \brief Specifies where a Panel should be opened by default.
 ///
-enum PanelDefaultArea {
+enum class PanelDefaultArea {
     Left,
     Right
 };


### PR DESCRIPTION
#1577

Similar to #1864 but for Clang.

I also tried -Wshadow-uncaptured-local (introduced in Clang 5), as mentioned in #1864, but in fact simply using -Wshadow is the closest equivalent to MSVC warnings, since -Wshadow-uncaptured-local doesn't actually catch the case when a local variable is shadowing another local variable. I also tried -Wshadow-all but it was too strict (similar to GCC's -Wshadow), warning about things we want to allow.

Note that  -Wshadow actually did catch an actual programming error: missing `class` in `enum class PanelDefaultArea`. This meant that `Right` was directly into `vgc::ui`, and `vgc::ui::Margins::Indices::Right` was shadowing it, see https://github.com/vgc/vgc/blob/master/libs/vgc/ui/margins.h:

```
class Margins {
private:
    enum Indices_ {
        Top = 0,
        Right,
        Bottom,
        Left
    };
// ...
}
```