### PR TITLE
Fix incorrect use of GITHUB_WORKSPACE in Clang-Format Comment script (#797)

### DIFF
--- a/.github/workflows/clang-format-comment.yml
+++ b/.github/workflows/clang-format-comment.yml
@@ -33,7 +33,7 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('$GITHUB_WORKSPACE/clang_format_artifacts.zip', Buffer.from(download.data));
+            fs.writeFileSync('${{github.workspace}}/clang_format_artifacts.zip', Buffer.from(download.data));
       - run: unzip clang_format_artifacts.zip
 
       - name: Comment on PR


### PR DESCRIPTION
#797

In PR #1828, I changed some occurrences of `${{github.workspace}}` to `$GITHUB_WORKSPACE`. However, the latter cannot be used in a github-script since it is a JS script, not a bash script.

Therefore, this PR reverts this occurrence to the known-working `${{github.workspace}}`.