### PR TITLE
Upgrade clang-format-check to use upload-artifact@v4 (#797)

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -36,7 +36,7 @@ jobs:
           echo ${{ github.event.number }} > ./artifacts/pr_number.txt
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: clang_format_artifacts
           path: artifacts/


### PR DESCRIPTION
#797

We were using v2 which is now deprecated and causes the action to fail.

See:  https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/