### PR TITLE
Fix edges not drawn: resource pointer wasn't set to null on reset (#1201)

### DIFF
--- a/libs/vgc/graphics/resource.h
+++ b/libs/vgc/graphics/resource.h
@@ -500,9 +500,7 @@ public:
         T* p = Base::get();
         if (p) {
             p->decRef_();
-#ifdef VGC_DEBUG_BUILD
             Base::set_(nullptr);
-#endif
         }
     }
 


### PR DESCRIPTION
#1201

Related: #1887

Some uses of `Resource` do require the behavior that the pointer is set to null.

For example, in workspace/edge.h:

```
    void clearStrokeGeometry() {
        strokeGeometry_.reset();
    }
```

and the nullity of the pointer is then tested  in workspace/edge.cpp:

```
    if (shouldPaintStroke && !graphics.strokeGeometry()) {
        hasNewStrokeGraphics = true;
        // ...
    }
```
