### PR TITLE
Make core::drop() compatible with py::iterable (#1876)

### DIFF
--- a/libs/vgc/core/ranges.h
+++ b/libs/vgc/core/ranges.h
@@ -78,7 +78,9 @@ bool isEmpty(TRange&& range) {
 ///
 template<typename TRange, typename TSize>
 auto drop(TRange&& range, TSize n) -> Range<decltype(std::declval<TRange>().begin())> {
-    return {range.begin() + n, range.end()};
+    auto it = range.begin();
+    std::advance(it, n);
+    return {it, range.end()};
 }
 
 } // namespace vgc::core


### PR DESCRIPTION
#1876