### PR TITLE
Extend Array Python wrappers: support non-formattable, parsable, or comparable items and nested classes (#1654)

### DIFF
--- a/libs/vgc/core/wraps/class.h
+++ b/libs/vgc/core/wraps/class.h
@@ -61,6 +61,11 @@ public:
 
 #undef VGC_CORE_WRAPS_CLASS_FWD_PYCLASS_METHOD
 
+    // Allow implicit conversion to handle, like py::class_ does.
+    operator py::handle() const {
+        return c_;
+    }
+
 private:
     PyClass c_;
 };

--- a/libs/vgc/core/wraps/common.h
+++ b/libs/vgc/core/wraps/common.h
@@ -37,4 +37,38 @@ using namespace py::literals;
 //
 PYBIND11_DECLARE_HOLDER_TYPE(T, vgc::core::ObjPtr<T>, true)
 
+namespace vgc::core::wraps {
+
+/// Returns the fully-qualified name of the given scope, which is excepted
+/// to be a handle to either a class or a module.
+///
+/// Examples:
+/// - `vgc.geometry`
+/// - `vgc.geometry.SegmentIntersector2d`
+/// - `vgc.geometry.SegmentIntersector2d.PointIntersection`
+///
+inline std::string getScopeFullName(py::handle scope) {
+
+    if (py::hasattr(scope, "__module__")) {
+
+        // scope is a class (i.e., T is a nested class)
+        // Example:
+        //   scope.__module__   == 'vgc.geometry'
+        //   scope.__qualname__ == 'SegmentIntersector2d'
+        //
+        std::string moduleName = py::cast<std::string>(scope.attr("__module__"));
+        std::string parentQualName = py::cast<std::string>(scope.attr("__qualname__"));
+        return vgc::core::format("{}.{}", moduleName, parentQualName);
+    }
+    else {
+        // scope is a module.
+        // Example:
+        //   scope.__name__ == 'vgc.geometry'
+        //
+        return py::cast<std::string>(scope.attr("__name__"));
+    }
+}
+
+} // namespace vgc::core::wraps
+
 #endif // VGC_CORE_WRAPS_COMMON_H

--- a/libs/vgc/core/wraps/wrap_arrays.cpp
+++ b/libs/vgc/core/wraps/wrap_arrays.cpp
@@ -20,9 +20,9 @@
 #include <vgc/core/wraps/common.h>
 
 void wrap_arrays(py::module& m) {
-    vgc::core::wraps::wrap_array<double>(m, "Double");
-    vgc::core::wraps::wrap_array<float>(m, "Float");
-    vgc::core::wraps::wrap_array<vgc::Int>(m, "Int");
+    vgc::core::wraps::wrapArray<double>(m, "Double");
+    vgc::core::wraps::wrapArray<float>(m, "Float");
+    vgc::core::wraps::wrapArray<vgc::Int>(m, "Int");
 }
 
 namespace vgc::core::wraps::detail {

--- a/libs/vgc/core/wraps/wrap_color.cpp
+++ b/libs/vgc/core/wraps/wrap_color.cpp
@@ -72,5 +72,5 @@ void wrap_color(py::module& m) {
 
         ;
 
-    vgc::core::wraps::wrap_array<vgc::core::Color>(m, "Color");
+    vgc::core::wraps::wrapArray<vgc::core::Color>(m, "Color");
 }

--- a/libs/vgc/dom/wraps/wrap_element.cpp
+++ b/libs/vgc/dom/wraps/wrap_element.cpp
@@ -122,7 +122,7 @@ OutputIt writeAttributesRepr(OutputIt out, const This& self) {
 void wrap_element(py::module& m) {
 
     vgc::core::wraps::wrapObjectCommon<This>(m, "Element");
-    vgc::core::wraps::wrap_array<This*, false>(m, "Element");
+    vgc::core::wraps::wrapArray<This*>(m, "Element");
 
     vgc::core::wraps::ObjClass<This>(m, "Element")
         .def_create<This*, Document*, std::string_view>("parent"_a, "tagName"_a)

--- a/libs/vgc/dom/wraps/wrap_node.cpp
+++ b/libs/vgc/dom/wraps/wrap_node.cpp
@@ -33,7 +33,7 @@ void wrap_node(py::module& m) {
         .value("Document", NodeType::Document);
 
     vgc::core::wraps::wrapObjectCommon<This>(m, "Node");
-    vgc::core::wraps::wrap_array<This*, false>(m, "Node");
+    vgc::core::wraps::wrapArray<This*>(m, "Node");
 
     vgc::core::wraps::ObjClass<This>(m, "Node")
         // Note: Node has no public constructor

--- a/libs/vgc/geometry/wraps/wrap_vec.cpp
+++ b/libs/vgc/geometry/wraps/wrap_vec.cpp
@@ -45,7 +45,7 @@ void wrap_vecArray(py::module& m, const std::string& name) {
 
     std::string arrayTypeName = name + "Array";
     vgc::core::wraps::Class<ArrayType> c1(m, arrayTypeName.c_str());
-    vgc::core::wraps::defineArrayCommonMethods<TVec, true>(
+    vgc::core::wraps::defineArrayCommonMethods<TVec>(
         c1, vgc::core::format("{}.{}", moduleFullName, arrayTypeName));
     c1.def(py::init([name](py::sequence s) {
         ArrayType res;
@@ -58,7 +58,7 @@ void wrap_vecArray(py::module& m, const std::string& name) {
 
     std::string sharedConstArrayTypeName = std::string("SharedConst") + arrayTypeName;
     vgc::core::wraps::Class<SharedConstArrayType> c2(m, sharedConstArrayTypeName.c_str());
-    vgc::core::wraps::defineSharedConstArrayCommonMethods<TVec, true>(
+    vgc::core::wraps::defineSharedConstArrayCommonMethods<TVec>(
         c2, vgc::core::format("{}.{}", moduleFullName, sharedConstArrayTypeName));
 }
 


### PR DESCRIPTION
#1654