### PR TITLE
Avoid calling range.begin() multiple time on input range (#1851)

### DIFF
--- a/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
+++ b/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
@@ -75,7 +75,6 @@ void wrap_SegmentIntersector2(py::module& m, const std::string& name) {
     using This = SegmentIntersector2<T>;
 
     using Vec2x = Vec2<T>;
-    using Vec2xArray = vgc::core::Array<Vec2x>;
 
     vgc::core::wraps::Class<This> c(m, name.c_str());
     c.def(py::init<>())
@@ -87,16 +86,10 @@ void wrap_SegmentIntersector2(py::module& m, const std::string& name) {
                py::iterable range,
                bool isClosed,
                bool hasDuplicateEndpoints) {
-                // Currently, py::iterable is broken, see:
-                // https://github.com/pybind/pybind11/issues/5399
-                // So drop(range, 1) in addPolyline() fails and we cannot do:
-                // self.addPolyline(
-                //     isClosed, hasDuplicateEndpoints, range, [](py::handle h) {
-                //         return py::cast<Vec2x>(h);
-                //     });
-                // So we instead first convert to a Vec2d array
-                Vec2xArray array(range, [](py::handle h) { return py::cast<Vec2x>(h); });
-                self.addPolyline(isClosed, hasDuplicateEndpoints, array);
+                self.addPolyline(
+                    isClosed, hasDuplicateEndpoints, range, [](py::handle h) {
+                        return py::cast<Vec2x>(h);
+                    });
             },
             "range"_a,
             py::kw_only(),


### PR DESCRIPTION
#1851

See [[range.range](https://timsong-cpp.github.io/cppwp/n4861/range.range)] section in the C++20 latest working draft:

(3.3) if the type of ranges::begin(t) models forward_­iterator, ranges::begin(t) is equality-preserving.

(4) [ Note: Equality preservation of both ranges::begin and ranges::end enables passing a range whose iterator type models forward_­iterator to multiple algorithms and making multiple passes over the range by repeated calls to ranges::begin and ranges::end. Since ranges::begin is not required to be equality-preserving when the return type does not model forward_­iterator, repeated calls might not return equal values or might not be well-defined; ranges::begin should be called at most once for such a range. — end note ]

Also, this now makes `addPolyline` compatible with the broken `py::iterable` since we always first dereference before using prefix increment (see: https://github.com/pybind/pybind11/issues/5399)
