### PR TITLE
Remove constexpr for Mat::identity and Range/Rect::empty due to MSVC bug (#1906)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ elseif(MSVC)
     set(VGC_COMPILER_WARNING_FLAGS /wd4251)
     # C4996: 'strerror'/'getenv'/etc: This function or variable may be unsafe. Consider using 'strerror_s'/_dupenv_s'/etc instead.
     set(VGC_COMPILER_WARNING_DEFINITIONS _CRT_SECURE_NO_WARNINGS)
-    set(VGC_PEDANTIC_COMPILE_FLAGS /W4 /w45038)
+    set(VGC_PEDANTIC_COMPILE_FLAGS /W4 /w45038 /permissive-)
     set(VGC_WERROR_FLAG /WX)
 endif ()
 

--- a/libs/vgc/geometry/mat2.h
+++ b/libs/vgc/geometry/mat2.h
@@ -368,12 +368,9 @@ private:
     T data_[2][2];
 };
 
-// This definition must be out-of-class.
-// See: https://stackoverflow.com/questions/11928089/
-// static-constexpr-member-of-same-type-as-class-being-defined
-//
+// Why out-of-class? Why not constexpr? See: https://github.com/vgc/vgc/issues/1906
 template<typename T>
-inline constexpr Mat2<T> Mat2<T>::identity = Mat2<T>(1);
+inline const Mat2<T> Mat2<T>::identity = Mat2<T>(1);
 
 template<typename T>
 Mat2<T> Mat2<T>::inverse(bool* isInvertible, T epsilon_) const {

--- a/libs/vgc/geometry/mat3.h
+++ b/libs/vgc/geometry/mat3.h
@@ -581,12 +581,9 @@ private:
     T data_[3][3];
 };
 
-// This definition must be out-of-class.
-// See: https://stackoverflow.com/questions/11928089/
-// static-constexpr-member-of-same-type-as-class-being-defined
-//
+// Why out-of-class? Why not constexpr? See: https://github.com/vgc/vgc/issues/1906
 template<typename T>
-inline constexpr Mat3<T> Mat3<T>::identity = Mat3<T>(1);
+inline const Mat3<T> Mat3<T>::identity = Mat3<T>(1);
 
 template<typename T>
 Mat3<T> Mat3<T>::inverse(bool* isInvertible, T epsilon_) const {

--- a/libs/vgc/geometry/mat4.h
+++ b/libs/vgc/geometry/mat4.h
@@ -787,12 +787,9 @@ private:
     T data_[4][4];
 };
 
-// This definition must be out-of-class.
-// See: https://stackoverflow.com/questions/11928089/
-// static-constexpr-member-of-same-type-as-class-being-defined
-//
+// Why out-of-class? Why not constexpr? See: https://github.com/vgc/vgc/issues/1906
 template<typename T>
-inline constexpr Mat4<T> Mat4<T>::identity = Mat4<T>(1);
+inline const Mat4<T> Mat4<T>::identity = Mat4<T>(1);
 
 // We define this function out-of-class to keep the name `epsilon` in the
 // declaration (and thus documentation), while using `epsilon_` in the

--- a/libs/vgc/geometry/range1.h
+++ b/libs/vgc/geometry/range1.h
@@ -418,12 +418,9 @@ private:
     T pMax_;
 };
 
-// This definition must be out-of-class.
-// See: https://stackoverflow.com/questions/11928089/
-// static-constexpr-member-of-same-type-as-class-being-defined
-//
+// Why out-of-class? Why not constexpr? See: https://github.com/vgc/vgc/issues/1906
 template<typename T>
-inline constexpr Range1<T> Range1<T>::empty = //
+inline const Range1<T> Range1<T>::empty = //
     Range1<T>(core::infinity<T>, -core::infinity<T>);
 
 /// Alias for `Range1<float>`.

--- a/libs/vgc/geometry/rect2.h
+++ b/libs/vgc/geometry/rect2.h
@@ -956,12 +956,9 @@ private:
     }
 };
 
-// This definition must be out-of-class.
-// See: https://stackoverflow.com/questions/11928089/
-// static-constexpr-member-of-same-type-as-class-being-defined
-//
+// Why out-of-class? Why not constexpr? See: https://github.com/vgc/vgc/issues/1906
 template<typename T>
-inline constexpr Rect2<T> Rect2<T>::empty = //
+inline const Rect2<T> Rect2<T>::empty = //
     Rect2(core::infinity<T>, core::infinity<T>, -core::infinity<T>, -core::infinity<T>);
 
 /// Alias for `Rect2<float>`.


### PR DESCRIPTION
#1906