### PR TITLE
Extend SegmentIntersector2 to support overlapping segments

### DIFF
--- a/libs/vgc/geometry/segmentintersector2.h
+++ b/libs/vgc/geometry/segmentintersector2.h
@@ -52,6 +52,7 @@ namespace segmentintersector2 {
 using PolylineIndex = Int;
 using SegmentIndex = Int;
 using PointIntersectionIndex = Int;
+using SegmentIntersectionIndex = Int;
 
 /// When two or more segments intersect at a point, then for each involved
 /// segment we store its corresponding intersection parameter.
@@ -59,8 +60,8 @@ using PointIntersectionIndex = Int;
 template<typename T>
 class PointIntersectionInfo {
 public:
-    /// Constructs a `PointIntersection` with zero-initialized
-    /// `pointIntersectionIndex()` and `segmentIndex()`, and `parameter`.
+    /// Constructs a `PointIntersectionInfo` with zero-initialized
+    /// `pointIntersectionIndex()`, `segmentIndex()`, and `parameter()`.
     ///
     PointIntersectionInfo() {
     }
@@ -77,8 +78,8 @@ public:
         , parameter_(parameter) {
     }
 
-    /// Returns the index of the PointInteresection this
-    /// PointIntersectionInfo belongs to.
+    /// Returns the index of the `PointInteresection` this
+    /// `PointIntersectionInfo` belongs to.
     ///
     PointIntersectionIndex pointIntersectionIndex() const {
         return pointIntersectionIndex_;
@@ -96,7 +97,7 @@ public:
         return segmentIndex_;
     }
 
-    /// Modifies `pointIntersectionIndex()`.
+    /// Modifies `segmentIndex()`.
     ///
     void setSegmentIndex(SegmentIndex segmentIndex) {
         segmentIndex_ = segmentIndex;
@@ -191,6 +192,157 @@ private:
     core::Array<PointIntersectionInfo<T>> infos_;
 };
 
+/// When two or more segments overlap along a shared subsegment, then for each
+/// involved segment we store its corresponding intersection parameters.
+///
+template<typename T>
+class SegmentIntersectionInfo {
+public:
+    /// Constructs a `SegmentIntersectionInfo` with zero-initialized
+    /// `segmentIntersectionIndex()`, `segmentIndex()`, `parameter1(), and `parameter2()`.
+    ///
+    SegmentIntersectionInfo() {
+    }
+
+    /// Contructs a `PointIntersectionInfo`.
+    ///
+    SegmentIntersectionInfo(
+        SegmentIntersectionIndex segmentIntersectionIndex,
+        SegmentIndex segmentIndex,
+        T parameter1,
+        T parameter2)
+
+        : segmentIntersectionIndex_(segmentIntersectionIndex)
+        , segmentIndex_(segmentIndex)
+        , parameter1_(parameter1)
+        , parameter2_(parameter2) {
+    }
+
+    /// Returns the index of the `SegmentInteresection` this
+    /// `SegmentIntersectionInfo` belongs to.
+    ///
+    SegmentIntersectionIndex segmentIntersectionIndex() const {
+        return segmentIntersectionIndex_;
+    }
+
+    /// Modifies `segmentIntersectionIndex()`.
+    ///
+    void setSegmentIntersectionIndex(SegmentIntersectionIndex segmentIntersectionIndex) {
+        segmentIntersectionIndex_ = segmentIntersectionIndex;
+    }
+
+    /// Returns the index of the segment that overlap the `SegmentIntersection`.
+    ///
+    SegmentIndex segmentIndex() const {
+        return segmentIndex_;
+    }
+
+    /// Modifies `segmentIndex()`.
+    ///
+    void setSegmentIndex(SegmentIndex segmentIndex) {
+        segmentIndex_ = segmentIndex;
+    }
+
+    /// Returns the parameter along the segment corresponding to where
+    /// the segment starts to overlap the `SegmentIntersection`.
+    ///
+    T parameter1() const {
+        return parameter1_;
+    }
+
+    /// Modifies `parameter1()`.
+    ///
+    void setParameter1(T parameter1) {
+        parameter1_ = parameter1;
+    }
+
+    /// Returns the parameter along the segment corresponding to where
+    /// the segment finishes to overlap the `SegmentIntersection`.
+    ///
+    T parameter2() const {
+        return parameter2_;
+    }
+
+    /// Modifies `parameter2()`.
+    ///
+    void setParameter2(T parameter2) {
+        parameter2_ = parameter2;
+    }
+
+private:
+    PointIntersectionIndex segmentIntersectionIndex_;
+    SegmentIndex segmentIndex_;
+    T parameter1_;
+    T parameter2_;
+};
+
+/// Stores a minimal subsegment of an intersection segment, together with the
+/// information of which segments are overlapping that subsegment.
+///
+template<typename T>
+class SegmentIntersection {
+public:
+    /// Constructs a `SegmentIntersection` with a default constructed `segment` and
+    /// `infos()`.
+    ///
+    SegmentIntersection() noexcept {
+    }
+
+    /// Constructs a `SegmentIntersection` with the given `segment` and empty
+    /// `infos()`.
+    ///
+    explicit SegmentIntersection(const Segment2<T>& segment) noexcept
+        : segment_(segment) {
+    }
+
+    /// Constructs a `SegmentIntersection` with the given `segment` and `infos`.
+    ///
+    SegmentIntersection(
+        const Segment2<T>& segment,
+        const core::Array<SegmentIntersectionInfo<T>>& infos)
+
+        : segment_(segment)
+        , infos_(infos) {
+    }
+
+    /// Returns the shared subsegment of this segment intersection.
+    ///
+    Vec2<T> segment() const {
+        return segment_;
+    }
+
+    /// Modifies the shared subsegment of this point intersection.
+    ///
+    void setSegment(const Segment2<T>& segment) {
+        segment_ = segment;
+    }
+
+    /// Returns information about the segments that intersect
+    /// at this point intersection.
+    ///
+    const core::Array<SegmentIntersectionInfo<T>>& infos() const {
+        return infos_;
+    }
+
+    /// Sets the `infos` of this point intersection.
+    ///
+    void setInfos(core::Array<SegmentIntersectionInfo<T>> infos) {
+        infos_ = std::move(infos);
+    }
+
+    /// Adds a `PointIntersectionInfo` to this point intersection.
+    ///
+    void addInfo(const SegmentIntersectionInfo<T>& info) {
+        infos_.append(info);
+    }
+
+private:
+    Segment2<T> segment_;
+    core::Array<SegmentIntersectionInfo<T>> infos_;
+};
+
+/// Represent a range of continuous segment indices.
+///
 template<typename T>
 class SegmentIndexRange {
 public:
@@ -270,6 +422,9 @@ public:
 
     using PointIntersectionInfo = segmentintersector2::PointIntersectionInfo<T>;
     using PointIntersection = segmentintersector2::PointIntersection<T>;
+
+    using SegmentIntersectionInfo = segmentintersector2::SegmentIntersectionInfo<T>;
+    using SegmentIntersection = segmentintersector2::SegmentIntersection<T>;
 
     /// Creates a `SegmentIntersector2`.
     ///
@@ -357,6 +512,12 @@ public:
     ///
     const core::Array<PointIntersection>& pointIntersections() const {
         return output_.pointIntersections;
+    };
+
+    /// Returns the computed segment intersections.
+    ///
+    const core::Array<SegmentIntersection>& segmentIntersections() const {
+        return output_.segmentIntersections;
     };
 
     /// Returns which polyline contains the given segment.
@@ -472,7 +633,8 @@ struct AlgorithmData {
     EventQueue eventQueue;
 
     // The segments that intersect the sweep line, ordered by increasing
-    // y-coords of their intersection with the sweep line.
+    // y-coords of their intersection with the sweep line, and ordered
+    // by slope in case of equality (vertical segments last).
     //
     core::Array<SegmentIndex> sweepSegments;
 
@@ -490,11 +652,26 @@ struct AlgorithmData {
     //
     core::Array<Event<T>> sweepEvents;
 
+    // During the plane sweep, we store overlap groups as a directed acyclic
+    // graph (DAG):
+    //
+    // - a segment that is not part of an overlap group stores -1
+    // - a segment that is part of an overlap group stores either:
+    //   - an index to itself, or
+    //   - an index to a greater segment index that it overlaps with
+    //
+    // This makes merging overlap group trivial and constant time during
+    // the plane sweep. We can then post-process them in O(n log n) after
+    // the plane sweep.
+    //
+    core::Array<SegmentIndex> overlapGroups;
+
     void clear() {
         VGC_ASSERT(eventQueue.empty()); // priority_queue has no clear() method
         sweepSegments.clear();
         outgoingSegments.clear();
         sweepEvents.clear();
+        overlapGroups.clear();
     }
 };
 
@@ -686,6 +863,12 @@ void initializeEventQueue(InputData<T>& in, AlgorithmData<T>& alg) {
 template<typename T>
 void initializeSweepSegments(AlgorithmData<T>& alg) {
     alg.sweepSegments.clear();
+}
+
+template<typename T>
+void initializeOverlapGroups(InputData<T>& in, AlgorithmData<T>& alg) {
+    Int n = in.segments.length();
+    alg.overlapGroups.assign(n, -1);
 }
 
 // Get the next event and all events sharing the same position. We call these
@@ -1136,6 +1319,137 @@ void computeOutgoingSegments(
         [&slopes = in.segmentSlopes](SegmentIndex i1, SegmentIndex i2) {
             return slopes.getUnchecked(i1) < slopes.getUnchecked(i2);
         });
+
+    // Find if there are overlapping segment among the outgoing segments. They
+    // are those with the same slope, but due to numerical errors, we do not
+    // rely on slope but on our robust intersection test for this. But since
+    // outgoingSegments are sorted by slopes, we still only have to test
+    // consecutive segment pairs.
+    //
+    for (Int j = 1; j < alg.outgoingSegments.length(); ++j) {
+        SegmentIndex i1 = alg.outgoingSegments.getUnchecked(j - 1);
+        SegmentIndex i2 = alg.outgoingSegments.getUnchecked(j);
+        const Segment2<T>& s1 = in.segments.getUnchecked(i1);
+        const Segment2<T>& s2 = in.segments.getUnchecked(i2);
+        SegmentIntersection2<T> inter = s1.intersect(s2);
+        if (inter.type() == SegmentIntersectionType::Segment) {
+
+            // Report the overlap
+            Int& g1 = alg.overlapGroups[i1];
+            Int& g2 = alg.overlapGroups[i2];
+            if (g1 == -1) {
+                if (g2 == -1) {
+                    Int g = alg.numOverlapGroups++;
+                    g1 = g;
+                    g2 = g;
+                }
+                else {
+                    g1 = g2;
+                }
+            }
+            else {
+                if (g2 == -1) {
+                    g2 = g1;
+                }
+                else {
+#ifdef VGC_DEBUG_BUILD
+                    // This is impossible in theory (due to the strong ordering
+                    // on segment.a()), but can happen due to numerical errors.
+                    //
+                    // For example assume the following, where segmentIntersect()
+                    // returns an overlap only for the pairs (1,2), (2,3), and (3,4):
+                    //
+                    //     A  B  C  D
+                    // (1) o-------------o
+                    // (2)       o--------o
+                    // (3)          o--------o
+                    // (4)    o-------------o
+                    //
+                    // Event A: add (1)
+                    // Event B: add (4)
+                    // Event C: add (2)
+                    //          (1, 2) overlap: rem (1), assign group index 0 to (1) and (2)
+                    // Event D: add (3)
+                    //          (3, 4) overlap: rem (4), assign group index 1 to (3) and (4)
+                    //          (2, 3) overlap: rem (2), group index clash!
+                    //
+                    VGC_WARNING(
+                        LogVgcGeometry,
+                        "Overlapping segments {} and {} both already have an overlap "
+                        "group assigned ({}, {}).",
+                        s1,
+                        s2,
+                        g1,
+                        g2);
+#endif
+                    // Merge groups. Unfortunately, this makes the algorithm not O(n log n)
+                    // anymore.
+                    //
+                    for (Int& g : alg.overlapGroups) {
+                        if (g == g2) {
+                            g = g1;
+                        }
+                    }
+                }
+            }
+
+            if (g == -1) {
+                g = alg.numOverlapGroups++;
+            }
+            g1 = g;
+
+            alg.overlapGroups[i1] = g;
+
+            Int overlapGroup = (std::max)(alg.overlapGroups[i1], )
+
+                // Only keep the segment that extend further to the right of the
+                // sweep line (or in case of vertical segments, the segment that
+                // extend further to the top along the sweep line).
+                //
+                if (s2.b() > s1.b()) {
+                alg.outgoingSegments.removeAt(i1);
+            }
+            else {
+                alg.outgoingSegments.removeAt(i2);
+            }
+            --j;
+
+            // TODO:
+            // - Report the intersection
+            // - Assign an overlap group
+            // - In the end, post process these to add all
+            //   skipped intersections, e.g.:
+            //
+            //   A  B  C  D  E  F  G  H
+            //   o--------o                (1)
+            //      o--------------o       (2)
+            //         o--------o          (3)
+            //               o--------o    (4)
+            //
+            // Event A: add (1)
+            // Event B: report (1,2), remove (1), add (2)
+            // Event C: report (2,3), keep (2), don't add (3)
+            // Event D: skip (TODO: what if there is another segment starting
+            //          exactly at D? Don't we want to handle that robustly, instead
+            //          of relying on the fact that D is geometrically on BE?)
+            // Event E: report (2, 4), remove (2), add (4)
+            // Event F: skip
+            // Event G: skip
+            // Event H: remove (4)
+            //
+            // Where:
+            // - "add (1)" means "add segment (1) to sweepSegments"
+            // - "rem (1)" means "remove segment (1) from sweepSegments"
+            // - "report (1,2)" means "report segment overlap between (1) and (2)"
+            //
+            // Intermediate output: (1,2), (2,3), (2,4)
+            // Final output:        (1,2), (1,3), (2,3), (2,4), (3,4)
+            //
+            // (Note that (1) and (4) do not intersect, while they all belong to the same
+            //  overlap group)
+            //
+        }
+    }
 }
 
 // Compute the intersection between the two given segments, and add it to the
@@ -1159,7 +1473,33 @@ void findNewIntersection(
             alg.eventQueue.push(Event<T>{EventType::Intersection, inter.p(), i2});
         }
     }
-    // TODO: SegmentIntersectionType::Segment
+    else if (inter.type() == SegmentIntersectionType::Segment) {
+
+        // In theory, it is impossible to get an intersection of type Segment,
+        // since one of the segment (say, s1) pass through the event position
+        // p, while the other (s2) does not. More precisely:
+        //
+        // - If they have different slopes:
+        //     They either don't intersect or intersect at a point
+        //
+        // - If both have the same slope:
+        //   - If they are non-vertical, then they are parallel non-intersecting
+        //   - If they are vertical, s2 is either entirely below p, in which case
+        //     it is not anymore in sweepSegments, or s2 is entirely above p, in
+        //     which case it is not yet in p
+        //
+        // In practice, due to numerical, it might possibly happen?
+        // For now we simply ignore this.
+        //
+#ifdef VGC_DEBUG_BUILD
+        VGC_WARNING(
+            LogVgcGeometry,
+            "Intersection of type Segment found between {} and {} at event position {}.",
+            s1,
+            s2,
+            position);
+#endif
+    }
 }
 
 // Compute intersection between segments that have just become neighbors in
@@ -1235,6 +1575,7 @@ template<typename T>
 void computeIntersections(InputData<T>& in, AlgorithmData<T>& alg, OutputData<T>& out) {
     initializeEventQueue(in, alg);
     initializeSweepSegments(alg);
+    initializeOverlapGroups(in, alg);
     while (!alg.eventQueue.empty()) {
         processNextEvent(in, alg, out);
     }

--- a/libs/vgc/geometry/tests/test_segmentintersector2.py
+++ b/libs/vgc/geometry/tests/test_segmentintersector2.py
@@ -50,7 +50,7 @@ class TestSegmentIntersector2(unittest.TestCase):
     def testConstructor(self):
         for SegmentIntersector2 in SegmentIntersector2Types:
             si = SegmentIntersector2()
-            self.assertEqual(len(si.pointIntersections()), 0)
+            self.assertEqual(len(si.intersectionPoints()), 0)
 
     def testAddSegment(self):
         for SegmentIntersector2 in SegmentIntersector2Types:
@@ -58,21 +58,21 @@ class TestSegmentIntersector2(unittest.TestCase):
             si.addSegment((0, 0), (1, 1))
             si.addSegment((0, 1), (1, 0))
             si.computeIntersections()
-            self.assertEqual(len(si.pointIntersections()), 1)
+            self.assertEqual(len(si.intersectionPoints()), 1)
 
     def testAddOpenPolyline(self):
         for SegmentIntersector2 in SegmentIntersector2Types:
             si = SegmentIntersector2()
             si.addPolyline([(0, 0), (1, 1), (0, 1), (1, 0)])
             si.computeIntersections()
-            self.assertEqual(len(si.pointIntersections()), 1)
+            self.assertEqual(len(si.intersectionPoints()), 1)
 
     def testAddOpenPolylineWithCommonEndpoints(self):
         for SegmentIntersector2 in SegmentIntersector2Types:
             si = SegmentIntersector2()
             si.addPolyline([(0, 0), (1, 1), (0, 1), (1, 0), (0, 0)])
             si.computeIntersections()
-            self.assertEqual(len(si.pointIntersections()), 2)
+            self.assertEqual(len(si.intersectionPoints()), 2)
 
     def testAddClosedPolyline(self):
         for SegmentIntersector2 in SegmentIntersector2Types:
@@ -80,7 +80,7 @@ class TestSegmentIntersector2(unittest.TestCase):
             si.addPolyline([(0, 0), (1, 1), (0, 1), (1, 0)],
                            isClosed=True)
             si.computeIntersections()
-            self.assertEqual(len(si.pointIntersections()), 1)
+            self.assertEqual(len(si.intersectionPoints()), 1)
 
     def testAddClosedPolylineWithDuplicateEndpoints(self):
         for SegmentIntersector2 in SegmentIntersector2Types:
@@ -88,7 +88,7 @@ class TestSegmentIntersector2(unittest.TestCase):
             si.addPolyline([(0, 0), (1, 1), (0, 1), (1, 0), (0, 0)],
                            isClosed=True, hasDuplicateEndpoints=True)
             si.computeIntersections()
-            self.assertEqual(len(si.pointIntersections()), 1)
+            self.assertEqual(len(si.intersectionPoints()), 1)
 
     def testTwoSegments(self):
 
@@ -141,18 +141,34 @@ class TestSegmentIntersector2(unittest.TestCase):
                                 si.addSegment(s1.a, s1.b)
                                 si.addSegment(s2.a, s2.b)
                                 si.computeIntersections()
+
                                 if (expected.type == SegmentIntersectionType.Point):
-                                    self.assertEqual(len(si.pointIntersections()), 1)
-                                    self.assertEqual(si.pointIntersections()[0].position, expected.p)
-                                    self.assertEqual(len(si.segmentIntersections()), 0)
+                                    self.assertEqual(len(si.intersectionPoints()), 1)
+                                    self.assertEqual(len(si.intersectionSubsegments()), 0)
+                                    self.assertEqual(si.intersectionPoints()[0].position, expected.p)
+                                    self.assertEqual(len(si.intersectionPoints()[0].segments), 2)
+                                    foundS1 = False
+                                    foundS2 = False
+                                    for vertseg in si.intersectionPoints()[0].segments:
+                                        self.assertEqual(vertseg.vertexIndex, 0)
+                                        if vertseg.segmentIndex == 0:
+                                            self.assertEqual(vertseg.parameter, expected.t1)
+                                            foundS1 = True
+                                        if vertseg.segmentIndex == 1:
+                                            self.assertEqual(vertseg.parameter, expected.t2)
+                                            foundS2 = True
+                                    self.assertTrue(foundS1)
+                                    self.assertTrue(foundS2)
+
                                 elif (expected.type == SegmentIntersectionType.Segment):
-                                    self.assertEqual(len(si.segmentIntersections()), 1)
-                                    self.assertEqual(si.segmentIntersections()[0].segment, expected.segment)
+                                    self.assertEqual(len(si.intersectionSubsegments()), 1)
+                                    self.assertEqual(si.intersectionSubsegments()[0].subsegment, expected.segment)
                                     # TODO: test expected number of point-intersections
+                                    #self.assertEqual(len(si.intersectionPoints()), 1)
                                     pass
                                 elif (expected.type == SegmentIntersectionType.Empty):
-                                    self.assertEqual(len(si.pointIntersections()), 0)
-                                    self.assertEqual(len(si.segmentIntersections()), 0)
+                                    self.assertEqual(len(si.intersectionPoints()), 0)
+                                    self.assertEqual(len(si.intersectionSubsegments()), 0)
 
     def testThreeOverlapSegments(self):
         for Segment2, SegmentIntersector2, Segment2Intersection in (
@@ -165,11 +181,11 @@ class TestSegmentIntersector2(unittest.TestCase):
             si.addSegment((2, 0), (5, 0)) # B =    o--------o
             si.addSegment((3, 0), (6, 0)) # C =       o--------o
             si.computeIntersections()
-            self.assertEqual(len(si.pointIntersections()), 0)
-            self.assertEqual(len(si.segmentIntersections()), 3) # (A, B), (A, C), (B, C)
-            self.assertEqual(si.segmentIntersections()[0].segment, Segment2((2, 0), (4, 0)))
-            self.assertEqual(si.segmentIntersections()[1].segment, Segment2((3, 0), (4, 0)))
-            self.assertEqual(si.segmentIntersections()[2].segment, Segment2((3, 0), (5, 0)))
+            self.assertEqual(len(si.intersectionPoints()), 0)
+            self.assertEqual(len(si.intersectionSubsegments()), 3) # (A, B), (A, C), (B, C)
+            self.assertEqual(si.intersectionSubsegments()[0].subsegment, Segment2((2, 0), (4, 0)))
+            self.assertEqual(si.intersectionSubsegments()[1].subsegment, Segment2((3, 0), (4, 0)))
+            self.assertEqual(si.intersectionSubsegments()[2].subsegment, Segment2((3, 0), (5, 0)))
 
 
 

--- a/libs/vgc/geometry/tests/test_segmentintersector2.py
+++ b/libs/vgc/geometry/tests/test_segmentintersector2.py
@@ -173,18 +173,17 @@ class TestSegmentIntersector2(unittest.TestCase):
                 Segment2SegmentIntersector2Segment2IntersectionTypes):
 
             # Case without other segments
-            # TODO: make the test order-independent?
             si = SegmentIntersector2()
             si.addSegment((1, 0), (4, 0)) # A = o--------o
             si.addSegment((2, 0), (5, 0)) # B =    o--------o
             si.addSegment((3, 0), (6, 0)) # C =       o--------o
-            si.computeIntersections()
+            si.computeIntersections()     #     x--x--x--x--x--x     < output vertices/edges
+                                          #     0  1  2  3  4  5
             self.assertEqual(len(si.intersectionPoints()), 4)
             self.assertEqual(len(si.intersectionSubsegments()), 3) # (A, B), (A, C), (B, C)
-            self.assertEqual(si.intersectionSubsegments()[0].subsegment, Segment2((2, 0), (4, 0)))
+            self.assertEqual(si.intersectionSubsegments()[0].subsegment, Segment2((2, 0), (3, 0)))
             self.assertEqual(si.intersectionSubsegments()[1].subsegment, Segment2((3, 0), (4, 0)))
-            self.assertEqual(si.intersectionSubsegments()[2].subsegment, Segment2((3, 0), (5, 0)))
-
+            self.assertEqual(si.intersectionSubsegments()[2].subsegment, Segment2((4, 0), (5, 0)))
 
 
 if __name__ == '__main__':

--- a/libs/vgc/geometry/tests/test_segmentintersector2.py
+++ b/libs/vgc/geometry/tests/test_segmentintersector2.py
@@ -185,6 +185,64 @@ class TestSegmentIntersector2(unittest.TestCase):
             self.assertEqual(si.intersectionSubsegments()[1].subsegment, Segment2((3, 0), (4, 0)))
             self.assertEqual(si.intersectionSubsegments()[2].subsegment, Segment2((4, 0), (5, 0)))
 
+    def testOneSegmentThroughTwoOverlapSegments(self):
+        for Segment2, SegmentIntersector2, Segment2Intersection in (
+                Segment2SegmentIntersector2Segment2IntersectionTypes):
+
+            si = SegmentIntersector2()         #         o
+            si.addSegment((1, 2), (9, 4))      # A = o---|---o
+            si.addSegment((3, 2.5), (11, 4.5)) # B =   o-|-----o
+            si.addSegment((8, -3), (4, 5))     # C =     o
+
+            si.computeIntersections()
+
+            ipoints = si.intersectionPoints()
+            self.assertEqual(len(ipoints), 3)
+            self.assertEqual(ipoints[0].position, (3, 2.5))
+            self.assertEqual(ipoints[1].position, (5, 3))
+            self.assertEqual(ipoints[2].position, (9, 4))
+
+            segments = list(ipoints[0].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.vertexIndex for s in segments], [1, 1])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1])
+            self.assertEqual([s.parameter for s in segments], [0.25, 0])
+
+            segments = list(ipoints[1].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.vertexIndex for s in segments], [3, 3, 3])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1, 2])
+            self.assertEqual([s.parameter for s in segments], [0.5, 0.25, 0.75])
+
+            segments = list(ipoints[2].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.vertexIndex for s in segments], [5, 5])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1])
+            self.assertEqual([s.parameter for s in segments], [1, 0.75])
+
+            isegs = si.intersectionSubsegments()
+            self.assertEqual(len(isegs), 2)
+            self.assertEqual(isegs[0].subsegment, Segment2((3, 2.5), (5, 3)))
+            self.assertEqual(isegs[0].startVertexIndex, 1)
+            self.assertEqual(isegs[0].endVertexIndex, 3)
+            self.assertEqual(isegs[1].subsegment, Segment2((5, 3), (9, 4)))
+            self.assertEqual(isegs[1].startVertexIndex, 3)
+            self.assertEqual(isegs[1].endVertexIndex, 5)
+
+            segments = list(isegs[0].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.edgeIndex for s in segments], [1, 1])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1])
+            self.assertEqual([s.parameter1 for s in segments], [0.25, 0])
+            self.assertEqual([s.parameter2 for s in segments], [0.5, 0.25])
+
+            segments = list(isegs[1].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.edgeIndex for s in segments], [2, 2])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1])
+            self.assertEqual([s.parameter1 for s in segments], [0.5, 0.25])
+            self.assertEqual([s.parameter2 for s in segments], [1, 0.75])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/libs/vgc/geometry/tests/test_segmentintersector2.py
+++ b/libs/vgc/geometry/tests/test_segmentintersector2.py
@@ -144,11 +144,15 @@ class TestSegmentIntersector2(unittest.TestCase):
                                 if (expected.type == SegmentIntersectionType.Point):
                                     self.assertEqual(len(si.pointIntersections()), 1)
                                     self.assertEqual(si.pointIntersections()[0].position, expected.p)
+                                    self.assertEqual(len(si.segmentIntersections()), 0)
                                 elif (expected.type == SegmentIntersectionType.Segment):
-                                    # TODO
+                                    self.assertEqual(len(si.segmentIntersections()), 1)
+                                    self.assertEqual(si.segmentIntersections()[0].segment, expected.segment)
+                                    # TODO: test expected number of point-intersections
                                     pass
                                 elif (expected.type == SegmentIntersectionType.Empty):
                                     self.assertEqual(len(si.pointIntersections()), 0)
+                                    self.assertEqual(len(si.segmentIntersections()), 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/libs/vgc/geometry/tests/test_segmentintersector2.py
+++ b/libs/vgc/geometry/tests/test_segmentintersector2.py
@@ -154,5 +154,24 @@ class TestSegmentIntersector2(unittest.TestCase):
                                     self.assertEqual(len(si.pointIntersections()), 0)
                                     self.assertEqual(len(si.segmentIntersections()), 0)
 
+    def testThreeOverlapSegments(self):
+        for Segment2, SegmentIntersector2, Segment2Intersection in (
+                Segment2SegmentIntersector2Segment2IntersectionTypes):
+
+            # Case without other segments
+            # TODO: make the test order-independent?
+            si = SegmentIntersector2()
+            si.addSegment((1, 0), (4, 0)) # A = o--------o
+            si.addSegment((2, 0), (5, 0)) # B =    o--------o
+            si.addSegment((3, 0), (6, 0)) # C =       o--------o
+            si.computeIntersections()
+            self.assertEqual(len(si.pointIntersections()), 0)
+            self.assertEqual(len(si.segmentIntersections()), 3) # (A, B), (A, C), (B, C)
+            self.assertEqual(si.segmentIntersections()[0].segment, Segment2((2, 0), (4, 0)))
+            self.assertEqual(si.segmentIntersections()[1].segment, Segment2((3, 0), (4, 0)))
+            self.assertEqual(si.segmentIntersections()[2].segment, Segment2((3, 0), (5, 0)))
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/libs/vgc/geometry/tests/test_segmentintersector2.py
+++ b/libs/vgc/geometry/tests/test_segmentintersector2.py
@@ -150,7 +150,6 @@ class TestSegmentIntersector2(unittest.TestCase):
                                     foundS1 = False
                                     foundS2 = False
                                     for vertseg in si.intersectionPoints()[0].segments:
-                                        self.assertEqual(vertseg.vertexIndex, 0)
                                         if vertseg.segmentIndex == 0:
                                             self.assertEqual(vertseg.parameter, expected.t1)
                                             foundS1 = True
@@ -161,10 +160,9 @@ class TestSegmentIntersector2(unittest.TestCase):
                                     self.assertTrue(foundS2)
 
                                 elif (expected.type == SegmentIntersectionType.Segment):
+                                    self.assertEqual(len(si.intersectionPoints()), 2)
                                     self.assertEqual(len(si.intersectionSubsegments()), 1)
                                     self.assertEqual(si.intersectionSubsegments()[0].subsegment, expected.segment)
-                                    # TODO: test expected number of point-intersections
-                                    #self.assertEqual(len(si.intersectionPoints()), 1)
                                     pass
                                 elif (expected.type == SegmentIntersectionType.Empty):
                                     self.assertEqual(len(si.intersectionPoints()), 0)
@@ -181,7 +179,7 @@ class TestSegmentIntersector2(unittest.TestCase):
             si.addSegment((2, 0), (5, 0)) # B =    o--------o
             si.addSegment((3, 0), (6, 0)) # C =       o--------o
             si.computeIntersections()
-            self.assertEqual(len(si.intersectionPoints()), 0)
+            self.assertEqual(len(si.intersectionPoints()), 4)
             self.assertEqual(len(si.intersectionSubsegments()), 3) # (A, B), (A, C), (B, C)
             self.assertEqual(si.intersectionSubsegments()[0].subsegment, Segment2((2, 0), (4, 0)))
             self.assertEqual(si.intersectionSubsegments()[1].subsegment, Segment2((3, 0), (4, 0)))

--- a/libs/vgc/geometry/tests/test_segmentintersector2.py
+++ b/libs/vgc/geometry/tests/test_segmentintersector2.py
@@ -243,6 +243,47 @@ class TestSegmentIntersector2(unittest.TestCase):
             self.assertEqual([s.parameter1 for s in segments], [0.5, 0.25])
             self.assertEqual([s.parameter2 for s in segments], [1, 0.75])
 
+    def testOneSegmentThroughStartOfTwoOverlapSegments(self):
+        for Segment2, SegmentIntersector2, Segment2Intersection in (
+                Segment2SegmentIntersector2Segment2IntersectionTypes):
+
+            si = SegmentIntersector2()         #             o
+            si.addSegment((1, 2), (9, 4))      # A = o-------|
+            si.addSegment((3, 2.5), (11, 4.5)) # B =   o-----|-o
+            si.addSegment((9, 3), (9, 5))      # C =         o
+
+            si.computeIntersections()
+
+            ipoints = si.intersectionPoints()
+            self.assertEqual(len(ipoints), 2)
+            self.assertEqual(ipoints[0].position, (3, 2.5))
+            self.assertEqual(ipoints[1].position, (9, 4))
+
+            segments = list(ipoints[0].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.vertexIndex for s in segments], [1, 1])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1])
+            self.assertEqual([s.parameter for s in segments], [0.25, 0])
+
+            segments = list(ipoints[1].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.vertexIndex for s in segments], [3, 3, 3])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1, 2])
+            self.assertEqual([s.parameter for s in segments], [1, 0.75, 0.5])
+
+            isegs = si.intersectionSubsegments()
+            self.assertEqual(len(isegs), 1)
+            self.assertEqual(isegs[0].subsegment, Segment2((3, 2.5), (9, 4)))
+            self.assertEqual(isegs[0].startVertexIndex, 1)
+            self.assertEqual(isegs[0].endVertexIndex, 3)
+
+            segments = list(isegs[0].segments)
+            segments.sort(key=lambda s: s.segmentIndex)
+            self.assertEqual([s.edgeIndex for s in segments], [1, 1])
+            self.assertEqual([s.segmentIndex for s in segments], [0, 1])
+            self.assertEqual([s.parameter1 for s in segments], [0.25, 0])
+            self.assertEqual([s.parameter2 for s in segments], [1, 0.75])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
+++ b/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
@@ -38,27 +38,20 @@ namespace {
 template<typename T>
 void wrap_Vertex(py::handle scope) {
     using This = typename SegmentIntersector2<T>::Vertex;
-    using VertexSegment = typename SegmentIntersector2<T>::VertexSegment;
     std::string name = "Vertex";
     vgc::core::wraps::Class<This>(scope, name.c_str())
         .def(py::init<>())
-        .def(py::init<const Vec2<T>&>())
-        .def(py::init<const Vec2<T>&, const vgc::core::Array<VertexSegment>&>())
-        .def_property("position", &This::position, &This::setPosition)
-        .def_property("segments", &This::segments, &This::setSegments)
-        .def("addSegment", &This::addSegment);
+        .def_property_readonly("position", &This::position)
+        .def_property_readonly("segments", &This::segments);
     vgc::core::wraps::wrapArray<This>(scope, "Vertex");
 }
 
 template<typename T>
 void wrap_VertexSegment(py::handle scope) {
     using This = typename SegmentIntersector2<T>::VertexSegment;
-    using VertexIndex = typename SegmentIntersector2<T>::VertexIndex;
-    using SegmentIndex = typename SegmentIntersector2<T>::SegmentIndex;
     std::string name = "VertexSegment";
     vgc::core::wraps::Class<This>(scope, name.c_str())
         .def(py::init<>())
-        .def(py::init<VertexIndex, SegmentIndex, T>())
         .def_property("vertexIndex", &This::vertexIndex, &This::setVertexIndex)
         .def_property("segmentIndex", &This::segmentIndex, &This::setSegmentIndex)
         .def_property("parameter", &This::parameter, &This::setParameter);
@@ -68,15 +61,13 @@ void wrap_VertexSegment(py::handle scope) {
 template<typename T>
 void wrap_Edge(py::handle scope) {
     using This = typename SegmentIntersector2<T>::Edge;
-    using EdgeSegment = typename SegmentIntersector2<T>::EdgeSegment;
     std::string name = "Edge";
     vgc::core::wraps::Class<This>(scope, name.c_str())
         .def(py::init<>())
-        .def(py::init<const Segment2<T>&>())
-        .def(py::init<const Segment2<T>&, const vgc::core::Array<EdgeSegment>&>())
-        .def_property("subsegment", &This::subsegment, &This::setSubsegment)
-        .def_property("segments", &This::segments, &This::setSegments)
-        .def("addSegment", &This::addSegment);
+        .def_property_readonly("startVertexIndex", &This::startVertexIndex)
+        .def_property_readonly("endVertexIndex", &This::endVertexIndex)
+        .def_property_readonly("subsegment", &This::subsegment)
+        .def_property_readonly("segments", &This::segments);
     vgc::core::wraps::wrapArray<This>(scope, "Edge");
 }
 

--- a/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
+++ b/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
@@ -70,6 +70,44 @@ void wrap_PointIntersectionInfo(py::handle scope) {
 }
 
 template<typename T>
+void wrap_SegmentIntersection(py::handle scope) {
+    using This = typename SegmentIntersector2<T>::SegmentIntersection;
+    using SegmentIntersectionInfo =
+        typename SegmentIntersector2<T>::SegmentIntersectionInfo;
+    std::string name = "SegmentIntersection";
+    vgc::core::wraps::Class<This>(scope, name.c_str())
+        .def(py::init<>())
+        .def(py::init<const Segment2<T>&>())
+        .def(py::init<
+             const Segment2<T>&,
+             const vgc::core::Array<SegmentIntersectionInfo>&>())
+        .def_property("segment", &This::segment, &This::setSegment)
+        .def_property("infos", &This::infos, &This::setInfos)
+        .def("addInfo", &This::addInfo);
+    vgc::core::wraps::wrapArray<This>(scope, "SegmentIntersection");
+}
+
+template<typename T>
+void wrap_SegmentIntersectionInfo(py::handle scope) {
+    using This = typename SegmentIntersector2<T>::SegmentIntersectionInfo;
+    using SegmentIntersectionIndex =
+        typename SegmentIntersector2<T>::SegmentIntersectionIndex;
+    using SegmentIndex = typename SegmentIntersector2<T>::SegmentIndex;
+    std::string name = "SegmentIntersectionInfo";
+    vgc::core::wraps::Class<This>(scope, name.c_str())
+        .def(py::init<>())
+        .def(py::init<SegmentIntersectionIndex, SegmentIndex, T, T>())
+        .def_property(
+            "segmentIntersectionIndex",
+            &This::segmentIntersectionIndex,
+            &This::setSegmentIntersectionIndex)
+        .def_property("segmentIndex", &This::segmentIndex, &This::setSegmentIndex)
+        .def_property("parameter1", &This::parameter1, &This::setParameter1)
+        .def_property("parameter2", &This::parameter2, &This::setParameter2);
+    vgc::core::wraps::wrapArray<This>(scope, "SegmentIntersectionInfo");
+}
+
+template<typename T>
 void wrap_SegmentIntersector2(py::module& m, const std::string& name) {
 
     using This = SegmentIntersector2<T>;
@@ -96,10 +134,13 @@ void wrap_SegmentIntersector2(py::module& m, const std::string& name) {
             "isClosed"_a = false,
             "hasDuplicateEndpoints"_a = false)
         .def("computeIntersections", &This::computeIntersections)
-        .def("pointIntersections", &This::pointIntersections);
+        .def("pointIntersections", &This::pointIntersections)
+        .def("segmentIntersections", &This::segmentIntersections);
 
     wrap_PointIntersection<T>(c);
     wrap_PointIntersectionInfo<T>(c);
+    wrap_SegmentIntersection<T>(c);
+    wrap_SegmentIntersectionInfo<T>(c);
 }
 
 } // namespace

--- a/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
+++ b/libs/vgc/geometry/wraps/wrap_segmentintersector2.cpp
@@ -28,83 +28,72 @@ using vgc::geometry::Vec2;
 
 namespace {
 
-// Note: In C++, SegmentIntersector2d::PointIntersection is an alias of
-// segmentintersector2::PointIntersection<double>, which is defined at
+// Note: In C++, SegmentIntersector2d::Vertex is an alias of
+// segmentintersector2::Vertex<double>, which is defined at
 // namespace scope to make it deducible in partial template
 // specializations. In Python, none of this is relevant, so we can more
 // simply define it directly as a nested type of SegmentIntersector2d.
-// Same for PointIntersectionInfo.
+// Same for VertexSegment.
 
 template<typename T>
-void wrap_PointIntersection(py::handle scope) {
-    using This = typename SegmentIntersector2<T>::PointIntersection;
-    using PointIntersectionInfo = typename SegmentIntersector2<T>::PointIntersectionInfo;
-    std::string name = "PointIntersection";
+void wrap_Vertex(py::handle scope) {
+    using This = typename SegmentIntersector2<T>::Vertex;
+    using VertexSegment = typename SegmentIntersector2<T>::VertexSegment;
+    std::string name = "Vertex";
     vgc::core::wraps::Class<This>(scope, name.c_str())
         .def(py::init<>())
         .def(py::init<const Vec2<T>&>())
-        .def(py::init<const Vec2<T>&, const vgc::core::Array<PointIntersectionInfo>&>())
+        .def(py::init<const Vec2<T>&, const vgc::core::Array<VertexSegment>&>())
         .def_property("position", &This::position, &This::setPosition)
-        .def_property("infos", &This::infos, &This::setInfos)
-        .def("addInfo", &This::addInfo);
-    vgc::core::wraps::wrapArray<This>(scope, "PointIntersection");
+        .def_property("segments", &This::segments, &This::setSegments)
+        .def("addSegment", &This::addSegment);
+    vgc::core::wraps::wrapArray<This>(scope, "Vertex");
 }
 
 template<typename T>
-void wrap_PointIntersectionInfo(py::handle scope) {
-    using This = typename SegmentIntersector2<T>::PointIntersectionInfo;
-    using PointIntersectionIndex =
-        typename SegmentIntersector2<T>::PointIntersectionIndex;
+void wrap_VertexSegment(py::handle scope) {
+    using This = typename SegmentIntersector2<T>::VertexSegment;
+    using VertexIndex = typename SegmentIntersector2<T>::VertexIndex;
     using SegmentIndex = typename SegmentIntersector2<T>::SegmentIndex;
-    std::string name = "PointIntersectionInfo";
+    std::string name = "VertexSegment";
     vgc::core::wraps::Class<This>(scope, name.c_str())
         .def(py::init<>())
-        .def(py::init<PointIntersectionIndex, SegmentIndex, T>())
-        .def_property(
-            "pointIntersectionIndex",
-            &This::pointIntersectionIndex,
-            &This::setPointIntersectionIndex)
+        .def(py::init<VertexIndex, SegmentIndex, T>())
+        .def_property("vertexIndex", &This::vertexIndex, &This::setVertexIndex)
         .def_property("segmentIndex", &This::segmentIndex, &This::setSegmentIndex)
         .def_property("parameter", &This::parameter, &This::setParameter);
-    vgc::core::wraps::wrapArray<This>(scope, "PointIntersectionInfo");
+    vgc::core::wraps::wrapArray<This>(scope, "VertexSegment");
 }
 
 template<typename T>
-void wrap_SegmentIntersection(py::handle scope) {
-    using This = typename SegmentIntersector2<T>::SegmentIntersection;
-    using SegmentIntersectionInfo =
-        typename SegmentIntersector2<T>::SegmentIntersectionInfo;
-    std::string name = "SegmentIntersection";
+void wrap_Edge(py::handle scope) {
+    using This = typename SegmentIntersector2<T>::Edge;
+    using EdgeSegment = typename SegmentIntersector2<T>::EdgeSegment;
+    std::string name = "Edge";
     vgc::core::wraps::Class<This>(scope, name.c_str())
         .def(py::init<>())
         .def(py::init<const Segment2<T>&>())
-        .def(py::init<
-             const Segment2<T>&,
-             const vgc::core::Array<SegmentIntersectionInfo>&>())
-        .def_property("segment", &This::segment, &This::setSegment)
-        .def_property("infos", &This::infos, &This::setInfos)
-        .def("addInfo", &This::addInfo);
-    vgc::core::wraps::wrapArray<This>(scope, "SegmentIntersection");
+        .def(py::init<const Segment2<T>&, const vgc::core::Array<EdgeSegment>&>())
+        .def_property("subsegment", &This::subsegment, &This::setSubsegment)
+        .def_property("segments", &This::segments, &This::setSegments)
+        .def("addSegment", &This::addSegment);
+    vgc::core::wraps::wrapArray<This>(scope, "Edge");
 }
 
 template<typename T>
-void wrap_SegmentIntersectionInfo(py::handle scope) {
-    using This = typename SegmentIntersector2<T>::SegmentIntersectionInfo;
-    using SegmentIntersectionIndex =
-        typename SegmentIntersector2<T>::SegmentIntersectionIndex;
+void wrap_EdgeSegment(py::handle scope) {
+    using This = typename SegmentIntersector2<T>::EdgeSegment;
+    using EdgeIndex = typename SegmentIntersector2<T>::EdgeIndex;
     using SegmentIndex = typename SegmentIntersector2<T>::SegmentIndex;
-    std::string name = "SegmentIntersectionInfo";
+    std::string name = "EdgeSegment";
     vgc::core::wraps::Class<This>(scope, name.c_str())
         .def(py::init<>())
-        .def(py::init<SegmentIntersectionIndex, SegmentIndex, T, T>())
-        .def_property(
-            "segmentIntersectionIndex",
-            &This::segmentIntersectionIndex,
-            &This::setSegmentIntersectionIndex)
+        .def(py::init<EdgeIndex, SegmentIndex, T, T>())
+        .def_property("edgeIndex", &This::edgeIndex, &This::setEdgeIndex)
         .def_property("segmentIndex", &This::segmentIndex, &This::setSegmentIndex)
         .def_property("parameter1", &This::parameter1, &This::setParameter1)
         .def_property("parameter2", &This::parameter2, &This::setParameter2);
-    vgc::core::wraps::wrapArray<This>(scope, "SegmentIntersectionInfo");
+    vgc::core::wraps::wrapArray<This>(scope, "EdgeSegment");
 }
 
 template<typename T>
@@ -134,13 +123,13 @@ void wrap_SegmentIntersector2(py::module& m, const std::string& name) {
             "isClosed"_a = false,
             "hasDuplicateEndpoints"_a = false)
         .def("computeIntersections", &This::computeIntersections)
-        .def("pointIntersections", &This::pointIntersections)
-        .def("segmentIntersections", &This::segmentIntersections);
+        .def("intersectionPoints", &This::intersectionPoints)
+        .def("intersectionSubsegments", &This::intersectionSubsegments);
 
-    wrap_PointIntersection<T>(c);
-    wrap_PointIntersectionInfo<T>(c);
-    wrap_SegmentIntersection<T>(c);
-    wrap_SegmentIntersectionInfo<T>(c);
+    wrap_Vertex<T>(c);
+    wrap_VertexSegment<T>(c);
+    wrap_Edge<T>(c);
+    wrap_EdgeSegment<T>(c);
 }
 
 } // namespace

--- a/libs/vgc/vacomplex/detail/intersect.cpp
+++ b/libs/vgc/vacomplex/detail/intersect.cpp
@@ -115,17 +115,17 @@ void computeIntersections(
 
     // Process intersections.
     //
-    for (const auto& inter : intersector.pointIntersections()) {
+    for (const auto& vertex : intersector.intersectionPoints()) {
 
         // For now, we only handle intersections between two segments
-        const auto& infos = inter.infos();
-        if (infos.length() != 2) {
+        const auto& segments = vertex.segments();
+        if (segments.length() != 2) {
             continue;
         }
 
         // Get segments, polylines, and edges relative to this intersection
-        SegmentIndex i1 = infos.first().segmentIndex();
-        SegmentIndex i2 = infos.last().segmentIndex();
+        SegmentIndex i1 = segments.first().segmentIndex();
+        SegmentIndex i2 = segments.last().segmentIndex();
         PolylineIndex j1 = intersector.polylineIndex(i1);
         PolylineIndex j2 = intersector.polylineIndex(i2);
         KeyEdge* edge1 = getInputEdge(j1);
@@ -158,8 +158,8 @@ void computeIntersections(
         i2 -= intersector.segmentIndexRange(j2).first();
 
         // Get curve parameters
-        double t1 = infos.first().parameter();
-        double t2 = infos.last().parameter();
+        double t1 = segments.first().parameter();
+        double t2 = segments.last().parameter();
         geometry::CurveParameter param1 = getCurveParameter(edge1, i1, t1);
         geometry::CurveParameter param2 = getCurveParameter(edge2, i2, t2);
 


### PR DESCRIPTION
This is an extension to the Bentley-Ottmann algorithm to support the case where two (or more) segments overlap along a common subsegment.

In addition to the modifications in the algorithm itself, this requires to change the output data structure so that client code can inspect the result in a meaningful way. The output now more closely resembles a planar map, with vertices and edges, the only difference being that no faces are computed.

An "intersection point" is simply a vertex with two or more incident edges. An "intersection subsegment" is an edge that is a common subsegment of two or more input segments.