### PR TITLE
Upgrade GitHub Actions to macos-13 (#1825)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,11 +87,6 @@ jobs:
     - name: Adding Tcl/Tk Symlink
       run: ln -sf /usr/local/opt/tcl-tk@8 /usr/local/opt/tcl-tk
 
-    - name: Test Tcl/Tk Symlink
-      run: |
-        cp /usr/local/opt/tcl-tk/lib/libtcl8.6.dylib libtcl8.6.copy.dylib
-        ls -al
-
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,6 +83,15 @@ jobs:
         python-version: ${{env.PYTHON_VERSION}}
         architecture: 'x64'
 
+    # See: https://github.com/actions/runner-images/issues/11074
+    - name: Adding Tcl/Tk Symlink
+      run: ln -sf /usr/local/opt/tcl-tk@8 /usr/local/opt/tcl-tk
+
+    - name: Test Tcl/Tk Symlink
+      run: |
+        cp /usr/local/opt/tcl-tk/lib/libtcl8.6.dylib libtcl8.6.copy.dylib
+        ls -al
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ defaults:
 jobs:
   build:
     name: Build
-    runs-on: macos-12
+    runs-on: macos-13
     outputs:
       version-name: ${{steps.deploy.outputs.version-name}}
       artifacts-name: ${{steps.artifacts.outputs.name}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   BUILD_TYPE: Release
   QT_VERSION: 5.15.2
-  PYTHON_VERSION: 3.7
+  PYTHON_VERSION: 3.8
   PARALLEL_JOBS: 5
   MACOSX_DEPLOYMENT_TARGET: 10.13
 


### PR DESCRIPTION
#1825

Before this change, we were using macos-12 which is now not available anymore, see: https://github.com/actions/runner-images/issues/10721

Note that macos-13 is the last version using x86_64 chips. When we eventually move to macos-14, the runner will be on M1 processor and therefore most likely some changes will be necessary.