### PR TITLE
Fix Linux build fails due to removal of Node16 in GitHub-hosted runners (#1804)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
     # Getting more commits can also be helpful for computing human-readable
     # commit ID, such as 2020-12-16.3 for the 4th commit of the day.
     #
-    - uses: actions/checkout@v3 # Cannot use v4 (requires Node20/GLIBC_2.28 not available on Ubuntu 18.04)
+    - uses: actions/checkout@v2 # Cannot use v3/v4 (requires Node20/GLIBC_2.28 not available on Ubuntu 18.04)
       with:
         fetch-depth: 100
         submodules: 'recursive'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: vgcsoftware/vgc-ci-ubuntu-18.04:2023-03-08.0
     outputs:
       version-name: ${{steps.deploy.outputs.version-name}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
     # Getting more commits can also be helpful for computing human-readable
     # commit ID, such as 2020-12-16.3 for the 4th commit of the day.
     #
-    - uses: actions/checkout@v2 # Cannot use v3/v4 (requires Node20/GLIBC_2.28 not available on Ubuntu 18.04)
+    - uses: actions/checkout@v1 # Cannot use v2+ (requires Node20/GLIBC_2.28 not available on Ubuntu 18.04)
       with:
         fetch-depth: 100
         submodules: 'recursive'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,29 +3,20 @@ name: Linux
 on: [push, pull_request]
 
 env:
+  CONTAINER: vgcsoftware/vgc-ci-ubuntu-18.04:2023-03-08.0
   BUILD_TYPE: Release
   QT_VERSION: 5.12.5
   PARALLEL_JOBS: 5
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-  # https://github.com/vgc/vgc/issues/1804
-  # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
 
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
-    container: vgcsoftware/vgc-ci-ubuntu-18.04:2023-03-08.0
+    runs-on: ubuntu-24.04
     outputs:
       version-name: ${{steps.deploy.outputs.version-name}}
       artifacts-name: ${{steps.artifacts.outputs.name}}
-      artifacts-cache-key: ${{steps.artifacts.outputs.cache-key}}
 
     steps:
-
-    # Fix "fatal: detected dubious ownership in repository at '/__w/<user>/<repo>'""
-    #
-    - name: Add GitHub workspace to Git safe directories
-      run: git config --global --add safe.directory `pwd`
 
     # By default, actions/checkout will only check out the last commit. For
     # pull requests, this is a temporary merge commit used to test integration
@@ -34,7 +25,7 @@ jobs:
     # Getting more commits can also be helpful for computing human-readable
     # commit ID, such as 2020-12-16.3 for the 4th commit of the day.
     #
-    - uses: actions/checkout@v1 # Cannot use v2+ (requires Node20/GLIBC_2.28 not available on Ubuntu 18.04)
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 100
         submodules: 'recursive'
@@ -68,12 +59,6 @@ jobs:
 
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables
     #
-    # Note: in a Docker container, we have:
-    # - ${{github.workspace}} = /home/runner/work/test-cpp-github-actions/test-cpp-github-actions
-    # - $GITHUB_WORKSPACE     = /__w/test-cpp-github-actions/test-cpp-github-actions
-    #
-    # It's best to use ${{github.workspace}} in `working-directory`, and $GITHUB_WORKSPACE in `run`
-    #
     - name: Print useful environment variables
       if:
       run: |
@@ -97,32 +82,53 @@ jobs:
         echo "COMMIT_BRANCH:        $COMMIT_BRANCH"
         echo "COMMIT_MESSAGE:       $COMMIT_MESSAGE"
 
-    - name: Configure
-      working-directory: ${{github.workspace}}
+    # We manually start a container and execute scripts in it instead of using `jobs.build.container`,
+    # otherwise we couldn't use GitHub-provided actions (checkout, upload-artifact, etc.) as they rely
+    # on Node 20 which would not necessarily be available on some containers (e.g., Ubuntu 18.04).
+    #
+    # See: https://github.com/actions/checkout/issues/1590
+    #
+    - name: Start Docker Container
       run: |
-        mkdir build
-        cd build
-        cmake --version
-        cmake .. \
-          -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-          -DVGC_COMMIT_BRANCH="$COMMIT_BRANCH" \
-          -DQt5_DIR="/opt/qt/$QT_VERSION/gcc_64/lib/cmake/Qt5" \
-          -DVGC_PEDANTIC=ON \
-          -DVGC_WERROR=ON
+        docker pull $CONTAINER
+        docker run --name build-container -d -v ${{ github.workspace }}:/workspace $CONTAINER tail -f /dev/null
+
+    - name: Configure
+      env:
+        SCRIPT: |
+          cd /workspace && mkdir build && cd build
+          cmake --version
+          cmake .. \
+            -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+            -DVGC_COMMIT_BRANCH="$COMMIT_BRANCH" \
+            -DQt5_DIR="/opt/qt/$QT_VERSION/gcc_64/lib/cmake/Qt5" \
+            -DVGC_PEDANTIC=ON \
+            -DVGC_WERROR=ON
+      run: docker exec build-container bash -c "$SCRIPT"
 
     - name: Build
-      working-directory: ${{github.workspace}}/build
-      run: cmake --build . --parallel $PARALLEL_JOBS
+      env:
+        SCRIPT: |
+          cd /workspace/build
+          cmake --build . --parallel ${{env.PARALLEL_JOBS}}
+      run: docker exec build-container bash -c "$SCRIPT"
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: cmake --build . --target check --parallel $PARALLEL_JOBS
+      env:
+        SCRIPT: |
+          cd /workspace/build
+          cmake --build . --target check --parallel ${{env.PARALLEL_JOBS}}
+      run: docker exec build-container bash -c "$SCRIPT"
 
     - name: Deploy
       id: deploy
       working-directory: ${{github.workspace}}/build
+      env:
+        SCRIPT: |
+          cd /workspace/build
+          cmake --build . --target deploy --parallel ${{env.PARALLEL_JOBS}}
       run: |
-        cmake --build . --target deploy --parallel $PARALLEL_JOBS
+        docker exec build-container bash -c "$SCRIPT"
         versionName=VGC-$(awk -F "=" '/versionName/ {print $2}' $BUILD_TYPE/resources/core/version.txt)
         versionName=$(echo $versionName | tr " " "-")
         echo "version-name=$versionName" >> "$GITHUB_OUTPUT"
@@ -137,72 +143,18 @@ jobs:
         cp build/deploy/$BUILD_TYPE/info.json artifacts
         cp build/deploy/$BUILD_TYPE/vgc*.AppImage artifacts
         name=$VERSION_NAME-Linux
-        cackeKey=$VERSION_NAME-$GITHUB_RUN_ID-artifacts
         echo "name=$name" >> "$GITHUB_OUTPUT"
-        echo "cache-key=$cackeKey" >> "$GITHUB_OUTPUT"
-
-    # We cannot use upload-artifact@v4 on Ubuntu 18.04 as it requires Node 20.
-    #
-    # We cannot use upload-artifact@v3 as it is deprecated and will be removed on Nov 30, 2024:
-    #
-    # https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
-    #
-    # Therefore with use GitHub cache instead of GitHub artifacts, and in a subsequent job
-    # using ubuntu-latest, we retrieve the cache and upload it using upload-artifact@v4.
-    #
-    # We cannot use cache@v4 on Ubuntu 18.04 as it requires Node 20.
-    #
-    # We cannot use the latest cache@v3 (as of 3.3.3) as it is buggy and does not
-    # properly support enableCrossOsArchive and fail-on-cache-miss anymore.
-    #
-    # Therefore, we use cache@v3.2.4, which is the first version supporting both
-    # enableCrossOsArchive and fail-on-cache-miss.
-    #
-    # Note that we do need `enableCrossOsArchive` otherwise the ubuntu:18.04
-    # Docker image and the ubuntu-latest image are considered different and
-    # do not share cache, that is, theyhave a different "cache version", see:
-    #
-    # - https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache
-    # - https://github.com/marketplace/actions/cache#cache-version
-    #
-    - name: Cache Artifacts
-      uses: actions/cache/save@v3.2.4
-      if: always() # If we re-run the job, we want to override the cache
-      with:
-        path: artifacts
-        key: ${{steps.artifacts.outputs.cache-key}}
-        enableCrossOsArchive: true
-
-  # This is a separate job running on ubuntu-latest to be able to use upload-artifact@v4
-  #
-  upload-artifacts:
-    name: Upload Artifacts
-    runs-on: ubuntu-latest
-    needs: build
-    outputs:
-      version-name: ${{needs.build.outputs.version-name}}
-      artifacts-name: ${{needs.build.outputs.artifacts-name}}
-
-    steps:
-
-    - name: Restore Cached Artifacts
-      uses: actions/cache/restore@v3.2.4
-      with:
-        path: artifacts
-        key: ${{needs.build.outputs.artifacts-cache-key}}
-        enableCrossOsArchive: true
-        fail-on-cache-miss: true
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
         path: artifacts
-        name: ${{needs.build.outputs.artifacts-name}}
+        name: ${{steps.artifacts.outputs.name}}
 
   upload-vgc:
     name: Upload
     runs-on: ubuntu-latest
-    needs: [build, upload-artifacts]
+    needs: build
     if: ${{ github.repository == 'vgc/vgc' }}
     steps:
 
@@ -217,7 +169,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: artifacts
-        name: ${{needs.upload-artifacts.outputs.artifacts-name}}
+        name: ${{needs.build.outputs.artifacts-name}}
 
     # The file info.json is specific to this platform/workflow and shouldn't be uploaded
     - name: Move info.json

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -99,9 +99,9 @@ jobs:
           cd /workspace && mkdir build && cd build
           cmake --version
           cmake .. \
-            -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-            -DVGC_COMMIT_BRANCH="$COMMIT_BRANCH" \
-            -DQt5_DIR="/opt/qt/$QT_VERSION/gcc_64/lib/cmake/Qt5" \
+            -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" \
+            -DVGC_COMMIT_BRANCH="${{env.COMMIT_BRANCH}}" \
+            -DQt5_DIR="/opt/qt/${{env.QT_VERSION}}/gcc_64/lib/cmake/Qt5" \
             -DVGC_PEDANTIC=ON \
             -DVGC_WERROR=ON
       run: docker exec build-container bash -c "$SCRIPT"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Start Docker Container
       run: |
         docker pull $CONTAINER
-        docker run --name build-container -d -v ${{ github.workspace }}:/workspace $CONTAINER tail -f /dev/null
+        docker run --name build-container -d -e COMMIT_MESSAGE -v ${{ github.workspace }}:/workspace $CONTAINER tail -f /dev/null
 
     - name: Configure
       env:


### PR DESCRIPTION
#1804

For now, I just decided to revert back explicitly to `ubuntu-22.04`, as there is no known solution on how to make this work for `ubuntu-24.04`.
