### PR TITLE
Make parameters of distanceToCurve() and projectToCenterline() more generic (#392)

### DIFF
--- a/libs/vgc/geometry/curve.h
+++ b/libs/vgc/geometry/curve.h
@@ -159,7 +159,7 @@ namespace detail {
 
 template<typename TSample>
 DistanceToCurve
-distanceToCurve(const core::Array<TSample>& samples, const Vec2d& position) {
+distanceToCurve(core::ConstSpan<TSample> samples, const Vec2d& position) {
 
     DistanceToCurve result(core::DoubleInfinity, 0, 0, 0);
     constexpr double hpi = core::pi / 2;

--- a/libs/vgc/geometry/curve.h
+++ b/libs/vgc/geometry/curve.h
@@ -158,8 +158,7 @@ private:
 namespace detail {
 
 template<typename TSample>
-DistanceToCurve
-distanceToCurve(core::ConstSpan<TSample> samples, const Vec2d& position) {
+DistanceToCurve distanceToCurve(core::ConstSpan<TSample> samples, const Vec2d& position) {
 
     DistanceToCurve result(core::DoubleInfinity, 0, 0, 0);
     constexpr double hpi = core::pi / 2;

--- a/libs/vgc/geometry/stroke.cpp
+++ b/libs/vgc/geometry/stroke.cpp
@@ -30,7 +30,7 @@
 namespace vgc::geometry {
 
 DistanceToCurve
-distanceToCurve(const StrokeSample2dArray& samples, const Vec2d& position) {
+distanceToCurve(StrokeSample2dConstSpan samples, const Vec2d& position) {
     return detail::distanceToCurve<StrokeSample2d>(samples, position);
 }
 
@@ -706,7 +706,7 @@ bool AbstractStroke2d::fixEvalParameter_(Int& segmentIndex, double& u) const {
 }
 
 SampledCurveProjection
-projectToCenterline(const StrokeSample2dArray& samples, const Vec2d& position) {
+projectToCenterline(StrokeSample2dConstSpan samples, const Vec2d& position) {
 
     SampledCurveProjection result;
 

--- a/libs/vgc/geometry/stroke.cpp
+++ b/libs/vgc/geometry/stroke.cpp
@@ -29,8 +29,7 @@
 
 namespace vgc::geometry {
 
-DistanceToCurve
-distanceToCurve(StrokeSample2dConstSpan samples, const Vec2d& position) {
+DistanceToCurve distanceToCurve(StrokeSample2dConstSpan samples, const Vec2d& position) {
     return detail::distanceToCurve<StrokeSample2d>(samples, position);
 }
 

--- a/libs/vgc/geometry/stroke.h
+++ b/libs/vgc/geometry/stroke.h
@@ -308,8 +308,7 @@ using StrokeSample2dConstSpan = core::ConstSpan<StrokeSample2d>;
 using SharedConstStrokeSample2dArray = core::SharedConstArray<StrokeSample2d>;
 
 VGC_GEOMETRY_API
-DistanceToCurve
-distanceToCurve(StrokeSample2dConstSpan samples, const Vec2d& position);
+DistanceToCurve distanceToCurve(StrokeSample2dConstSpan samples, const Vec2d& position);
 
 /// \class vgc::geometry::WidthProfile
 /// \brief A widths profile to apply on curves.

--- a/libs/vgc/geometry/stroke.h
+++ b/libs/vgc/geometry/stroke.h
@@ -295,13 +295,21 @@ inline StrokeSample2d nlerp(const StrokeSample2d& a, const StrokeSample2d& b, do
 ///
 using StrokeSample2dArray = core::Array<StrokeSample2d>;
 
+/// Alias for `vgc::core::Span<vgc::geometry::StrokeSample2d>`.
+///
+using StrokeSample2dSpan = core::Span<StrokeSample2d>;
+
+/// Alias for `vgc::core::ConstSpan<vgc::geometry::StrokeSample2d>`.
+///
+using StrokeSample2dConstSpan = core::ConstSpan<StrokeSample2d>;
+
 /// Alias for `vgc::core::SharedConstArray<vgc::geometry::StrokeSample2d>`.
 ///
 using SharedConstStrokeSample2dArray = core::SharedConstArray<StrokeSample2d>;
 
 VGC_GEOMETRY_API
 DistanceToCurve
-distanceToCurve(const StrokeSample2dArray& samples, const Vec2d& position);
+distanceToCurve(StrokeSample2dConstSpan samples, const Vec2d& position);
 
 /// \class vgc::geometry::WidthProfile
 /// \brief A widths profile to apply on curves.
@@ -1175,9 +1183,11 @@ private:
 /// given `position`, including all the points that are in the
 /// segment between two consecutive samples.
 ///
+// XXX: Combine implementation with distanceToCurve?
+//
 VGC_GEOMETRY_API
 SampledCurveProjection
-projectToCenterline(const StrokeSample2dArray& samples, const Vec2d& position);
+projectToCenterline(StrokeSample2dConstSpan samples, const Vec2d& position);
 
 } // namespace vgc::geometry
 


### PR DESCRIPTION
#392