### PR TITLE
Fix snapping sometimes not working due to numerical errors (#1148)

### DIFF
--- a/libs/vgc/tools/sketch.h
+++ b/libs/vgc/tools/sketch.h
@@ -226,7 +226,6 @@ protected:
     std::optional<geometry::Vec2d> snapStartPosition_;
     geometry::Vec2dArray startSnappedCleanInputPositions_;
     Int numStableStartSnappedCleanInputPositions_ = 0;
-    core::Id snapEndVertexItemId_ = 0;
 
     void updateStartSnappedCleanInputPositions_();
 
@@ -276,7 +275,6 @@ protected:
         // fast access to position to do snap tests
         geometry::Vec2d position;
         core::Id itemId;
-        std::optional<bool> isSelectable;
     };
     core::Array<VertexInfo> vertexInfos_;
 


### PR DESCRIPTION
#1148

This was mostly occurring in the following cases:
1. Self-snapping (because in this case, the edge has low sampling quality)
2. Occluded edges in Outline Overlay display mode (because in this case, the outline edge has zero width)

This is fixed via two strategies:
- If the item is not itself in the list of occluders, but if the list of occluders is empty, we consider it non-occluded.
- We use a bigger tolerance (before: `snapDistance * core::epsilon`, after: `snapDistance * 0.01`)
